### PR TITLE
Avoid meta 1.10.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   color: ^3.0.0
   js: ^0.6.2
   matcher: ^0.12.9
-  meta: ^1.6.0
+  meta: '>=1.6.0  <1.10.0'
   react: ^6.0.0
   test: ^1.14.4
 
@@ -20,3 +20,6 @@ dev_dependencies:
   build_web_compilers: ^3.0.0
   test_html_builder: ^3.0.0
   workiva_analysis_options: ^1.0.0
+dependency_validator:
+  ignore:
+    - meta


### PR DESCRIPTION
Summary
---
This is a batch change to apply a dependency range pin to the meta package
in order to avoid a "bad release". That version causes nearly all of our builds to
fail (anything on analyzer < 5).
So restricting the version range to <1.10.0 works around the issue until we
can upgrade to analyzer 5.

For more info, visit `#lang-dart` in Slack.

[_Created by Sourcegraph batch change `Workiva/avoid_meta_1_10_0`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/avoid_meta_1_10_0)