### PR TITLE
Align waitFor implementation more closely with JS implementation

### DIFF
--- a/test/unit/dom/wait_for_test.dart
+++ b/test/unit/dom/wait_for_test.dart
@@ -113,10 +113,13 @@ void main() {
           }, timeout: asyncQueryTestTimeout);
 
           group('that fails, throws the error returned from the expectation', () {
-            test('', () async {
+            test('when it completes sooner than the timeout', () async {
               expect(view.queryByAltText('waitFor'), isNull, reason: 'test setup sanity check');
               expect(
-                  () => rtl.waitFor(() => view.findByAltText('somethingThatDoesNotExist'), container: view.container),
+                  () => rtl.waitFor(
+                      () => view.findByAltText('somethingThatDoesNotExist',
+                          timeout: asyncQueryTimeout ~/ 2),
+                      container: view.container),
                   throwsA(allOf(
                     isA<TestingLibraryElementError>(),
                     hasToStringValue(contains('alt text: somethingThatDoesNotExist')),
@@ -126,7 +129,7 @@ void main() {
             test('unless the timeout duration is less than the timeout duration of the query', () async {
               expect(view.queryByAltText('waitFor'), isNull, reason: 'test setup sanity check');
               expect(
-                  () => rtl.waitFor(() => view.findByAltText('somethingThatDoesNotExist'),
+                  rtl.waitFor(() => view.findByAltText('somethingThatDoesNotExist'),
                       container: view.container, timeout: asyncQueryTimeout ~/ 2),
                   throwsA(allOf(
                     isA<TimeoutException>(),


### PR DESCRIPTION
## Motivation
There were some issues in the current `waitFor` implementation related to async callbacks.

I found that aligning the implementation more closely with [its JS counterpart](https://github.com/testing-library/dom-testing-library/blob/main/src/wait-for.js) fixes the issue, allowing the original implementation to be simpler than the original fix in https://github.com/Workiva/react_testing_library/pull/40, and also fixes some other behavioral parity issues.

## Changes
- Update `waitFor` implementation to more closely match the JS implementation.
- Add additional tests

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

        If you're not sure who from our team should review these changes, then leave this section
        blank for now and post a link to the PR in the #support-ui-platform Slack channel.
  -->

<!-- Tag people to review via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author:
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/react_testing_library/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/react_testing_library/blob/master/CONTRIBUTING.md#manual-testing-criteria
