### PR TITLE
Allow react 7 and w_flux 3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   js: ^0.6.2
   matcher: ^0.12.9
   meta: ^1.6.0
-  react: ^6.0.0
+  react: '>=6.0.0 <8.0.0'
   test: ^1.14.4
 
 dev_dependencies:


### PR DESCRIPTION
This PR raises the max allowed versions for react and w_flux. A second batch will follow to raise the minimums of these later.
These versions have been tested across the frontend ecosystem in a test batch prior to releasing these versions.
Feel free to review, approve and merge if CI passes. Otherwise someone on FEDX will come around and get it merged.
For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/react_flux_majors`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/react_flux_majors)