### PR TITLE
Raise the meta dependency min to v1.16.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   color: ^3.0.0
   js: ^0.6.2
   matcher: ^0.12.9
-  meta: ^1.6.0
+  meta: ^1.16.0
   react: ^7.0.0
   test: ^1.14.4
 


### PR DESCRIPTION
This PR raises the min version of meta to 1.16.0. Passing CI
should be sufficient for QA, so feel free to review and merge this once CI completes.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/meta_raise_min_v1_16_0_really`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/meta_raise_min_v1_16_0_really)