### PR TITLE
Raise the Dart SDK minimum to at least 2.11.0

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.7.2, 2.13.4 ]
+        sdk: [ 2.13.4 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Dart unit testing library for OverReact components that mimics th
 homepage: https://github.com/Workiva/react_testing_library/
 documentation: https://workiva.github.io/react_testing_library
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
   color: ">=2.1.1 <4.0.0"

--- a/test/unit/dom/matchers/has_form_values_test.dart
+++ b/test/unit/dom/matchers/has_form_values_test.dart
@@ -39,7 +39,8 @@ void main() {
   group('hasFormValues matcher', () {
     const rootElemTestId = 'root-of-test-form';
     RenderResult renderFormWithValues(
-        /*ReactDomComponentFactoryProxy*/ dynamic rootElem, List<_FormElemDefinition> els) {
+        /*ReactDomComponentFactoryProxy*/ dynamic rootElem,
+        List<_FormElemDefinition> els) {
       assert(rootElem == react.form || rootElem == react.fieldset);
 
       final vDom = rootElem(

--- a/test/unit/dom/matchers/is_partially_checked_test.dart
+++ b/test/unit/dom/matchers/is_partially_checked_test.dart
@@ -31,9 +31,7 @@ void main() {
       });
 
       test('An element with role="checkbox"', () {
-        final cboxEl = DivElement()
-          ..setAttribute('role', 'checkbox')
-          ..setAttribute('aria-checked', 'mixed');
+        final cboxEl = DivElement()..setAttribute('role', 'checkbox')..setAttribute('aria-checked', 'mixed');
         shouldPass(cboxEl, isPartiallyChecked);
       });
     });

--- a/test/unit/util/exception.dart
+++ b/test/unit/util/exception.dart
@@ -1,3 +1,19 @@
+// @dart = 2.7
+
+// Copyright 2021 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /// A unique exception type, for use in testing, so that we can easily differentiate errors thrown
 /// intentionally as part of a test from other errors by using `isA`.
 class ExceptionForTesting implements Exception {

--- a/test/unit/util/prints_and_logs_recording.dart
+++ b/test/unit/util/prints_and_logs_recording.dart
@@ -1,3 +1,19 @@
+// @dart = 2.7
+
+// Copyright 2021 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import 'dart:async';
 
 import 'package:meta/meta.dart';


### PR DESCRIPTION
## Overview
This updates the minimum Dart version that can be used to at least 2.11.0. Why 2.11.0 and not 2.13.4? Because setting it to 2.12.0 or higher opts the project into null safety (https://dart.dev/null-safety) which our code has not been migrated to yet. 
## What about null safety?
Once a project has been migrated to null safety it is ok to update the  minimum to 2.12.0 or even 2.13.4 since everyone at Workiva should be  using 2.13.4 now.
## Review / Testing / QA / Merge
If CI passes please review and merge. Most Dart CI has already been updated to run under 2.13.4 already so updating the minimum here doesn't change any code, or CI circumstances.
If CI fails, it's likely because an image in the Dockerfile or skynet.yaml is still running an older version of Dart. It should be updated to one with Dart 2.13. A list of existing 2.13 images lives here  https://wiki.atl.workiva.net/display/CP/Dart+2.13+Upgrade Feel free to fix CI and get this PR merged. However if you don't get to it, be aware that Client Platform will be going through the batch to help fix  any failures.
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/up_dart_sdk_minimum_to_2.11`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/up_dart_sdk_minimum_to_2.11)