### PR TITLE
CPLAT-15593 Fix printConsoleLogs state error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # React Testing Library Changelog
 
+## 1.1.10
+*  Fix state error thrown by calls to `logRoles()` and `.debug()` (bug introduced in 1.1.9)
+
 ## 1.1.9
 *  Fix `render` swallowing errors on component mount
 

--- a/test/unit/console_log_utils_test.dart
+++ b/test/unit/console_log_utils_test.dart
@@ -129,6 +129,35 @@ void main() {
         });
         expect(printCalls, ['foo', 'bar']);
       });
+
+      group('does not throw when printing logs in a non-print-spied zone:', () {
+        // Failures for tehse tests might not show up as actual test failures, but rather uncaught
+        // errors that look like:
+        // "Bad state: Cannot fire new event. Controller is already firing an even"
+
+        void sharedTest(Zone parentZone) {
+          final onErrorCalls = <List<dynamic>>[];
+          parentZone.fork(specification: ZoneSpecification(
+            handleUncaughtError: (_, __, ___, e, st) {
+              onErrorCalls.add([e, st]);
+            },
+          )).runGuarded(() {
+            printConsoleLogs(() {
+              window.console.log('foo');
+              window.console.log('bar');
+            });
+          });
+          expect(onErrorCalls, isEmpty, reason: 'no errors should have been thrown by zone');
+        }
+
+        test('a test zone', () {
+          sharedTest(Zone.current);
+        });
+
+        test('a non-test zone', () {
+          sharedTest(Zone.root);
+        });
+      });
     });
 
     group('captures all logs correctly', () {

--- a/test/unit/console_log_utils_test.dart
+++ b/test/unit/console_log_utils_test.dart
@@ -130,6 +130,18 @@ void main() {
         expect(printCalls, ['foo', 'bar']);
       });
 
+      test('prints even if the function throws partway through', () {
+        final printCalls = recordPrintCalls(() {
+          expect(() {
+            printConsoleLogs(() {
+              window.console.log('foo');
+              throw ExceptionForTesting();
+            });
+          }, throwsA(isA<ExceptionForTesting>()));
+        });
+        expect(printCalls, ['foo']);
+      });
+
       group('does not throw when printing logs in a non-print-spied zone:', () {
         // Failures for tehse tests might not show up as actual test failures, but rather uncaught
         // errors that look like:


### PR DESCRIPTION
## Motivation
Calling `logRoles` or any other function that uses `printConsoleLogs` in a real test environment resulted in the following error:
```
 Failed to load "test/unit/rtl_test.dart": Bad state: Cannot fire new event. Controller is already firing an event
  dart:sdk_internal                                                       <fn>
  package:react_testing_library/src/util/console_log_utils.dart 95:17     <fn>
  dart:sdk_internal                                                       <fn>
  package:react_testing_library/src/util/console_log_utils.dart 95:17     <fn>
  dart:sdk_internal                                                       log
  packages/react_testing_library/js/react-testing-library.js 15687:30     logRoles
  package:react_testing_library/src/dom/accessibility_helpers.dart 51:28  <fn>
  package:react_testing_library/src/util/console_log_utils.dart 60:20     spyOnConsoleLogs
  package:react_testing_library/src/util/console_log_utils.dart 39:5      printConsoleLogs
  package:react_testing_library/src/dom/accessibility_helpers.dart 51:5   logRoles
  rtl_test.dart 23:7                                                      <fn>
```

This is likely because we were calling `print` inside a call to `console.log` called by `print`, which could cause stack overflows, but in this case seems to get stopped by a synchronous StreamController state error somewhere in the test package library or Dart SDK.

This issue was introduced in https://github.com/Workiva/react_testing_library/pull/31

## Changes
- Add regression test that reproduces the error by running `printConsoleLogs` in a test zone where print statements are forwarded along normally
- Update `printConsoleLogs` implementation to print logs at the end of the function call, as opposed to as they come in, to work around this issue.

#### Release Notes
- Fix state error thrown by calls to `logRoles()` and `.debug()`

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

        If you're not sure who from our team should review these changes, then leave this section
        blank for now and post a link to the PR in the #support-ui-platform Slack channel.
  -->

<!-- Tag people to review via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author:
        - Verify that regression test passes
        - Verify locally that a call to `logRoles()` works as intended without any errors
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/react_testing_library/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/react_testing_library/blob/master/CONTRIBUTING.md#manual-testing-criteria
