### PR TITLE
Only check formatting in CI on Dart 2.13.4

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -31,10 +31,6 @@ jobs:
         run: dart pub get
         timeout-minutes: 2
 
-      - name: Check formatting
-        run: dart format . -l 120 --set-exit-if-changed
-        if: ${{ always() && steps.install.outcome == 'success' && matrix.sdk == 'stable' }}
-
       - name: Analyze project source
         run: dart analyze
         if: ${{ always() && steps.install.outcome == 'success' }}
@@ -84,6 +80,10 @@ jobs:
         name: Install dependencies
         run: pub get
         timeout-minutes: 2
+
+      - name: Check formatting
+        run: dart format . -l 120 --set-exit-if-changed
+        if: ${{ always() && steps.install.outcome == 'success' }}
 
       - name: Analyze project source
         run: dartanalyzer .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # React Testing Library Changelog
 
+## 1.1.13
+*  (CI-only change) Only check formatting on Dart 2.13.4
+
+## 1.1.12
+*  Add default timeout to `waitForElementToBeRemoved`
+
+## 1.1.11
+*  Raise the Dart SDK minimum to at least 2.11.0
+
 ## 1.1.10
 *  Fix state error thrown by calls to `logRoles()` and `.debug()` (bug introduced in 1.1.9)
 


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Dart 2.14.2 and Dart 2.13.4 have different opinions on formatting - right now we are checking formatting in CI on Dart 2.14.2, but we are using Dart 2.13.4 locally so it can be confusing to figure out what is causing those formatting failures. It seems like it would be more straight forward to check formatting on the Dart version that we use locally.

## Changes
  <!-- What this PR changes to fix the problem. -->
- Move formatting check to Dart 2.13.4

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

        If you're not sure who from our team should review these changes, then leave this section
        blank for now and post a link to the PR in the #support-ui-platform Slack channel.
  -->

<!-- Tag people to review via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author:
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
      - [ ] CI passes
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/react_testing_library/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/react_testing_library/blob/master/CONTRIBUTING.md#manual-testing-criteria
