### PR TITLE
CPLAT-15628 Add default timeout to waitForElementToBeRemoved

### DIFF
--- a/lib/src/dom/async/wait_for.dart
+++ b/lib/src/dom/async/wait_for.dart
@@ -168,7 +168,7 @@ Future<T> waitFor<T>(
 Future<void> waitForElementToBeRemoved(
   Node Function() callback, {
   Node container,
-  Duration timeout,
+  Duration timeout = const Duration(seconds: 1),
   Duration interval = const Duration(milliseconds: 50),
   QueryTimeoutFn onTimeout,
   MutationObserverOptions mutationObserverOptions = defaultMutationObserverOptions,


### PR DESCRIPTION
## Motivation
`waitForElementToBeRemoved` doesn’t have a default for timeout. Though it calls waitFor (which has a default timeout), it throws its own timeout exception which uses waitFor's duration in the message.

## Changes
* Add a 1-second default `Duration` to the `timeout` parameter

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

<!-- Tag people to review via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed:
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct

[contributing-review-types]: https://github.com/Workiva/react_testing_library/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/react_testing_library/blob/master/CONTRIBUTING.md#manual-testing-criteria