### PR TITLE
Update references to the previous team name

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 ## Review
 _[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._
 
-  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)
+  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)
 
         *** Please refrain from tagging the whole team to prevent extraneous notifications. ***
 
@@ -31,7 +31,7 @@ _[See CONTRIBUTING.md][contributing-review-types] for more details on review typ
 
 ## Merge Checklist
 While we perform many automated checks before auto-merging, some manual checks are needed:
-- [ ] A Client Platform member has reviewed these changes
+- [ ] A Frontend Frameworks Design member has reviewed these changes
 - [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
 - [ ] _For release PRs -_ Version metadata in Rosie comment is correct
 


### PR DESCRIPTION
This batch changes references to the former team name Client Platform to now reference Frontend Frameworks Design.

`replace "Client Platform" "Frontend Frameworks Design"`

### QA steps:

CI passing should be sufficient as these changes are documentation changes.

[_Created by Sourcegraph batch change `kealjones-wk/Update_PR_Template_Team_Names_FED`._](https://sourcegraph.plat.workiva.net/users/kealjones-wk/batch-changes/Update_PR_Template_Team_Names_FED)