### PR TITLE
Add changelog for 2.1.0 release, add de-facto skynet plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # React Testing Library Changelog
 
+## 2.1.0
+- [#48](https://github.com/Workiva/react_testing_library/pull/48) Expose the `skipPointerEventsCheck` check
+
 ## 2.0.1
 - Fix test ID queries using test IDs in RegExps without escaping them
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,10 @@ RUN eval "$(ssh-agent -s)" && \
 	ssh-add /root/.ssh/id_rsa
 
 WORKDIR /build/
-ADD pubspec.yaml /build
-RUN pub get
+COPY pubspec.yaml .
+RUN dart pub get
+COPY /lib ./lib/
 ARG BUILD_ARTIFACTS_AUDIT=/build/pubspec.lock
+# Output the bundle to be verified in Skynet runs.
+ARG BUILD_ARTIFACTS_RTL_JS_BUNDLE=/build/lib/js/react-testing-library.js
 FROM scratch

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,0 +1,15 @@
+name: validate_js_bundle
+description: Verifies the JS bundle exists
+image: drydock.workiva.net/workiva/skynet-images:node-test-image-latest
+size: large
+timeout: 900
+
+requires:
+  Workiva/react_testing_library:
+    - rtl_js_bundle
+
+scripts:
+  - mkdir build
+  - cp $SKYNET_APPLICATION_REACT_TESTING_LIBRARY_RTL_JS_BUNDLE ./build
+  - cd build
+  - test -e ./react-testing-library.js && { echo 'Verified js bundle exists.'; } || { echo 'JS bundle /lib/js/react-testing-library.js should exist.'; exit 1; }

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,5 +1,5 @@
 name: validate_js_bundle
-description: Verifies the JS bundle exists
+description: Verifies the JS bundle is checked in - this check is mainly in place so we have at least one Skynet config
 image: drydock.workiva.net/workiva/skynet-images:node-test-image-latest
 size: large
 timeout: 900


### PR DESCRIPTION
## Motivation
We need a changelog entry for the 2.1.0 release, and we need skynet to run on PRs so that the Workiva release pipelines will continue to work / get past those checks.