### PR TITLE
Raise analyzer minimum & unpin meta

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   color: ">=2.1.1 <4.0.0"
   js: ^0.6.2
   matcher: ^0.12.9
-  meta: ">=1.1.0 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
+  meta: ^1.6.0 # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   react: ^6.0.0
   test: ^1.14.4
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   color: ">=2.1.1 <4.0.0"
   js: ^0.6.2
   matcher: ^0.12.9
-  meta: ^1.6.0 # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
+  meta: ^1.6.0
   react: ^6.0.0
   test: ^1.14.4
 


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This will require analyzer 1.7.2+ and now that we're past analyzer 1.7.1
we can unpin the meta dependency. (We had restricted it to <1.7.0 in many places)

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/analyzer1_unpin_meta`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/analyzer1_unpin_meta)