### PR TITLE
Update test_html_builder to v2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,5 +18,5 @@ dev_dependencies:
   build_runner: ">=1.7.1 <3.0.0"
   build_test: ">=0.10.9 <3.0.0"
   build_web_compilers: ">=2.12.0 <4.0.0"
-  test_html_builder: ">=2.0.0 <4.0.0"
+  test_html_builder: '>=2.2.2 <4.0.0'
   workiva_analysis_options: ^1.0.0


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! Read more details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This batch is to find and open PRs to upgrade test_html_builder to v2.

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/update_test_html_builder_to_v2`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/update_test_html_builder_to_v2)