### PR TITLE
TESTING: Release react_testing_library 0.1.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: react_testing_library
-version: 0.1.0
+version: 0.1.1
 description: A Dart unit testing library for OverReact components that mimics the API of the JS react-testing-library
 homepage: https://github.com/Workiva/react_testing_library/
 environment:


### PR DESCRIPTION
This is a test pull request triggered from w-rmconsole and is not intended for merge.


Diff Between Last Tag and Proposed Release: https://github.com/Workiva/react_testing_library/compare/0.1.0...Workiva:release_react_testing_library_0.1.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/react_testing_library/compare/0.1.0...0.1.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6144895237226496/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6144895237226496/?pull_number=4&repo_name=Workiva%2Freact_testing_library)