### PR TITLE
Handle synchronous TestFailure within async fn body

### DIFF
--- a/lib/src/dom/async/wait_for.dart
+++ b/lib/src/dom/async/wait_for.dart
@@ -107,8 +107,7 @@ Future<T> waitFor<T>(
       if (result is Future) {
         isPending = true;
         (result as Future)
-            .then((resolvedValue) => onDone(null, resolvedValue as T),
-                onError: (e) => lastError = e)
+            .then((resolvedValue) => onDone(null, resolvedValue as T), onError: (e) => lastError = e)
             .whenComplete(() => isPending = false);
       } else {
         onDone(null, result as T);

--- a/test/unit/dom/wait_for_test.dart
+++ b/test/unit/dom/wait_for_test.dart
@@ -157,8 +157,7 @@ void main() {
               expect(view.queryByAltText('waitFor'), isNull, reason: 'test setup sanity check');
               expect(
                   () => rtl.waitFor(
-                      () => view.findByAltText('somethingThatDoesNotExist',
-                          timeout: asyncQueryTimeout ~/ 2),
+                      () => view.findByAltText('somethingThatDoesNotExist', timeout: asyncQueryTimeout ~/ 2),
                       container: view.container),
                   throwsA(allOf(
                     isA<TestingLibraryElementError>(),

--- a/test/unit/dom/wait_for_test.dart
+++ b/test/unit/dom/wait_for_test.dart
@@ -58,6 +58,30 @@ void main() {
                     rtl.waitFor(() => expect(view.container.contains(rootElement), isFalse), container: view.container),
                 throwsA(isA<TestFailure>()));
           }, timeout: asyncQueryTestTimeout);
+
+          group('that is placed within an asynchronous function body', () {
+            test('and succeeds before timeout', () async {
+              var numRuns = 0;
+              await rtl.waitFor(() async {
+                numRuns++;
+                expect(numRuns, 5);
+              });
+            }, timeout: asyncQueryTestTimeout);
+
+            test(
+                'and never succeeds before timeout, throwing the consumer TestFailure instead of a generic TimeoutException',
+                () async {
+              var numRuns = 0;
+              expect(
+                  () => rtl.waitFor(() async {
+                        if (numRuns < 4) {
+                          numRuns++;
+                        }
+                        expect(numRuns, 5);
+                      }),
+                  throwsA(isA<TestFailure>()));
+            }, timeout: asyncQueryTestTimeout);
+          });
         });
 
         test('a function that throws an arbitrary error, rethrows the error thrown by the expectation', () async {


### PR DESCRIPTION
## Motivation
@josephnaberhaus-wk pointed out that when the `async` modifier is added to the `waitFor` callback, any `expect()` within the callback that fails will cause `waitFor` to throw immediately instead of continuing to call the callback on an interval.

Essentially - the issue is that currently, the first test will fail immediately instead of waiting for `numRuns` to get to `5`, whereas the second test will pass since it's not `async`.

```dart
test('this will fail as a result of the async modifier on the callback', () async {
  var numRuns = 0;
  await rtl.waitFor(() async {
    numRuns++;
    expect(numRuns, 5);
  });
});

test('this will pass', () async {
  var numRuns = 0;
  await rtl.waitFor(() {
    numRuns++;
    expect(numRuns, 5);
  });
});
```

@greglittlefield-wf @joebingham-wk @sydneyjodon-wk I am unsure if handling synchronous failures like this is desired behavior, but I am putting up this PR since I was able to get something working that seems to also preserve the existing behaviors of waiting for things like one of RTL's async matchers (`findBy*`).

## Changes
Only call `onDone()` when the error thrown from the async function is *not* a `TestFailure`. If it is a `TestFailure`, store that failure as the `lastError` like we do when an error is thrown from a synchronous callback, and keep trying the callback until a timeout occurs.

These changes make it so that both of the test cases shown above will pass as expected.

#### Release Notes
Add support for synchronous test failures within an asynchronous callback in the `waitFor` utility.