### PR TITLE
TEST: formatting for Dart dev makes formatting step on Dart stable fail

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -32,7 +32,7 @@ jobs:
         timeout-minutes: 2
 
       - name: Check formatting
-        run: dart format . -l 120 && git diff --exit-code
+        run: dart format . -l 120 --set-exit-if-changed
         if: ${{ always() && steps.install.outcome == 'success' }}
 
       - name: Analyze project source

--- a/test/unit/dom/matchers/has_form_values_test.dart
+++ b/test/unit/dom/matchers/has_form_values_test.dart
@@ -39,8 +39,7 @@ void main() {
   group('hasFormValues matcher', () {
     const rootElemTestId = 'root-of-test-form';
     RenderResult renderFormWithValues(
-        /*ReactDomComponentFactoryProxy*/ dynamic rootElem,
-        List<_FormElemDefinition> els) {
+        /*ReactDomComponentFactoryProxy*/ dynamic rootElem, List<_FormElemDefinition> els) {
       assert(rootElem == react.form || rootElem == react.fieldset);
 
       final vDom = rootElem(

--- a/test/unit/dom/matchers/is_partially_checked_test.dart
+++ b/test/unit/dom/matchers/is_partially_checked_test.dart
@@ -31,7 +31,9 @@ void main() {
       });
 
       test('An element with role="checkbox"', () {
-        final cboxEl = DivElement()..setAttribute('role', 'checkbox')..setAttribute('aria-checked', 'mixed');
+        final cboxEl = DivElement()
+          ..setAttribute('role', 'checkbox')
+          ..setAttribute('aria-checked', 'mixed');
         shouldPass(cboxEl, isPartiallyChecked);
       });
     });


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

## Changes
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

        If you're not sure who from our team should review these changes, then leave this section
        blank for now and post a link to the PR in the #support-ui-platform Slack channel.
  -->

<!-- Tag people to review via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author:
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/react_testing_library/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/react_testing_library/blob/master/CONTRIBUTING.md#manual-testing-criteria
