### PR TITLE
Misc maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Rather than dealing with [OverReact] `UiComponent` instances, or React VDom `Rea
 
 ```yaml
 dependencies:
+  # This is not required to use this library, but it is assumed
+  # that you are testing OverReact UI components, so it is 
+  # shown here for completeness.
   over_react: ^4.0.0
 
 dev_dependencies:

--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ dependencies:
   over_react: ^4.0.0
 
 dev_dependencies:
-  build_runner: ^1.7.1
+  build_runner: ">=1.7.1 <3.0.0"
   build_test: ">=0.10.9 <3.0.0"
-  build_web_compilers: ^2.9.0
-  react_testing_library: ^1.1.4
+  build_web_compilers: ">=2.12.0 <4.0.0"
+  react_testing_library: ^1.1.13
   test: ^1.14.4
   # This is not technically required, 
   # but makes the HTML portion of your test bootstrapping much easier!
-  test_html_builder: ^1.0.0 
+  test_html_builder: ^2.0.0
 ```
 </figure>
 
@@ -105,12 +105,13 @@ We *strongly* recommend using the [test_html_builder] library to create a templa
 <!DOCTYPE html>
 <html lang="en">
   <head>
-      <title>React Testing Library Unit Test</title>
+      <title>{{testName}}</title>
       <script src="packages/react/react.js"></script>
       <script src="packages/react/react_dom.js"></script>
       <script src="packages/react_testing_library/js/react-testing-library.js"></script>
 
-      {test}
+      {{testScript}}
+      <script src="packages/test/dart.js"></script>
   </head>
 </html>
 ```

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,5 @@
+# Getting Started With React Testing Library
+
+Check out the [Getting Started section in the main readme](./#getting-started) for an example of how to use the `react_testing_library` package.
+
+The API documentation of all the [matchers](https://pub.dev/documentation/react_testing_library/latest/topics/Matchers-topic.html) and [querying utilities](https://pub.dev/documentation/react_testing_library/latest/topics/Queries-topic.html) also provide complete code examples.

--- a/pubspec.next.yaml
+++ b/pubspec.next.yaml
@@ -1,5 +1,5 @@
 name: react_testing_library
-version: 0.1.0-nullsafety.0
+version: 1.1.13-nullsafety.0
 description: A Dart unit testing library for OverReact components that mimics the API of the JS react-testing-library
 homepage: https://github.com/Workiva/react_testing_library/
 documentation: https://workiva.github.io/react_testing_library
@@ -15,11 +15,10 @@ dependencies:
   test: ^1.14.4
 
 dev_dependencies:
-  build_runner: ^1.7.1
+  build_runner: ">=1.7.1 <3.0.0"
   build_test: ">=0.10.9 <3.0.0"
-  build_web_compilers: ^2.9.0
-  test_core: "<=0.3.25" # https://github.com/dart-lang/test/issues/1535
-  test_html_builder: ^1.0.0
+  build_web_compilers: ">=2.12.0 <4.0.0"
+  test_html_builder: ^2.0.0
   workiva_analysis_options: ^1.0.0
 
 dependency_overrides:
@@ -30,4 +29,4 @@ dependency_overrides:
   test_html_builder:
     git:
       url: https://github.com/workiva/test_html_builder.git
-      ref: dart212
+      ref: v3_wip

--- a/pubspec.next.yaml
+++ b/pubspec.next.yaml
@@ -18,7 +18,7 @@ dev_dependencies:
   build_runner: ">=1.7.1 <3.0.0"
   build_test: ">=0.10.9 <3.0.0"
   build_web_compilers: ">=2.12.0 <4.0.0"
-  test_html_builder: ^2.0.0
+  test_html_builder: ">=2.0.0 <4.0.0"
   workiva_analysis_options: ^1.0.0
 
 dependency_overrides:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   color: ">=2.1.1 <4.0.0"
   js: ^0.6.2
   matcher: ^0.12.9
-  meta: ^1.1.0
+  meta: ">=1.1.0 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   react: ^6.0.0
   test: ^1.14.4
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,5 +18,5 @@ dev_dependencies:
   build_runner: ">=1.7.1 <3.0.0"
   build_test: ">=0.10.9 <3.0.0"
   build_web_compilers: ">=2.12.0 <4.0.0"
-  test_html_builder: ^2.0.0
+  test_html_builder: ">=2.0.0 <4.0.0"
   workiva_analysis_options: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   test: ^1.14.4
 
 dev_dependencies:
-  build_runner: ^1.7.1
+  build_runner: ">=1.7.1 <3.0.0"
   build_test: ">=0.10.9 <3.0.0"
-  build_web_compilers: ^2.9.0
+  build_web_compilers: ">=2.12.0 <4.0.0"
   test_html_builder: ^1.0.0
   workiva_analysis_options: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,5 +18,5 @@ dev_dependencies:
   build_runner: ">=1.7.1 <3.0.0"
   build_test: ">=0.10.9 <3.0.0"
   build_web_compilers: ">=2.12.0 <4.0.0"
-  test_html_builder: ^1.0.0
+  test_html_builder: ^2.0.0
   workiva_analysis_options: ^1.0.0

--- a/test/unit/unit_test_template.html
+++ b/test/unit/unit_test_template.html
@@ -17,11 +17,12 @@ limitations under the License.
 <!DOCTYPE html>
 <html lang="en">
   <head>
-      <title>React Testing Library Unit Test</title>
+      <title>{{testName}}</title>
       <script src="packages/react/react.js"></script>
       <script src="packages/react/react_dom.js"></script>
       <script src="packages/react_testing_library/js/react-testing-library.js"></script>
 
-      {test}
+      {{testScript}}
+      <script src="packages/test/dart.js"></script>
   </head>
 </html>


### PR DESCRIPTION
## Motivation
1. The `pub.dev` score for this package was being docked 10 points for not having an `example` directory.
1. `test_html_builder` 2.0 is a thing, and we should use it - and update our setup example accordingly.

## Changes
1. Add an `example/README.md` file to satisfy the Dart package layout conventions.
1. Upgrade to `test_html_builder` 2, update setup examples.
1. Widen dependency ranges to un-block analyzer 1.x.