### PR TITLE
Add comments to unblock Dart 2.12

### DIFF
--- a/test/unit/dom/configure_test.dart
+++ b/test/unit/dom/configure_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/fire_event_test.dart
+++ b/test/unit/dom/fire_event_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/matchers/contains_element_test.dart
+++ b/test/unit/dom/matchers/contains_element_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/matchers/css_class_matchers_test.dart
+++ b/test/unit/dom/matchers/css_class_matchers_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/matchers/has_attribute_test.dart
+++ b/test/unit/dom/matchers/has_attribute_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/matchers/has_description_test.dart
+++ b/test/unit/dom/matchers/has_description_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/matchers/has_form_values_test.dart
+++ b/test/unit/dom/matchers/has_form_values_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/matchers/has_styles_test.dart
+++ b/test/unit/dom/matchers/has_styles_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/matchers/has_text_content_test.dart
+++ b/test/unit/dom/matchers/has_text_content_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/matchers/has_value_test.dart
+++ b/test/unit/dom/matchers/has_value_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/matchers/is_checked_test.dart
+++ b/test/unit/dom/matchers/is_checked_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/matchers/is_disabled_test.dart
+++ b/test/unit/dom/matchers/is_disabled_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/matchers/is_empty_dom_element_test.dart
+++ b/test/unit/dom/matchers/is_empty_dom_element_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/matchers/is_focused_test.dart
+++ b/test/unit/dom/matchers/is_focused_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/matchers/is_in_the_document_test.dart
+++ b/test/unit/dom/matchers/is_in_the_document_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/matchers/is_partially_checked_test.dart
+++ b/test/unit/dom/matchers/is_partially_checked_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/pretty_dom_test.dart
+++ b/test/unit/dom/pretty_dom_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/queries/by_label_text_test.dart
+++ b/test/unit/dom/queries/by_label_text_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/queries/by_role_test.dart
+++ b/test/unit/dom/queries/by_role_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/queries/by_testid_test.dart
+++ b/test/unit/dom/queries/by_testid_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/queries/by_text_test.dart
+++ b/test/unit/dom/queries/by_text_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/screen_test.dart
+++ b/test/unit/dom/screen_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/text_match_test.dart
+++ b/test/unit/dom/text_match_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 // ignore_for_file: prefer_interpolation_to_compose_strings
 

--- a/test/unit/dom/top_level_queries_test.dart
+++ b/test/unit/dom/top_level_queries_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/wait_for_test.dart
+++ b/test/unit/dom/wait_for_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/dom/within_test.dart
+++ b/test/unit/dom/within_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/react/render_test.dart
+++ b/test/unit/react/render_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/user_event/clear_test.dart
+++ b/test/unit/user_event/clear_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/user_event/click_test.dart
+++ b/test/unit/user_event/click_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/user_event/hover_test.dart
+++ b/test/unit/user_event/hover_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/user_event/paste_test.dart
+++ b/test/unit/user_event/paste_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/user_event/select_options_test.dart
+++ b/test/unit/user_event/select_options_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/user_event/special_chars_test.dart
+++ b/test/unit/user_event/special_chars_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/user_event/tab_test.dart
+++ b/test/unit/user_event/tab_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/user_event/type_test.dart
+++ b/test/unit/user_event/type_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.

--- a/test/unit/user_event/upload_test.dart
+++ b/test/unit/user_event/upload_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // @dart = 2.7
 
 // Copyright 2021 Workiva Inc.


### PR DESCRIPTION
Adds null safety opt-out comments to Dart entry points to prepare for Dart 2.12+
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/add_dart2_9_comments`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/add_dart2_9_comments)