### PR TITLE
FEDX-1711: Workiva Analysis Options v2

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,4 @@
-include: package:workiva_analysis_options/v1.recommended.yaml
-
+include: package:workiva_analysis_options/v2.yaml
 analyzer:
   errors:
     unused_import: warning

--- a/lib/src/util/console_log_utils.dart
+++ b/lib/src/util/console_log_utils.dart
@@ -203,9 +203,6 @@ external _PropertyDescriptor _getOwnPropertyDescriptor(dynamic object, String pr
 @JS('Object.defineProperty')
 external void _defineProperty(dynamic object, String propertyName, dynamic descriptor);
 
-@JS('Object.prototype.hasOwnProperty')
-external bool _hasOwnProperty(dynamic object, String name);
-
 @JS()
 @anonymous
 class _PropertyDescriptor {}


### PR DESCRIPTION
# [FEDX-1711](https://jira.atl.workiva.net/browse/FEDX-1711)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-1711)

This PR bumps/adds workiva_analysis_options to v2. This is being done in an effort to adopt consistency in
`analysis_options.yaml` files across the codebase, and ensure all developers are using the most up to date
functionality that the dart analyzer can provide.

Failing CI will be evaluated by someone from FEDX and resolved. We will reach out when the pr is ready for review.

If you have any questions, concerns, or opinions, please reach out to #support-frontend-dx.

[_Created by Sourcegraph batch change `Workiva/workiva_analysis_options_v2`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/workiva_analysis_options_v2)