### PR TITLE
Update README / Dartdoc options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # React Testing Library Changelog
 
+## 1.1.5
+
+* Show a valid minimum version for this library in the README.
+* Attempt to fix Dartdoc generation on pub.dev
+
 ## 1.1.4
 
 Initial public release of the library.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ dev_dependencies:
   build_runner: ^1.7.1
   build_test: ">=0.10.9 <3.0.0"
   build_web_compilers: ^2.9.0
-  react_testing_library: ^1.0.0
+  react_testing_library: ^1.1.4
   test: ^1.14.4
   # This is not technically required, 
   # but makes the HTML portion of your test bootstrapping much easier!

--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,4 +1,5 @@
 dartdoc:
+  showUndocumentedCategories: true
   exclude:
     - react_testing_library # exclude the big "catch-all" library since we want the exports to be broken up a little nicer in the docs
   header:


### PR DESCRIPTION
* README showed a lower bound of `^1.0.0` for react_testing_library, but the first public version released was `1.1.4`.
* Use `show-undocumented-categories: true` in `dartdoc_options.yaml` so that the docs that get published to pub.dev match those that we deploy to https://workiva.github.io/react_testing_library