### PR TITLE
FED-3273 SPIKE - do not merge: React 18 dual versions

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4,6 +4,7 @@ targets:
       build_web_compilers|entrypoint:
         # These are globs for the entrypoints you want to compile.
         generate_for:
+          - example/**
           - test/**.browser_test.dart
         options:
           # List any dart2js specific args here, or omit it.

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,14 @@
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+      <title>RTL - React 18</title>
+      <script src="packages/react/react.js"></script>
+      <script src="packages/react/react_dom.js"></script>
+      <script src="packages/react_testing_library/js/react-testing-library.js"></script>
+  </head>
+<body>
+    <script defer src="main.js"></script>
+    <script defer src="main.dart.js"></script>
+</body>
+</html>

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,0 +1,28 @@
+import 'package:react/react.dart' as react;
+import 'package:react_testing_library/react_testing_library.dart';
+import 'package:react_testing_library/user_event.dart';
+
+main() {
+  final content = react.button({
+    'onClick': (_) {
+      print('clicked');
+      throw TestException('intentionally thrown during onClick');
+    },
+  }, 'Hello World');
+  final view = render(content, autoTearDown: false);
+  final button = view.getByRole('button', name: 'Hello World');
+  try {
+    UserEvent.click(button);
+  } catch (e) {
+    print('Caught exception $e');
+  }
+}
+
+class TestException implements Exception {
+  final String message;
+
+  TestException(this.message);
+
+  @override
+  String toString() => 'TestException: $message';
+}

--- a/example/main.js
+++ b/example/main.js
@@ -1,0 +1,2 @@
+console.log('window.React.version', window.React.version);
+console.log('window.rtl', window.rtl);

--- a/js_src/package-lock.json
+++ b/js_src/package-lock.json
@@ -1,0 +1,2089 @@
+{
+  "name": "react_testing_library_src",
+  "version": "1.0.0-alpha.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "react_testing_library_src",
+      "version": "1.0.0-alpha.0",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@testing-library/dom": "^8.0.0",
+        "@testing-library/react": "^13.0.0",
+        "@testing-library/user-event": "^13.1.9",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "devDependencies": {
+        "vite": "^5.4.9"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.28.1.tgz",
+      "integrity": "sha512-2aZp8AES04KI2dy3Ss6/MDjXbwBzj+i0GqKtWXgw2/Ma6E4jJvujryO6gJAghIRVz7Vwr9Gtl/8na3nDUKpraQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.28.1.tgz",
+      "integrity": "sha512-EbkK285O+1YMrg57xVA+Dp0tDBRB93/BZKph9XhMjezf6F4TpYjaUSuPt5J0fZXlSag0LmZAsTmdGGqPp4pQFA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.28.1.tgz",
+      "integrity": "sha512-prduvrMKU6NzMq6nxzQw445zXgaDBbMQvmKSJaxpaZ5R1QDM8w+eGxo6Y/jhT/cLoCvnZI42oEqf9KQNYz1fqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.28.1.tgz",
+      "integrity": "sha512-WsvbOunsUk0wccO/TV4o7IKgloJ942hVFK1CLatwv6TJspcCZb9umQkPdvB7FihmdxgaKR5JyxDjWpCOp4uZlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.28.1.tgz",
+      "integrity": "sha512-HTDPdY1caUcU4qK23FeeGxCdJF64cKkqajU0iBnTVxS8F7H/7BewvYoG+va1KPSL63kQ1PGNyiwKOfReavzvNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.28.1.tgz",
+      "integrity": "sha512-m/uYasxkUevcFTeRSM9TeLyPe2QDuqtjkeoTpP9SW0XxUWfcYrGDMkO/m2tTw+4NMAF9P2fU3Mw4ahNvo7QmsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.28.1.tgz",
+      "integrity": "sha512-QAg11ZIt6mcmzpNE6JZBpKfJaKkqTm1A9+y9O+frdZJEuhQxiugM05gnCWiANHj4RmbgeVJpTdmKRmH/a+0QbA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.28.1.tgz",
+      "integrity": "sha512-dRP9PEBfolq1dmMcFqbEPSd9VlRuVWEGSmbxVEfiq2cs2jlZAl0YNxFzAQS2OrQmsLBLAATDMb3Z6MFv5vOcXg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.28.1.tgz",
+      "integrity": "sha512-uGr8khxO+CKT4XU8ZUH1TTEUtlktK6Kgtv0+6bIFSeiSlnGJHG1tSFSjm41uQ9sAO/5ULx9mWOz70jYLyv1QkA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.28.1.tgz",
+      "integrity": "sha512-QF54q8MYGAqMLrX2t7tNpi01nvq5RI59UBNx+3+37zoKX5KViPo/gk2QLhsuqok05sSCRluj0D00LzCwBikb0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.28.1.tgz",
+      "integrity": "sha512-vPul4uodvWvLhRco2w0GcyZcdyBfpfDRgNKU+p35AWEbJ/HPs1tOUrkSueVbBS0RQHAf/A+nNtDpvw95PeVKOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.28.1.tgz",
+      "integrity": "sha512-pTnTdBuC2+pt1Rmm2SV7JWRqzhYpEILML4PKODqLz+C7Ou2apEV52h19CR7es+u04KlqplggmN9sqZlekg3R1A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.28.1.tgz",
+      "integrity": "sha512-vWXy1Nfg7TPBSuAncfInmAI/WZDd5vOklyLJDdIRKABcZWojNDY0NJwruY2AcnCLnRJKSaBgf/GiJfauu8cQZA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.28.1.tgz",
+      "integrity": "sha512-/yqC2Y53oZjb0yz8PVuGOQQNOTwxcizudunl/tFs1aLvObTclTwZ0JhXF2XcPT/zuaymemCDSuuUPXJJyqeDOg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.28.1.tgz",
+      "integrity": "sha512-fzgeABz7rrAlKYB0y2kSEiURrI0691CSL0+KXwKwhxvj92VULEDQLpBYLHpF49MSiPG4sq5CK3qHMnb9tlCjBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.28.1.tgz",
+      "integrity": "sha512-xQTDVzSGiMlSshpJCtudbWyRfLaNiVPXt1WgdWTwWz9n0U12cI2ZVtWe/Jgwyv/6wjL7b66uu61Vg0POWVfz4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.28.1.tgz",
+      "integrity": "sha512-wSXmDRVupJstFP7elGMgv+2HqXelQhuNf+IS4V+nUpNVi/GUiBgDmfwD0UGN3pcAnWsgKG3I52wMOBnk1VHr/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.28.1.tgz",
+      "integrity": "sha512-ZkyTJ/9vkgrE/Rk9vhMXhf8l9D+eAhbAVbsGsXKy2ohmJaWg0LPQLnIxRdRp/bKyr8tXuPlXhIoGlEB5XpJnGA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.28.1.tgz",
+      "integrity": "sha512-ZvK2jBafvttJjoIdKm/Q/Bh7IJ1Ose9IBOwpOXcOvW3ikGTQGmKDgxTC6oCAzW6PynbkKP8+um1du81XJHZ0JA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
+      "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
+      "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^8.5.0",
+        "@types/react-dom": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
+      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.14",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.17.tgz",
+      "integrity": "sha512-opAQ5no6LqJNo9TqnxBKsgnkIYHozW9KSTlFVoSUJYh1Fl/sswkEoqIugRSm7tbh6pABtYjGAjW+GOS23j8qbw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
+      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "deep-equal": "^2.0.5"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
+      "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "dunder-proto": "^1.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "function-bind": "^1.1.2",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
+      "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.0.0.tgz",
+      "integrity": "sha512-4MqMiKP90ybymYvsut0CH2g4XWbfLtmlCkXmtmdcDCxNB+mQcu1w/1+L/VD7vi/PSv7X2JYV7SCcR+jiPXnQtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "license": "MIT"
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
+      "integrity": "sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.28.1.tgz",
+      "integrity": "sha512-61fXYl/qNVinKmGSTHAZ6Yy8I3YIJC/r2m9feHo6SwVAVcLT5MPwOUFe7EuURA/4m0NR8lXG4BBXuo/IZEsjMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.6"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.28.1",
+        "@rollup/rollup-android-arm64": "4.28.1",
+        "@rollup/rollup-darwin-arm64": "4.28.1",
+        "@rollup/rollup-darwin-x64": "4.28.1",
+        "@rollup/rollup-freebsd-arm64": "4.28.1",
+        "@rollup/rollup-freebsd-x64": "4.28.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.28.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.28.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.28.1",
+        "@rollup/rollup-linux-arm64-musl": "4.28.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.28.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.28.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.28.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.28.1",
+        "@rollup/rollup-linux-x64-gnu": "4.28.1",
+        "@rollup/rollup-linux-x64-musl": "4.28.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.28.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.28.1",
+        "@rollup/rollup-win32-x64-msvc": "4.28.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
+      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
+      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    }
+  }
+}

--- a/js_src/package.json
+++ b/js_src/package.json
@@ -4,11 +4,11 @@
   "version": "1.0.0-alpha.0",
   "private": true,
   "license": "UNLICENSED",
-  "main": "src/_react-testing-library.js",
+  "main": "src/index.js",
   "files": [
     "src"
   ],
-  "module": "src/_react-testing-library.js",
+  "module": "src/index.js",
   "prodBundle": "../lib/js/react-testing-library.js",
   "scripts": {
     "build": "vite build",

--- a/js_src/src/index.js
+++ b/js_src/src/index.js
@@ -1,0 +1,22 @@
+import * as rtl17 from './rtl-17.esm';
+import * as rtl18 from './_react-testing-library';
+
+// The entry point for the react_testing_library JS file.
+//
+// Conditionally exports, and populates the window with, a version of RTL that's
+// compatible with either React 17 or 18, depending on `window.React.version`.
+
+const reactVersion = window.React?.version;
+const isReact17 = typeof reactVersion === 'string' && reactVersion.startsWith('17.');
+
+console.log(`RTL: reactVersion: ${reactVersion}, isReact17: ${isReact17}`)
+
+let rtl;
+if (isReact17) {
+    console.log('RTL: selected React-17-compatible version.');
+    rtl = rtl17;
+} else {
+    console.log('RTL: selected React-18-compatible version.');
+    rtl = rtl18;
+}
+export default rtl;

--- a/js_src/src/rtl-17.esm.js
+++ b/js_src/src/rtl-17.esm.js
@@ -1,0 +1,26610 @@
+import * as l$1 from 'react';
+import l__default from 'react';
+import m$1 from 'react-dom';
+
+var global$1 = (typeof global !== "undefined" ? global :
+            typeof self !== "undefined" ? self :
+            typeof window !== "undefined" ? window : {});
+
+// shim for using process in browser
+// based off https://github.com/defunctzombie/node-process/blob/master/browser.js
+
+function defaultSetTimout() {
+    throw new Error('setTimeout has not been defined');
+}
+function defaultClearTimeout () {
+    throw new Error('clearTimeout has not been defined');
+}
+var cachedSetTimeout = defaultSetTimout;
+var cachedClearTimeout = defaultClearTimeout;
+if (typeof global$1.setTimeout === 'function') {
+    cachedSetTimeout = setTimeout;
+}
+if (typeof global$1.clearTimeout === 'function') {
+    cachedClearTimeout = clearTimeout;
+}
+
+function runTimeout(fun) {
+    if (cachedSetTimeout === setTimeout) {
+        //normal enviroments in sane situations
+        return setTimeout(fun, 0);
+    }
+    // if setTimeout wasn't available but was latter defined
+    if ((cachedSetTimeout === defaultSetTimout || !cachedSetTimeout) && setTimeout) {
+        cachedSetTimeout = setTimeout;
+        return setTimeout(fun, 0);
+    }
+    try {
+        // when when somebody has screwed with setTimeout but no I.E. maddness
+        return cachedSetTimeout(fun, 0);
+    } catch(e){
+        try {
+            // When we are in I.E. but the script has been evaled so I.E. doesn't trust the global object when called normally
+            return cachedSetTimeout.call(null, fun, 0);
+        } catch(e){
+            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error
+            return cachedSetTimeout.call(this, fun, 0);
+        }
+    }
+
+
+}
+function runClearTimeout(marker) {
+    if (cachedClearTimeout === clearTimeout) {
+        //normal enviroments in sane situations
+        return clearTimeout(marker);
+    }
+    // if clearTimeout wasn't available but was latter defined
+    if ((cachedClearTimeout === defaultClearTimeout || !cachedClearTimeout) && clearTimeout) {
+        cachedClearTimeout = clearTimeout;
+        return clearTimeout(marker);
+    }
+    try {
+        // when when somebody has screwed with setTimeout but no I.E. maddness
+        return cachedClearTimeout(marker);
+    } catch (e){
+        try {
+            // When we are in I.E. but the script has been evaled so I.E. doesn't  trust the global object when called normally
+            return cachedClearTimeout.call(null, marker);
+        } catch (e){
+            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error.
+            // Some versions of I.E. have different rules for clearTimeout vs setTimeout
+            return cachedClearTimeout.call(this, marker);
+        }
+    }
+
+
+
+}
+var queue = [];
+var draining = false;
+var currentQueue;
+var queueIndex = -1;
+
+function cleanUpNextTick() {
+    if (!draining || !currentQueue) {
+        return;
+    }
+    draining = false;
+    if (currentQueue.length) {
+        queue = currentQueue.concat(queue);
+    } else {
+        queueIndex = -1;
+    }
+    if (queue.length) {
+        drainQueue();
+    }
+}
+
+function drainQueue() {
+    if (draining) {
+        return;
+    }
+    var timeout = runTimeout(cleanUpNextTick);
+    draining = true;
+
+    var len = queue.length;
+    while(len) {
+        currentQueue = queue;
+        queue = [];
+        while (++queueIndex < len) {
+            if (currentQueue) {
+                currentQueue[queueIndex].run();
+            }
+        }
+        queueIndex = -1;
+        len = queue.length;
+    }
+    currentQueue = null;
+    draining = false;
+    runClearTimeout(timeout);
+}
+function nextTick(fun) {
+    var args = new Array(arguments.length - 1);
+    if (arguments.length > 1) {
+        for (var i = 1; i < arguments.length; i++) {
+            args[i - 1] = arguments[i];
+        }
+    }
+    queue.push(new Item(fun, args));
+    if (queue.length === 1 && !draining) {
+        runTimeout(drainQueue);
+    }
+}
+// v8 likes predictible objects
+function Item(fun, array) {
+    this.fun = fun;
+    this.array = array;
+}
+Item.prototype.run = function () {
+    this.fun.apply(null, this.array);
+};
+var title = 'browser';
+var platform = 'browser';
+var browser = true;
+var env = {};
+var argv = [];
+var version$1 = ''; // empty string to avoid regexp issues
+var versions$1 = {};
+var release = {};
+var config$1 = {};
+
+function noop$1() {}
+
+var on = noop$1;
+var addListener = noop$1;
+var once = noop$1;
+var off = noop$1;
+var removeListener = noop$1;
+var removeAllListeners = noop$1;
+var emit = noop$1;
+
+function binding(name) {
+    throw new Error('process.binding is not supported');
+}
+
+function cwd () { return '/' }
+function chdir (dir) {
+    throw new Error('process.chdir is not supported');
+}function umask() { return 0; }
+
+// from https://github.com/kumavis/browser-process-hrtime/blob/master/index.js
+var performance$1 = global$1.performance || {};
+var performanceNow =
+  performance$1.now        ||
+  performance$1.mozNow     ||
+  performance$1.msNow      ||
+  performance$1.oNow       ||
+  performance$1.webkitNow  ||
+  function(){ return (new Date()).getTime() };
+
+// generate timestamp or delta
+// see http://nodejs.org/api/process.html#process_process_hrtime
+function hrtime(previousTimestamp){
+  var clocktime = performanceNow.call(performance$1)*1e-3;
+  var seconds = Math.floor(clocktime);
+  var nanoseconds = Math.floor((clocktime%1)*1e9);
+  if (previousTimestamp) {
+    seconds = seconds - previousTimestamp[0];
+    nanoseconds = nanoseconds - previousTimestamp[1];
+    if (nanoseconds<0) {
+      seconds--;
+      nanoseconds += 1e9;
+    }
+  }
+  return [seconds,nanoseconds]
+}
+
+var startTime = new Date();
+function uptime() {
+  var currentTime = new Date();
+  var dif = currentTime - startTime;
+  return dif / 1000;
+}
+
+var process$1 = {
+  nextTick: nextTick,
+  title: title,
+  browser: browser,
+  env: env,
+  argv: argv,
+  version: version$1,
+  versions: versions$1,
+  on: on,
+  addListener: addListener,
+  once: once,
+  off: off,
+  removeListener: removeListener,
+  removeAllListeners: removeAllListeners,
+  emit: emit,
+  binding: binding,
+  cwd: cwd,
+  chdir: chdir,
+  umask: umask,
+  hrtime: hrtime,
+  platform: platform,
+  release: release,
+  config: config$1,
+  uptime: uptime
+};
+
+function _extends() {
+  return _extends = Object.assign ? Object.assign.bind() : function (n) {
+    for (var e = 1; e < arguments.length; e++) {
+      var t = arguments[e];
+      for (var r in t) ({}).hasOwnProperty.call(t, r) && (n[r] = t[r]);
+    }
+    return n;
+  }, _extends.apply(null, arguments);
+}
+
+function asyncGeneratorStep(n, t, e, r, o, a, c) {
+  try {
+    var i = n[a](c),
+      u = i.value;
+  } catch (n) {
+    return void e(n);
+  }
+  i.done ? t(u) : Promise.resolve(u).then(r, o);
+}
+function _asyncToGenerator(n) {
+  return function () {
+    var t = this,
+      e = arguments;
+    return new Promise(function (r, o) {
+      var a = n.apply(t, e);
+      function _next(n) {
+        asyncGeneratorStep(a, r, o, _next, _throw, "next", n);
+      }
+      function _throw(n) {
+        asyncGeneratorStep(a, r, o, _next, _throw, "throw", n);
+      }
+      _next(void 0);
+    });
+  };
+}
+
+function getDefaultExportFromCjs (x) {
+	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+}
+
+function getAugmentedNamespace(n) {
+	if (n.__esModule) return n;
+	var a = Object.defineProperty({}, '__esModule', {value: true});
+	Object.keys(n).forEach(function (k) {
+		var d = Object.getOwnPropertyDescriptor(n, k);
+		Object.defineProperty(a, k, d.get ? d : {
+			enumerable: true,
+			get: function () {
+				return n[k];
+			}
+		});
+	});
+	return a;
+}
+
+function createCommonjsModule(fn) {
+  var module = { exports: {} };
+	return fn(module, module.exports), module.exports;
+}
+
+var _typeof_1$1 = createCommonjsModule(function (module) {
+function _typeof(o) {
+  "@babel/helpers - typeof";
+
+  return module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
+    return typeof o;
+  } : function (o) {
+    return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o;
+  }, module.exports.__esModule = true, module.exports["default"] = module.exports, _typeof(o);
+}
+module.exports = _typeof, module.exports.__esModule = true, module.exports["default"] = module.exports;
+});
+
+var regeneratorRuntime$1 = createCommonjsModule(function (module) {
+var _typeof = _typeof_1$1["default"];
+function _regeneratorRuntime() {
+  module.exports = _regeneratorRuntime = function _regeneratorRuntime() {
+    return e;
+  }, module.exports.__esModule = true, module.exports["default"] = module.exports;
+  var t,
+    e = {},
+    r = Object.prototype,
+    n = r.hasOwnProperty,
+    o = Object.defineProperty || function (t, e, r) {
+      t[e] = r.value;
+    },
+    i = "function" == typeof Symbol ? Symbol : {},
+    a = i.iterator || "@@iterator",
+    c = i.asyncIterator || "@@asyncIterator",
+    u = i.toStringTag || "@@toStringTag";
+  function define(t, e, r) {
+    return Object.defineProperty(t, e, {
+      value: r,
+      enumerable: !0,
+      configurable: !0,
+      writable: !0
+    }), t[e];
+  }
+  try {
+    define({}, "");
+  } catch (t) {
+    define = function define(t, e, r) {
+      return t[e] = r;
+    };
+  }
+  function wrap(t, e, r, n) {
+    var i = e && e.prototype instanceof Generator ? e : Generator,
+      a = Object.create(i.prototype),
+      c = new Context(n || []);
+    return o(a, "_invoke", {
+      value: makeInvokeMethod(t, r, c)
+    }), a;
+  }
+  function tryCatch(t, e, r) {
+    try {
+      return {
+        type: "normal",
+        arg: t.call(e, r)
+      };
+    } catch (t) {
+      return {
+        type: "throw",
+        arg: t
+      };
+    }
+  }
+  e.wrap = wrap;
+  var h = "suspendedStart",
+    l = "suspendedYield",
+    f = "executing",
+    s = "completed",
+    y = {};
+  function Generator() {}
+  function GeneratorFunction() {}
+  function GeneratorFunctionPrototype() {}
+  var p = {};
+  define(p, a, function () {
+    return this;
+  });
+  var d = Object.getPrototypeOf,
+    v = d && d(d(values([])));
+  v && v !== r && n.call(v, a) && (p = v);
+  var g = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(p);
+  function defineIteratorMethods(t) {
+    ["next", "throw", "return"].forEach(function (e) {
+      define(t, e, function (t) {
+        return this._invoke(e, t);
+      });
+    });
+  }
+  function AsyncIterator(t, e) {
+    function invoke(r, o, i, a) {
+      var c = tryCatch(t[r], t, o);
+      if ("throw" !== c.type) {
+        var u = c.arg,
+          h = u.value;
+        return h && "object" == _typeof(h) && n.call(h, "__await") ? e.resolve(h.__await).then(function (t) {
+          invoke("next", t, i, a);
+        }, function (t) {
+          invoke("throw", t, i, a);
+        }) : e.resolve(h).then(function (t) {
+          u.value = t, i(u);
+        }, function (t) {
+          return invoke("throw", t, i, a);
+        });
+      }
+      a(c.arg);
+    }
+    var r;
+    o(this, "_invoke", {
+      value: function value(t, n) {
+        function callInvokeWithMethodAndArg() {
+          return new e(function (e, r) {
+            invoke(t, n, e, r);
+          });
+        }
+        return r = r ? r.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg();
+      }
+    });
+  }
+  function makeInvokeMethod(e, r, n) {
+    var o = h;
+    return function (i, a) {
+      if (o === f) throw Error("Generator is already running");
+      if (o === s) {
+        if ("throw" === i) throw a;
+        return {
+          value: t,
+          done: !0
+        };
+      }
+      for (n.method = i, n.arg = a;;) {
+        var c = n.delegate;
+        if (c) {
+          var u = maybeInvokeDelegate(c, n);
+          if (u) {
+            if (u === y) continue;
+            return u;
+          }
+        }
+        if ("next" === n.method) n.sent = n._sent = n.arg;else if ("throw" === n.method) {
+          if (o === h) throw o = s, n.arg;
+          n.dispatchException(n.arg);
+        } else "return" === n.method && n.abrupt("return", n.arg);
+        o = f;
+        var p = tryCatch(e, r, n);
+        if ("normal" === p.type) {
+          if (o = n.done ? s : l, p.arg === y) continue;
+          return {
+            value: p.arg,
+            done: n.done
+          };
+        }
+        "throw" === p.type && (o = s, n.method = "throw", n.arg = p.arg);
+      }
+    };
+  }
+  function maybeInvokeDelegate(e, r) {
+    var n = r.method,
+      o = e.iterator[n];
+    if (o === t) return r.delegate = null, "throw" === n && e.iterator["return"] && (r.method = "return", r.arg = t, maybeInvokeDelegate(e, r), "throw" === r.method) || "return" !== n && (r.method = "throw", r.arg = new TypeError("The iterator does not provide a '" + n + "' method")), y;
+    var i = tryCatch(o, e.iterator, r.arg);
+    if ("throw" === i.type) return r.method = "throw", r.arg = i.arg, r.delegate = null, y;
+    var a = i.arg;
+    return a ? a.done ? (r[e.resultName] = a.value, r.next = e.nextLoc, "return" !== r.method && (r.method = "next", r.arg = t), r.delegate = null, y) : a : (r.method = "throw", r.arg = new TypeError("iterator result is not an object"), r.delegate = null, y);
+  }
+  function pushTryEntry(t) {
+    var e = {
+      tryLoc: t[0]
+    };
+    1 in t && (e.catchLoc = t[1]), 2 in t && (e.finallyLoc = t[2], e.afterLoc = t[3]), this.tryEntries.push(e);
+  }
+  function resetTryEntry(t) {
+    var e = t.completion || {};
+    e.type = "normal", delete e.arg, t.completion = e;
+  }
+  function Context(t) {
+    this.tryEntries = [{
+      tryLoc: "root"
+    }], t.forEach(pushTryEntry, this), this.reset(!0);
+  }
+  function values(e) {
+    if (e || "" === e) {
+      var r = e[a];
+      if (r) return r.call(e);
+      if ("function" == typeof e.next) return e;
+      if (!isNaN(e.length)) {
+        var o = -1,
+          i = function next() {
+            for (; ++o < e.length;) if (n.call(e, o)) return next.value = e[o], next.done = !1, next;
+            return next.value = t, next.done = !0, next;
+          };
+        return i.next = i;
+      }
+    }
+    throw new TypeError(_typeof(e) + " is not iterable");
+  }
+  return GeneratorFunction.prototype = GeneratorFunctionPrototype, o(g, "constructor", {
+    value: GeneratorFunctionPrototype,
+    configurable: !0
+  }), o(GeneratorFunctionPrototype, "constructor", {
+    value: GeneratorFunction,
+    configurable: !0
+  }), GeneratorFunction.displayName = define(GeneratorFunctionPrototype, u, "GeneratorFunction"), e.isGeneratorFunction = function (t) {
+    var e = "function" == typeof t && t.constructor;
+    return !!e && (e === GeneratorFunction || "GeneratorFunction" === (e.displayName || e.name));
+  }, e.mark = function (t) {
+    return Object.setPrototypeOf ? Object.setPrototypeOf(t, GeneratorFunctionPrototype) : (t.__proto__ = GeneratorFunctionPrototype, define(t, u, "GeneratorFunction")), t.prototype = Object.create(g), t;
+  }, e.awrap = function (t) {
+    return {
+      __await: t
+    };
+  }, defineIteratorMethods(AsyncIterator.prototype), define(AsyncIterator.prototype, c, function () {
+    return this;
+  }), e.AsyncIterator = AsyncIterator, e.async = function (t, r, n, o, i) {
+    void 0 === i && (i = Promise);
+    var a = new AsyncIterator(wrap(t, r, n, o), i);
+    return e.isGeneratorFunction(r) ? a : a.next().then(function (t) {
+      return t.done ? t.value : a.next();
+    });
+  }, defineIteratorMethods(g), define(g, u, "Generator"), define(g, a, function () {
+    return this;
+  }), define(g, "toString", function () {
+    return "[object Generator]";
+  }), e.keys = function (t) {
+    var e = Object(t),
+      r = [];
+    for (var n in e) r.push(n);
+    return r.reverse(), function next() {
+      for (; r.length;) {
+        var t = r.pop();
+        if (t in e) return next.value = t, next.done = !1, next;
+      }
+      return next.done = !0, next;
+    };
+  }, e.values = values, Context.prototype = {
+    constructor: Context,
+    reset: function reset(e) {
+      if (this.prev = 0, this.next = 0, this.sent = this._sent = t, this.done = !1, this.delegate = null, this.method = "next", this.arg = t, this.tryEntries.forEach(resetTryEntry), !e) for (var r in this) "t" === r.charAt(0) && n.call(this, r) && !isNaN(+r.slice(1)) && (this[r] = t);
+    },
+    stop: function stop() {
+      this.done = !0;
+      var t = this.tryEntries[0].completion;
+      if ("throw" === t.type) throw t.arg;
+      return this.rval;
+    },
+    dispatchException: function dispatchException(e) {
+      if (this.done) throw e;
+      var r = this;
+      function handle(n, o) {
+        return a.type = "throw", a.arg = e, r.next = n, o && (r.method = "next", r.arg = t), !!o;
+      }
+      for (var o = this.tryEntries.length - 1; o >= 0; --o) {
+        var i = this.tryEntries[o],
+          a = i.completion;
+        if ("root" === i.tryLoc) return handle("end");
+        if (i.tryLoc <= this.prev) {
+          var c = n.call(i, "catchLoc"),
+            u = n.call(i, "finallyLoc");
+          if (c && u) {
+            if (this.prev < i.catchLoc) return handle(i.catchLoc, !0);
+            if (this.prev < i.finallyLoc) return handle(i.finallyLoc);
+          } else if (c) {
+            if (this.prev < i.catchLoc) return handle(i.catchLoc, !0);
+          } else {
+            if (!u) throw Error("try statement without catch or finally");
+            if (this.prev < i.finallyLoc) return handle(i.finallyLoc);
+          }
+        }
+      }
+    },
+    abrupt: function abrupt(t, e) {
+      for (var r = this.tryEntries.length - 1; r >= 0; --r) {
+        var o = this.tryEntries[r];
+        if (o.tryLoc <= this.prev && n.call(o, "finallyLoc") && this.prev < o.finallyLoc) {
+          var i = o;
+          break;
+        }
+      }
+      i && ("break" === t || "continue" === t) && i.tryLoc <= e && e <= i.finallyLoc && (i = null);
+      var a = i ? i.completion : {};
+      return a.type = t, a.arg = e, i ? (this.method = "next", this.next = i.finallyLoc, y) : this.complete(a);
+    },
+    complete: function complete(t, e) {
+      if ("throw" === t.type) throw t.arg;
+      return "break" === t.type || "continue" === t.type ? this.next = t.arg : "return" === t.type ? (this.rval = this.arg = t.arg, this.method = "return", this.next = "end") : "normal" === t.type && e && (this.next = e), y;
+    },
+    finish: function finish(t) {
+      for (var e = this.tryEntries.length - 1; e >= 0; --e) {
+        var r = this.tryEntries[e];
+        if (r.finallyLoc === t) return this.complete(r.completion, r.afterLoc), resetTryEntry(r), y;
+      }
+    },
+    "catch": function _catch(t) {
+      for (var e = this.tryEntries.length - 1; e >= 0; --e) {
+        var r = this.tryEntries[e];
+        if (r.tryLoc === t) {
+          var n = r.completion;
+          if ("throw" === n.type) {
+            var o = n.arg;
+            resetTryEntry(r);
+          }
+          return o;
+        }
+      }
+      throw Error("illegal catch attempt");
+    },
+    delegateYield: function delegateYield(e, r, n) {
+      return this.delegate = {
+        iterator: values(e),
+        resultName: r,
+        nextLoc: n
+      }, "next" === this.method && (this.arg = t), y;
+    }
+  }, e;
+}
+module.exports = _regeneratorRuntime, module.exports.__esModule = true, module.exports["default"] = module.exports;
+});
+
+// TODO(Babel 8): Remove this file.
+
+var runtime = regeneratorRuntime$1();
+var regenerator = runtime;
+
+// Copied from https://github.com/facebook/regenerator/blob/main/packages/runtime/runtime.js#L736=
+try {
+  regeneratorRuntime = runtime;
+} catch (accidentalStrictMode) {
+  if (typeof globalThis === "object") {
+    globalThis.regeneratorRuntime = runtime;
+  } else {
+    Function("r", "regeneratorRuntime = r")(runtime);
+  }
+}
+
+var colorName = {
+	"aliceblue": [240, 248, 255],
+	"antiquewhite": [250, 235, 215],
+	"aqua": [0, 255, 255],
+	"aquamarine": [127, 255, 212],
+	"azure": [240, 255, 255],
+	"beige": [245, 245, 220],
+	"bisque": [255, 228, 196],
+	"black": [0, 0, 0],
+	"blanchedalmond": [255, 235, 205],
+	"blue": [0, 0, 255],
+	"blueviolet": [138, 43, 226],
+	"brown": [165, 42, 42],
+	"burlywood": [222, 184, 135],
+	"cadetblue": [95, 158, 160],
+	"chartreuse": [127, 255, 0],
+	"chocolate": [210, 105, 30],
+	"coral": [255, 127, 80],
+	"cornflowerblue": [100, 149, 237],
+	"cornsilk": [255, 248, 220],
+	"crimson": [220, 20, 60],
+	"cyan": [0, 255, 255],
+	"darkblue": [0, 0, 139],
+	"darkcyan": [0, 139, 139],
+	"darkgoldenrod": [184, 134, 11],
+	"darkgray": [169, 169, 169],
+	"darkgreen": [0, 100, 0],
+	"darkgrey": [169, 169, 169],
+	"darkkhaki": [189, 183, 107],
+	"darkmagenta": [139, 0, 139],
+	"darkolivegreen": [85, 107, 47],
+	"darkorange": [255, 140, 0],
+	"darkorchid": [153, 50, 204],
+	"darkred": [139, 0, 0],
+	"darksalmon": [233, 150, 122],
+	"darkseagreen": [143, 188, 143],
+	"darkslateblue": [72, 61, 139],
+	"darkslategray": [47, 79, 79],
+	"darkslategrey": [47, 79, 79],
+	"darkturquoise": [0, 206, 209],
+	"darkviolet": [148, 0, 211],
+	"deeppink": [255, 20, 147],
+	"deepskyblue": [0, 191, 255],
+	"dimgray": [105, 105, 105],
+	"dimgrey": [105, 105, 105],
+	"dodgerblue": [30, 144, 255],
+	"firebrick": [178, 34, 34],
+	"floralwhite": [255, 250, 240],
+	"forestgreen": [34, 139, 34],
+	"fuchsia": [255, 0, 255],
+	"gainsboro": [220, 220, 220],
+	"ghostwhite": [248, 248, 255],
+	"gold": [255, 215, 0],
+	"goldenrod": [218, 165, 32],
+	"gray": [128, 128, 128],
+	"green": [0, 128, 0],
+	"greenyellow": [173, 255, 47],
+	"grey": [128, 128, 128],
+	"honeydew": [240, 255, 240],
+	"hotpink": [255, 105, 180],
+	"indianred": [205, 92, 92],
+	"indigo": [75, 0, 130],
+	"ivory": [255, 255, 240],
+	"khaki": [240, 230, 140],
+	"lavender": [230, 230, 250],
+	"lavenderblush": [255, 240, 245],
+	"lawngreen": [124, 252, 0],
+	"lemonchiffon": [255, 250, 205],
+	"lightblue": [173, 216, 230],
+	"lightcoral": [240, 128, 128],
+	"lightcyan": [224, 255, 255],
+	"lightgoldenrodyellow": [250, 250, 210],
+	"lightgray": [211, 211, 211],
+	"lightgreen": [144, 238, 144],
+	"lightgrey": [211, 211, 211],
+	"lightpink": [255, 182, 193],
+	"lightsalmon": [255, 160, 122],
+	"lightseagreen": [32, 178, 170],
+	"lightskyblue": [135, 206, 250],
+	"lightslategray": [119, 136, 153],
+	"lightslategrey": [119, 136, 153],
+	"lightsteelblue": [176, 196, 222],
+	"lightyellow": [255, 255, 224],
+	"lime": [0, 255, 0],
+	"limegreen": [50, 205, 50],
+	"linen": [250, 240, 230],
+	"magenta": [255, 0, 255],
+	"maroon": [128, 0, 0],
+	"mediumaquamarine": [102, 205, 170],
+	"mediumblue": [0, 0, 205],
+	"mediumorchid": [186, 85, 211],
+	"mediumpurple": [147, 112, 219],
+	"mediumseagreen": [60, 179, 113],
+	"mediumslateblue": [123, 104, 238],
+	"mediumspringgreen": [0, 250, 154],
+	"mediumturquoise": [72, 209, 204],
+	"mediumvioletred": [199, 21, 133],
+	"midnightblue": [25, 25, 112],
+	"mintcream": [245, 255, 250],
+	"mistyrose": [255, 228, 225],
+	"moccasin": [255, 228, 181],
+	"navajowhite": [255, 222, 173],
+	"navy": [0, 0, 128],
+	"oldlace": [253, 245, 230],
+	"olive": [128, 128, 0],
+	"olivedrab": [107, 142, 35],
+	"orange": [255, 165, 0],
+	"orangered": [255, 69, 0],
+	"orchid": [218, 112, 214],
+	"palegoldenrod": [238, 232, 170],
+	"palegreen": [152, 251, 152],
+	"paleturquoise": [175, 238, 238],
+	"palevioletred": [219, 112, 147],
+	"papayawhip": [255, 239, 213],
+	"peachpuff": [255, 218, 185],
+	"peru": [205, 133, 63],
+	"pink": [255, 192, 203],
+	"plum": [221, 160, 221],
+	"powderblue": [176, 224, 230],
+	"purple": [128, 0, 128],
+	"rebeccapurple": [102, 51, 153],
+	"red": [255, 0, 0],
+	"rosybrown": [188, 143, 143],
+	"royalblue": [65, 105, 225],
+	"saddlebrown": [139, 69, 19],
+	"salmon": [250, 128, 114],
+	"sandybrown": [244, 164, 96],
+	"seagreen": [46, 139, 87],
+	"seashell": [255, 245, 238],
+	"sienna": [160, 82, 45],
+	"silver": [192, 192, 192],
+	"skyblue": [135, 206, 235],
+	"slateblue": [106, 90, 205],
+	"slategray": [112, 128, 144],
+	"slategrey": [112, 128, 144],
+	"snow": [255, 250, 250],
+	"springgreen": [0, 255, 127],
+	"steelblue": [70, 130, 180],
+	"tan": [210, 180, 140],
+	"teal": [0, 128, 128],
+	"thistle": [216, 191, 216],
+	"tomato": [255, 99, 71],
+	"turquoise": [64, 224, 208],
+	"violet": [238, 130, 238],
+	"wheat": [245, 222, 179],
+	"white": [255, 255, 255],
+	"whitesmoke": [245, 245, 245],
+	"yellow": [255, 255, 0],
+	"yellowgreen": [154, 205, 50]
+};
+
+/* MIT license */
+
+/* eslint-disable no-mixed-operators */
+
+
+// NOTE: conversions should only return primitive values (i.e. arrays, or
+//       values that give correct `typeof` results).
+//       do not use box values types (i.e. Number(), String(), etc.)
+
+const reverseKeywords = {};
+for (const key of Object.keys(colorName)) {
+	reverseKeywords[colorName[key]] = key;
+}
+
+const convert$1 = {
+	rgb: {channels: 3, labels: 'rgb'},
+	hsl: {channels: 3, labels: 'hsl'},
+	hsv: {channels: 3, labels: 'hsv'},
+	hwb: {channels: 3, labels: 'hwb'},
+	cmyk: {channels: 4, labels: 'cmyk'},
+	xyz: {channels: 3, labels: 'xyz'},
+	lab: {channels: 3, labels: 'lab'},
+	lch: {channels: 3, labels: 'lch'},
+	hex: {channels: 1, labels: ['hex']},
+	keyword: {channels: 1, labels: ['keyword']},
+	ansi16: {channels: 1, labels: ['ansi16']},
+	ansi256: {channels: 1, labels: ['ansi256']},
+	hcg: {channels: 3, labels: ['h', 'c', 'g']},
+	apple: {channels: 3, labels: ['r16', 'g16', 'b16']},
+	gray: {channels: 1, labels: ['gray']}
+};
+
+var conversions = convert$1;
+
+// Hide .channels and .labels properties
+for (const model of Object.keys(convert$1)) {
+	if (!('channels' in convert$1[model])) {
+		throw new Error('missing channels property: ' + model);
+	}
+
+	if (!('labels' in convert$1[model])) {
+		throw new Error('missing channel labels property: ' + model);
+	}
+
+	if (convert$1[model].labels.length !== convert$1[model].channels) {
+		throw new Error('channel and label counts mismatch: ' + model);
+	}
+
+	const {channels, labels} = convert$1[model];
+	delete convert$1[model].channels;
+	delete convert$1[model].labels;
+	Object.defineProperty(convert$1[model], 'channels', {value: channels});
+	Object.defineProperty(convert$1[model], 'labels', {value: labels});
+}
+
+convert$1.rgb.hsl = function (rgb) {
+	const r = rgb[0] / 255;
+	const g = rgb[1] / 255;
+	const b = rgb[2] / 255;
+	const min = Math.min(r, g, b);
+	const max = Math.max(r, g, b);
+	const delta = max - min;
+	let h;
+	let s;
+
+	if (max === min) {
+		h = 0;
+	} else if (r === max) {
+		h = (g - b) / delta;
+	} else if (g === max) {
+		h = 2 + (b - r) / delta;
+	} else if (b === max) {
+		h = 4 + (r - g) / delta;
+	}
+
+	h = Math.min(h * 60, 360);
+
+	if (h < 0) {
+		h += 360;
+	}
+
+	const l = (min + max) / 2;
+
+	if (max === min) {
+		s = 0;
+	} else if (l <= 0.5) {
+		s = delta / (max + min);
+	} else {
+		s = delta / (2 - max - min);
+	}
+
+	return [h, s * 100, l * 100];
+};
+
+convert$1.rgb.hsv = function (rgb) {
+	let rdif;
+	let gdif;
+	let bdif;
+	let h;
+	let s;
+
+	const r = rgb[0] / 255;
+	const g = rgb[1] / 255;
+	const b = rgb[2] / 255;
+	const v = Math.max(r, g, b);
+	const diff = v - Math.min(r, g, b);
+	const diffc = function (c) {
+		return (v - c) / 6 / diff + 1 / 2;
+	};
+
+	if (diff === 0) {
+		h = 0;
+		s = 0;
+	} else {
+		s = diff / v;
+		rdif = diffc(r);
+		gdif = diffc(g);
+		bdif = diffc(b);
+
+		if (r === v) {
+			h = bdif - gdif;
+		} else if (g === v) {
+			h = (1 / 3) + rdif - bdif;
+		} else if (b === v) {
+			h = (2 / 3) + gdif - rdif;
+		}
+
+		if (h < 0) {
+			h += 1;
+		} else if (h > 1) {
+			h -= 1;
+		}
+	}
+
+	return [
+		h * 360,
+		s * 100,
+		v * 100
+	];
+};
+
+convert$1.rgb.hwb = function (rgb) {
+	const r = rgb[0];
+	const g = rgb[1];
+	let b = rgb[2];
+	const h = convert$1.rgb.hsl(rgb)[0];
+	const w = 1 / 255 * Math.min(r, Math.min(g, b));
+
+	b = 1 - 1 / 255 * Math.max(r, Math.max(g, b));
+
+	return [h, w * 100, b * 100];
+};
+
+convert$1.rgb.cmyk = function (rgb) {
+	const r = rgb[0] / 255;
+	const g = rgb[1] / 255;
+	const b = rgb[2] / 255;
+
+	const k = Math.min(1 - r, 1 - g, 1 - b);
+	const c = (1 - r - k) / (1 - k) || 0;
+	const m = (1 - g - k) / (1 - k) || 0;
+	const y = (1 - b - k) / (1 - k) || 0;
+
+	return [c * 100, m * 100, y * 100, k * 100];
+};
+
+function comparativeDistance(x, y) {
+	/*
+		See https://en.m.wikipedia.org/wiki/Euclidean_distance#Squared_Euclidean_distance
+	*/
+	return (
+		((x[0] - y[0]) ** 2) +
+		((x[1] - y[1]) ** 2) +
+		((x[2] - y[2]) ** 2)
+	);
+}
+
+convert$1.rgb.keyword = function (rgb) {
+	const reversed = reverseKeywords[rgb];
+	if (reversed) {
+		return reversed;
+	}
+
+	let currentClosestDistance = Infinity;
+	let currentClosestKeyword;
+
+	for (const keyword of Object.keys(colorName)) {
+		const value = colorName[keyword];
+
+		// Compute comparative distance
+		const distance = comparativeDistance(rgb, value);
+
+		// Check if its less, if so set as closest
+		if (distance < currentClosestDistance) {
+			currentClosestDistance = distance;
+			currentClosestKeyword = keyword;
+		}
+	}
+
+	return currentClosestKeyword;
+};
+
+convert$1.keyword.rgb = function (keyword) {
+	return colorName[keyword];
+};
+
+convert$1.rgb.xyz = function (rgb) {
+	let r = rgb[0] / 255;
+	let g = rgb[1] / 255;
+	let b = rgb[2] / 255;
+
+	// Assume sRGB
+	r = r > 0.04045 ? (((r + 0.055) / 1.055) ** 2.4) : (r / 12.92);
+	g = g > 0.04045 ? (((g + 0.055) / 1.055) ** 2.4) : (g / 12.92);
+	b = b > 0.04045 ? (((b + 0.055) / 1.055) ** 2.4) : (b / 12.92);
+
+	const x = (r * 0.4124) + (g * 0.3576) + (b * 0.1805);
+	const y = (r * 0.2126) + (g * 0.7152) + (b * 0.0722);
+	const z = (r * 0.0193) + (g * 0.1192) + (b * 0.9505);
+
+	return [x * 100, y * 100, z * 100];
+};
+
+convert$1.rgb.lab = function (rgb) {
+	const xyz = convert$1.rgb.xyz(rgb);
+	let x = xyz[0];
+	let y = xyz[1];
+	let z = xyz[2];
+
+	x /= 95.047;
+	y /= 100;
+	z /= 108.883;
+
+	x = x > 0.008856 ? (x ** (1 / 3)) : (7.787 * x) + (16 / 116);
+	y = y > 0.008856 ? (y ** (1 / 3)) : (7.787 * y) + (16 / 116);
+	z = z > 0.008856 ? (z ** (1 / 3)) : (7.787 * z) + (16 / 116);
+
+	const l = (116 * y) - 16;
+	const a = 500 * (x - y);
+	const b = 200 * (y - z);
+
+	return [l, a, b];
+};
+
+convert$1.hsl.rgb = function (hsl) {
+	const h = hsl[0] / 360;
+	const s = hsl[1] / 100;
+	const l = hsl[2] / 100;
+	let t2;
+	let t3;
+	let val;
+
+	if (s === 0) {
+		val = l * 255;
+		return [val, val, val];
+	}
+
+	if (l < 0.5) {
+		t2 = l * (1 + s);
+	} else {
+		t2 = l + s - l * s;
+	}
+
+	const t1 = 2 * l - t2;
+
+	const rgb = [0, 0, 0];
+	for (let i = 0; i < 3; i++) {
+		t3 = h + 1 / 3 * -(i - 1);
+		if (t3 < 0) {
+			t3++;
+		}
+
+		if (t3 > 1) {
+			t3--;
+		}
+
+		if (6 * t3 < 1) {
+			val = t1 + (t2 - t1) * 6 * t3;
+		} else if (2 * t3 < 1) {
+			val = t2;
+		} else if (3 * t3 < 2) {
+			val = t1 + (t2 - t1) * (2 / 3 - t3) * 6;
+		} else {
+			val = t1;
+		}
+
+		rgb[i] = val * 255;
+	}
+
+	return rgb;
+};
+
+convert$1.hsl.hsv = function (hsl) {
+	const h = hsl[0];
+	let s = hsl[1] / 100;
+	let l = hsl[2] / 100;
+	let smin = s;
+	const lmin = Math.max(l, 0.01);
+
+	l *= 2;
+	s *= (l <= 1) ? l : 2 - l;
+	smin *= lmin <= 1 ? lmin : 2 - lmin;
+	const v = (l + s) / 2;
+	const sv = l === 0 ? (2 * smin) / (lmin + smin) : (2 * s) / (l + s);
+
+	return [h, sv * 100, v * 100];
+};
+
+convert$1.hsv.rgb = function (hsv) {
+	const h = hsv[0] / 60;
+	const s = hsv[1] / 100;
+	let v = hsv[2] / 100;
+	const hi = Math.floor(h) % 6;
+
+	const f = h - Math.floor(h);
+	const p = 255 * v * (1 - s);
+	const q = 255 * v * (1 - (s * f));
+	const t = 255 * v * (1 - (s * (1 - f)));
+	v *= 255;
+
+	switch (hi) {
+		case 0:
+			return [v, t, p];
+		case 1:
+			return [q, v, p];
+		case 2:
+			return [p, v, t];
+		case 3:
+			return [p, q, v];
+		case 4:
+			return [t, p, v];
+		case 5:
+			return [v, p, q];
+	}
+};
+
+convert$1.hsv.hsl = function (hsv) {
+	const h = hsv[0];
+	const s = hsv[1] / 100;
+	const v = hsv[2] / 100;
+	const vmin = Math.max(v, 0.01);
+	let sl;
+	let l;
+
+	l = (2 - s) * v;
+	const lmin = (2 - s) * vmin;
+	sl = s * vmin;
+	sl /= (lmin <= 1) ? lmin : 2 - lmin;
+	sl = sl || 0;
+	l /= 2;
+
+	return [h, sl * 100, l * 100];
+};
+
+// http://dev.w3.org/csswg/css-color/#hwb-to-rgb
+convert$1.hwb.rgb = function (hwb) {
+	const h = hwb[0] / 360;
+	let wh = hwb[1] / 100;
+	let bl = hwb[2] / 100;
+	const ratio = wh + bl;
+	let f;
+
+	// Wh + bl cant be > 1
+	if (ratio > 1) {
+		wh /= ratio;
+		bl /= ratio;
+	}
+
+	const i = Math.floor(6 * h);
+	const v = 1 - bl;
+	f = 6 * h - i;
+
+	if ((i & 0x01) !== 0) {
+		f = 1 - f;
+	}
+
+	const n = wh + f * (v - wh); // Linear interpolation
+
+	let r;
+	let g;
+	let b;
+	/* eslint-disable max-statements-per-line,no-multi-spaces */
+	switch (i) {
+		default:
+		case 6:
+		case 0: r = v;  g = n;  b = wh; break;
+		case 1: r = n;  g = v;  b = wh; break;
+		case 2: r = wh; g = v;  b = n; break;
+		case 3: r = wh; g = n;  b = v; break;
+		case 4: r = n;  g = wh; b = v; break;
+		case 5: r = v;  g = wh; b = n; break;
+	}
+	/* eslint-enable max-statements-per-line,no-multi-spaces */
+
+	return [r * 255, g * 255, b * 255];
+};
+
+convert$1.cmyk.rgb = function (cmyk) {
+	const c = cmyk[0] / 100;
+	const m = cmyk[1] / 100;
+	const y = cmyk[2] / 100;
+	const k = cmyk[3] / 100;
+
+	const r = 1 - Math.min(1, c * (1 - k) + k);
+	const g = 1 - Math.min(1, m * (1 - k) + k);
+	const b = 1 - Math.min(1, y * (1 - k) + k);
+
+	return [r * 255, g * 255, b * 255];
+};
+
+convert$1.xyz.rgb = function (xyz) {
+	const x = xyz[0] / 100;
+	const y = xyz[1] / 100;
+	const z = xyz[2] / 100;
+	let r;
+	let g;
+	let b;
+
+	r = (x * 3.2406) + (y * -1.5372) + (z * -0.4986);
+	g = (x * -0.9689) + (y * 1.8758) + (z * 0.0415);
+	b = (x * 0.0557) + (y * -0.2040) + (z * 1.0570);
+
+	// Assume sRGB
+	r = r > 0.0031308
+		? ((1.055 * (r ** (1.0 / 2.4))) - 0.055)
+		: r * 12.92;
+
+	g = g > 0.0031308
+		? ((1.055 * (g ** (1.0 / 2.4))) - 0.055)
+		: g * 12.92;
+
+	b = b > 0.0031308
+		? ((1.055 * (b ** (1.0 / 2.4))) - 0.055)
+		: b * 12.92;
+
+	r = Math.min(Math.max(0, r), 1);
+	g = Math.min(Math.max(0, g), 1);
+	b = Math.min(Math.max(0, b), 1);
+
+	return [r * 255, g * 255, b * 255];
+};
+
+convert$1.xyz.lab = function (xyz) {
+	let x = xyz[0];
+	let y = xyz[1];
+	let z = xyz[2];
+
+	x /= 95.047;
+	y /= 100;
+	z /= 108.883;
+
+	x = x > 0.008856 ? (x ** (1 / 3)) : (7.787 * x) + (16 / 116);
+	y = y > 0.008856 ? (y ** (1 / 3)) : (7.787 * y) + (16 / 116);
+	z = z > 0.008856 ? (z ** (1 / 3)) : (7.787 * z) + (16 / 116);
+
+	const l = (116 * y) - 16;
+	const a = 500 * (x - y);
+	const b = 200 * (y - z);
+
+	return [l, a, b];
+};
+
+convert$1.lab.xyz = function (lab) {
+	const l = lab[0];
+	const a = lab[1];
+	const b = lab[2];
+	let x;
+	let y;
+	let z;
+
+	y = (l + 16) / 116;
+	x = a / 500 + y;
+	z = y - b / 200;
+
+	const y2 = y ** 3;
+	const x2 = x ** 3;
+	const z2 = z ** 3;
+	y = y2 > 0.008856 ? y2 : (y - 16 / 116) / 7.787;
+	x = x2 > 0.008856 ? x2 : (x - 16 / 116) / 7.787;
+	z = z2 > 0.008856 ? z2 : (z - 16 / 116) / 7.787;
+
+	x *= 95.047;
+	y *= 100;
+	z *= 108.883;
+
+	return [x, y, z];
+};
+
+convert$1.lab.lch = function (lab) {
+	const l = lab[0];
+	const a = lab[1];
+	const b = lab[2];
+	let h;
+
+	const hr = Math.atan2(b, a);
+	h = hr * 360 / 2 / Math.PI;
+
+	if (h < 0) {
+		h += 360;
+	}
+
+	const c = Math.sqrt(a * a + b * b);
+
+	return [l, c, h];
+};
+
+convert$1.lch.lab = function (lch) {
+	const l = lch[0];
+	const c = lch[1];
+	const h = lch[2];
+
+	const hr = h / 360 * 2 * Math.PI;
+	const a = c * Math.cos(hr);
+	const b = c * Math.sin(hr);
+
+	return [l, a, b];
+};
+
+convert$1.rgb.ansi16 = function (args, saturation = null) {
+	const [r, g, b] = args;
+	let value = saturation === null ? convert$1.rgb.hsv(args)[2] : saturation; // Hsv -> ansi16 optimization
+
+	value = Math.round(value / 50);
+
+	if (value === 0) {
+		return 30;
+	}
+
+	let ansi = 30
+		+ ((Math.round(b / 255) << 2)
+		| (Math.round(g / 255) << 1)
+		| Math.round(r / 255));
+
+	if (value === 2) {
+		ansi += 60;
+	}
+
+	return ansi;
+};
+
+convert$1.hsv.ansi16 = function (args) {
+	// Optimization here; we already know the value and don't need to get
+	// it converted for us.
+	return convert$1.rgb.ansi16(convert$1.hsv.rgb(args), args[2]);
+};
+
+convert$1.rgb.ansi256 = function (args) {
+	const r = args[0];
+	const g = args[1];
+	const b = args[2];
+
+	// We use the extended greyscale palette here, with the exception of
+	// black and white. normal palette only has 4 greyscale shades.
+	if (r === g && g === b) {
+		if (r < 8) {
+			return 16;
+		}
+
+		if (r > 248) {
+			return 231;
+		}
+
+		return Math.round(((r - 8) / 247) * 24) + 232;
+	}
+
+	const ansi = 16
+		+ (36 * Math.round(r / 255 * 5))
+		+ (6 * Math.round(g / 255 * 5))
+		+ Math.round(b / 255 * 5);
+
+	return ansi;
+};
+
+convert$1.ansi16.rgb = function (args) {
+	let color = args % 10;
+
+	// Handle greyscale
+	if (color === 0 || color === 7) {
+		if (args > 50) {
+			color += 3.5;
+		}
+
+		color = color / 10.5 * 255;
+
+		return [color, color, color];
+	}
+
+	const mult = (~~(args > 50) + 1) * 0.5;
+	const r = ((color & 1) * mult) * 255;
+	const g = (((color >> 1) & 1) * mult) * 255;
+	const b = (((color >> 2) & 1) * mult) * 255;
+
+	return [r, g, b];
+};
+
+convert$1.ansi256.rgb = function (args) {
+	// Handle greyscale
+	if (args >= 232) {
+		const c = (args - 232) * 10 + 8;
+		return [c, c, c];
+	}
+
+	args -= 16;
+
+	let rem;
+	const r = Math.floor(args / 36) / 5 * 255;
+	const g = Math.floor((rem = args % 36) / 6) / 5 * 255;
+	const b = (rem % 6) / 5 * 255;
+
+	return [r, g, b];
+};
+
+convert$1.rgb.hex = function (args) {
+	const integer = ((Math.round(args[0]) & 0xFF) << 16)
+		+ ((Math.round(args[1]) & 0xFF) << 8)
+		+ (Math.round(args[2]) & 0xFF);
+
+	const string = integer.toString(16).toUpperCase();
+	return '000000'.substring(string.length) + string;
+};
+
+convert$1.hex.rgb = function (args) {
+	const match = args.toString(16).match(/[a-f0-9]{6}|[a-f0-9]{3}/i);
+	if (!match) {
+		return [0, 0, 0];
+	}
+
+	let colorString = match[0];
+
+	if (match[0].length === 3) {
+		colorString = colorString.split('').map(char => {
+			return char + char;
+		}).join('');
+	}
+
+	const integer = parseInt(colorString, 16);
+	const r = (integer >> 16) & 0xFF;
+	const g = (integer >> 8) & 0xFF;
+	const b = integer & 0xFF;
+
+	return [r, g, b];
+};
+
+convert$1.rgb.hcg = function (rgb) {
+	const r = rgb[0] / 255;
+	const g = rgb[1] / 255;
+	const b = rgb[2] / 255;
+	const max = Math.max(Math.max(r, g), b);
+	const min = Math.min(Math.min(r, g), b);
+	const chroma = (max - min);
+	let grayscale;
+	let hue;
+
+	if (chroma < 1) {
+		grayscale = min / (1 - chroma);
+	} else {
+		grayscale = 0;
+	}
+
+	if (chroma <= 0) {
+		hue = 0;
+	} else
+	if (max === r) {
+		hue = ((g - b) / chroma) % 6;
+	} else
+	if (max === g) {
+		hue = 2 + (b - r) / chroma;
+	} else {
+		hue = 4 + (r - g) / chroma;
+	}
+
+	hue /= 6;
+	hue %= 1;
+
+	return [hue * 360, chroma * 100, grayscale * 100];
+};
+
+convert$1.hsl.hcg = function (hsl) {
+	const s = hsl[1] / 100;
+	const l = hsl[2] / 100;
+
+	const c = l < 0.5 ? (2.0 * s * l) : (2.0 * s * (1.0 - l));
+
+	let f = 0;
+	if (c < 1.0) {
+		f = (l - 0.5 * c) / (1.0 - c);
+	}
+
+	return [hsl[0], c * 100, f * 100];
+};
+
+convert$1.hsv.hcg = function (hsv) {
+	const s = hsv[1] / 100;
+	const v = hsv[2] / 100;
+
+	const c = s * v;
+	let f = 0;
+
+	if (c < 1.0) {
+		f = (v - c) / (1 - c);
+	}
+
+	return [hsv[0], c * 100, f * 100];
+};
+
+convert$1.hcg.rgb = function (hcg) {
+	const h = hcg[0] / 360;
+	const c = hcg[1] / 100;
+	const g = hcg[2] / 100;
+
+	if (c === 0.0) {
+		return [g * 255, g * 255, g * 255];
+	}
+
+	const pure = [0, 0, 0];
+	const hi = (h % 1) * 6;
+	const v = hi % 1;
+	const w = 1 - v;
+	let mg = 0;
+
+	/* eslint-disable max-statements-per-line */
+	switch (Math.floor(hi)) {
+		case 0:
+			pure[0] = 1; pure[1] = v; pure[2] = 0; break;
+		case 1:
+			pure[0] = w; pure[1] = 1; pure[2] = 0; break;
+		case 2:
+			pure[0] = 0; pure[1] = 1; pure[2] = v; break;
+		case 3:
+			pure[0] = 0; pure[1] = w; pure[2] = 1; break;
+		case 4:
+			pure[0] = v; pure[1] = 0; pure[2] = 1; break;
+		default:
+			pure[0] = 1; pure[1] = 0; pure[2] = w;
+	}
+	/* eslint-enable max-statements-per-line */
+
+	mg = (1.0 - c) * g;
+
+	return [
+		(c * pure[0] + mg) * 255,
+		(c * pure[1] + mg) * 255,
+		(c * pure[2] + mg) * 255
+	];
+};
+
+convert$1.hcg.hsv = function (hcg) {
+	const c = hcg[1] / 100;
+	const g = hcg[2] / 100;
+
+	const v = c + g * (1.0 - c);
+	let f = 0;
+
+	if (v > 0.0) {
+		f = c / v;
+	}
+
+	return [hcg[0], f * 100, v * 100];
+};
+
+convert$1.hcg.hsl = function (hcg) {
+	const c = hcg[1] / 100;
+	const g = hcg[2] / 100;
+
+	const l = g * (1.0 - c) + 0.5 * c;
+	let s = 0;
+
+	if (l > 0.0 && l < 0.5) {
+		s = c / (2 * l);
+	} else
+	if (l >= 0.5 && l < 1.0) {
+		s = c / (2 * (1 - l));
+	}
+
+	return [hcg[0], s * 100, l * 100];
+};
+
+convert$1.hcg.hwb = function (hcg) {
+	const c = hcg[1] / 100;
+	const g = hcg[2] / 100;
+	const v = c + g * (1.0 - c);
+	return [hcg[0], (v - c) * 100, (1 - v) * 100];
+};
+
+convert$1.hwb.hcg = function (hwb) {
+	const w = hwb[1] / 100;
+	const b = hwb[2] / 100;
+	const v = 1 - b;
+	const c = v - w;
+	let g = 0;
+
+	if (c < 1) {
+		g = (v - c) / (1 - c);
+	}
+
+	return [hwb[0], c * 100, g * 100];
+};
+
+convert$1.apple.rgb = function (apple) {
+	return [(apple[0] / 65535) * 255, (apple[1] / 65535) * 255, (apple[2] / 65535) * 255];
+};
+
+convert$1.rgb.apple = function (rgb) {
+	return [(rgb[0] / 255) * 65535, (rgb[1] / 255) * 65535, (rgb[2] / 255) * 65535];
+};
+
+convert$1.gray.rgb = function (args) {
+	return [args[0] / 100 * 255, args[0] / 100 * 255, args[0] / 100 * 255];
+};
+
+convert$1.gray.hsl = function (args) {
+	return [0, 0, args[0]];
+};
+
+convert$1.gray.hsv = convert$1.gray.hsl;
+
+convert$1.gray.hwb = function (gray) {
+	return [0, 100, gray[0]];
+};
+
+convert$1.gray.cmyk = function (gray) {
+	return [0, 0, 0, gray[0]];
+};
+
+convert$1.gray.lab = function (gray) {
+	return [gray[0], 0, 0];
+};
+
+convert$1.gray.hex = function (gray) {
+	const val = Math.round(gray[0] / 100 * 255) & 0xFF;
+	const integer = (val << 16) + (val << 8) + val;
+
+	const string = integer.toString(16).toUpperCase();
+	return '000000'.substring(string.length) + string;
+};
+
+convert$1.rgb.gray = function (rgb) {
+	const val = (rgb[0] + rgb[1] + rgb[2]) / 3;
+	return [val / 255 * 100];
+};
+
+/*
+	This function routes a model to all other models.
+
+	all functions that are routed have a property `.conversion` attached
+	to the returned synthetic function. This property is an array
+	of strings, each with the steps in between the 'from' and 'to'
+	color models (inclusive).
+
+	conversions that are not possible simply are not included.
+*/
+
+function buildGraph() {
+	const graph = {};
+	// https://jsperf.com/object-keys-vs-for-in-with-closure/3
+	const models = Object.keys(conversions);
+
+	for (let len = models.length, i = 0; i < len; i++) {
+		graph[models[i]] = {
+			// http://jsperf.com/1-vs-infinity
+			// micro-opt, but this is simple.
+			distance: -1,
+			parent: null
+		};
+	}
+
+	return graph;
+}
+
+// https://en.wikipedia.org/wiki/Breadth-first_search
+function deriveBFS(fromModel) {
+	const graph = buildGraph();
+	const queue = [fromModel]; // Unshift -> queue -> pop
+
+	graph[fromModel].distance = 0;
+
+	while (queue.length) {
+		const current = queue.pop();
+		const adjacents = Object.keys(conversions[current]);
+
+		for (let len = adjacents.length, i = 0; i < len; i++) {
+			const adjacent = adjacents[i];
+			const node = graph[adjacent];
+
+			if (node.distance === -1) {
+				node.distance = graph[current].distance + 1;
+				node.parent = current;
+				queue.unshift(adjacent);
+			}
+		}
+	}
+
+	return graph;
+}
+
+function link(from, to) {
+	return function (args) {
+		return to(from(args));
+	};
+}
+
+function wrapConversion(toModel, graph) {
+	const path = [graph[toModel].parent, toModel];
+	let fn = conversions[graph[toModel].parent][toModel];
+
+	let cur = graph[toModel].parent;
+	while (graph[cur].parent) {
+		path.unshift(graph[cur].parent);
+		fn = link(conversions[graph[cur].parent][cur], fn);
+		cur = graph[cur].parent;
+	}
+
+	fn.conversion = path;
+	return fn;
+}
+
+var route = function (fromModel) {
+	const graph = deriveBFS(fromModel);
+	const conversion = {};
+
+	const models = Object.keys(graph);
+	for (let len = models.length, i = 0; i < len; i++) {
+		const toModel = models[i];
+		const node = graph[toModel];
+
+		if (node.parent === null) {
+			// No possible conversion, or this node is the source model.
+			continue;
+		}
+
+		conversion[toModel] = wrapConversion(toModel, graph);
+	}
+
+	return conversion;
+};
+
+const convert = {};
+
+const models = Object.keys(conversions);
+
+function wrapRaw(fn) {
+	const wrappedFn = function (...args) {
+		const arg0 = args[0];
+		if (arg0 === undefined || arg0 === null) {
+			return arg0;
+		}
+
+		if (arg0.length > 1) {
+			args = arg0;
+		}
+
+		return fn(args);
+	};
+
+	// Preserve .conversion property if there is one
+	if ('conversion' in fn) {
+		wrappedFn.conversion = fn.conversion;
+	}
+
+	return wrappedFn;
+}
+
+function wrapRounded(fn) {
+	const wrappedFn = function (...args) {
+		const arg0 = args[0];
+
+		if (arg0 === undefined || arg0 === null) {
+			return arg0;
+		}
+
+		if (arg0.length > 1) {
+			args = arg0;
+		}
+
+		const result = fn(args);
+
+		// We're assuming the result is an array here.
+		// see notice in conversions.js; don't use box types
+		// in conversion functions.
+		if (typeof result === 'object') {
+			for (let len = result.length, i = 0; i < len; i++) {
+				result[i] = Math.round(result[i]);
+			}
+		}
+
+		return result;
+	};
+
+	// Preserve .conversion property if there is one
+	if ('conversion' in fn) {
+		wrappedFn.conversion = fn.conversion;
+	}
+
+	return wrappedFn;
+}
+
+models.forEach(fromModel => {
+	convert[fromModel] = {};
+
+	Object.defineProperty(convert[fromModel], 'channels', {value: conversions[fromModel].channels});
+	Object.defineProperty(convert[fromModel], 'labels', {value: conversions[fromModel].labels});
+
+	const routes = route(fromModel);
+	const routeModels = Object.keys(routes);
+
+	routeModels.forEach(toModel => {
+		const fn = routes[toModel];
+
+		convert[fromModel][toModel] = wrapRounded(fn);
+		convert[fromModel][toModel].raw = wrapRaw(fn);
+	});
+});
+
+var colorConvert = convert;
+
+var ansiStyles = createCommonjsModule(function (module) {
+
+const wrapAnsi16 = (fn, offset) => (...args) => {
+	const code = fn(...args);
+	return `\u001B[${code + offset}m`;
+};
+
+const wrapAnsi256 = (fn, offset) => (...args) => {
+	const code = fn(...args);
+	return `\u001B[${38 + offset};5;${code}m`;
+};
+
+const wrapAnsi16m = (fn, offset) => (...args) => {
+	const rgb = fn(...args);
+	return `\u001B[${38 + offset};2;${rgb[0]};${rgb[1]};${rgb[2]}m`;
+};
+
+const ansi2ansi = n => n;
+const rgb2rgb = (r, g, b) => [r, g, b];
+
+const setLazyProperty = (object, property, get) => {
+	Object.defineProperty(object, property, {
+		get: () => {
+			const value = get();
+
+			Object.defineProperty(object, property, {
+				value,
+				enumerable: true,
+				configurable: true
+			});
+
+			return value;
+		},
+		enumerable: true,
+		configurable: true
+	});
+};
+
+/** @type {typeof import('color-convert')} */
+let colorConvert$1;
+const makeDynamicStyles = (wrap, targetSpace, identity, isBackground) => {
+	if (colorConvert$1 === undefined) {
+		colorConvert$1 = colorConvert;
+	}
+
+	const offset = isBackground ? 10 : 0;
+	const styles = {};
+
+	for (const [sourceSpace, suite] of Object.entries(colorConvert$1)) {
+		const name = sourceSpace === 'ansi16' ? 'ansi' : sourceSpace;
+		if (sourceSpace === targetSpace) {
+			styles[name] = wrap(identity, offset);
+		} else if (typeof suite === 'object') {
+			styles[name] = wrap(suite[targetSpace], offset);
+		}
+	}
+
+	return styles;
+};
+
+function assembleStyles() {
+	const codes = new Map();
+	const styles = {
+		modifier: {
+			reset: [0, 0],
+			// 21 isn't widely supported and 22 does the same thing
+			bold: [1, 22],
+			dim: [2, 22],
+			italic: [3, 23],
+			underline: [4, 24],
+			inverse: [7, 27],
+			hidden: [8, 28],
+			strikethrough: [9, 29]
+		},
+		color: {
+			black: [30, 39],
+			red: [31, 39],
+			green: [32, 39],
+			yellow: [33, 39],
+			blue: [34, 39],
+			magenta: [35, 39],
+			cyan: [36, 39],
+			white: [37, 39],
+
+			// Bright color
+			blackBright: [90, 39],
+			redBright: [91, 39],
+			greenBright: [92, 39],
+			yellowBright: [93, 39],
+			blueBright: [94, 39],
+			magentaBright: [95, 39],
+			cyanBright: [96, 39],
+			whiteBright: [97, 39]
+		},
+		bgColor: {
+			bgBlack: [40, 49],
+			bgRed: [41, 49],
+			bgGreen: [42, 49],
+			bgYellow: [43, 49],
+			bgBlue: [44, 49],
+			bgMagenta: [45, 49],
+			bgCyan: [46, 49],
+			bgWhite: [47, 49],
+
+			// Bright color
+			bgBlackBright: [100, 49],
+			bgRedBright: [101, 49],
+			bgGreenBright: [102, 49],
+			bgYellowBright: [103, 49],
+			bgBlueBright: [104, 49],
+			bgMagentaBright: [105, 49],
+			bgCyanBright: [106, 49],
+			bgWhiteBright: [107, 49]
+		}
+	};
+
+	// Alias bright black as gray (and grey)
+	styles.color.gray = styles.color.blackBright;
+	styles.bgColor.bgGray = styles.bgColor.bgBlackBright;
+	styles.color.grey = styles.color.blackBright;
+	styles.bgColor.bgGrey = styles.bgColor.bgBlackBright;
+
+	for (const [groupName, group] of Object.entries(styles)) {
+		for (const [styleName, style] of Object.entries(group)) {
+			styles[styleName] = {
+				open: `\u001B[${style[0]}m`,
+				close: `\u001B[${style[1]}m`
+			};
+
+			group[styleName] = styles[styleName];
+
+			codes.set(style[0], style[1]);
+		}
+
+		Object.defineProperty(styles, groupName, {
+			value: group,
+			enumerable: false
+		});
+	}
+
+	Object.defineProperty(styles, 'codes', {
+		value: codes,
+		enumerable: false
+	});
+
+	styles.color.close = '\u001B[39m';
+	styles.bgColor.close = '\u001B[49m';
+
+	setLazyProperty(styles.color, 'ansi', () => makeDynamicStyles(wrapAnsi16, 'ansi16', ansi2ansi, false));
+	setLazyProperty(styles.color, 'ansi256', () => makeDynamicStyles(wrapAnsi256, 'ansi256', ansi2ansi, false));
+	setLazyProperty(styles.color, 'ansi16m', () => makeDynamicStyles(wrapAnsi16m, 'rgb', rgb2rgb, false));
+	setLazyProperty(styles.bgColor, 'ansi', () => makeDynamicStyles(wrapAnsi16, 'ansi16', ansi2ansi, true));
+	setLazyProperty(styles.bgColor, 'ansi256', () => makeDynamicStyles(wrapAnsi256, 'ansi256', ansi2ansi, true));
+	setLazyProperty(styles.bgColor, 'ansi16m', () => makeDynamicStyles(wrapAnsi16m, 'rgb', rgb2rgb, true));
+
+	return styles;
+}
+
+// Make the export immutable
+Object.defineProperty(module, 'exports', {
+	enumerable: true,
+	get: assembleStyles
+});
+});
+
+var printIteratorEntries_1 = printIteratorEntries;
+var printIteratorValues_1 = printIteratorValues;
+var printListItems_1 = printListItems;
+var printObjectProperties_1 = printObjectProperties;
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+const getKeysOfEnumerableProperties = object => {
+  const keys = Object.keys(object).sort();
+
+  if (Object.getOwnPropertySymbols) {
+    Object.getOwnPropertySymbols(object).forEach(symbol => {
+      if (Object.getOwnPropertyDescriptor(object, symbol).enumerable) {
+        keys.push(symbol);
+      }
+    });
+  }
+
+  return keys;
+};
+/**
+ * Return entries (for example, of a map)
+ * with spacing, indentation, and comma
+ * without surrounding punctuation (for example, braces)
+ */
+
+function printIteratorEntries(
+  iterator,
+  config,
+  indentation,
+  depth,
+  refs,
+  printer, // Too bad, so sad that separator for ECMAScript Map has been ' => '
+  // What a distracting diff if you change a data structure to/from
+  // ECMAScript Object or Immutable.Map/OrderedMap which use the default.
+  separator = ': '
+) {
+  let result = '';
+  let current = iterator.next();
+
+  if (!current.done) {
+    result += config.spacingOuter;
+    const indentationNext = indentation + config.indent;
+
+    while (!current.done) {
+      const name = printer(
+        current.value[0],
+        config,
+        indentationNext,
+        depth,
+        refs
+      );
+      const value = printer(
+        current.value[1],
+        config,
+        indentationNext,
+        depth,
+        refs
+      );
+      result += indentationNext + name + separator + value;
+      current = iterator.next();
+
+      if (!current.done) {
+        result += ',' + config.spacingInner;
+      } else if (!config.min) {
+        result += ',';
+      }
+    }
+
+    result += config.spacingOuter + indentation;
+  }
+
+  return result;
+}
+/**
+ * Return values (for example, of a set)
+ * with spacing, indentation, and comma
+ * without surrounding punctuation (braces or brackets)
+ */
+
+function printIteratorValues(
+  iterator,
+  config,
+  indentation,
+  depth,
+  refs,
+  printer
+) {
+  let result = '';
+  let current = iterator.next();
+
+  if (!current.done) {
+    result += config.spacingOuter;
+    const indentationNext = indentation + config.indent;
+
+    while (!current.done) {
+      result +=
+        indentationNext +
+        printer(current.value, config, indentationNext, depth, refs);
+      current = iterator.next();
+
+      if (!current.done) {
+        result += ',' + config.spacingInner;
+      } else if (!config.min) {
+        result += ',';
+      }
+    }
+
+    result += config.spacingOuter + indentation;
+  }
+
+  return result;
+}
+/**
+ * Return items (for example, of an array)
+ * with spacing, indentation, and comma
+ * without surrounding punctuation (for example, brackets)
+ **/
+
+function printListItems(list, config, indentation, depth, refs, printer) {
+  let result = '';
+
+  if (list.length) {
+    result += config.spacingOuter;
+    const indentationNext = indentation + config.indent;
+
+    for (let i = 0; i < list.length; i++) {
+      result +=
+        indentationNext +
+        printer(list[i], config, indentationNext, depth, refs);
+
+      if (i < list.length - 1) {
+        result += ',' + config.spacingInner;
+      } else if (!config.min) {
+        result += ',';
+      }
+    }
+
+    result += config.spacingOuter + indentation;
+  }
+
+  return result;
+}
+/**
+ * Return properties of an object
+ * with spacing, indentation, and comma
+ * without surrounding punctuation (for example, braces)
+ */
+
+function printObjectProperties(val, config, indentation, depth, refs, printer) {
+  let result = '';
+  const keys = getKeysOfEnumerableProperties(val);
+
+  if (keys.length) {
+    result += config.spacingOuter;
+    const indentationNext = indentation + config.indent;
+
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      const name = printer(key, config, indentationNext, depth, refs);
+      const value = printer(val[key], config, indentationNext, depth, refs);
+      result += indentationNext + name + ': ' + value;
+
+      if (i < keys.length - 1) {
+        result += ',' + config.spacingInner;
+      } else if (!config.min) {
+        result += ',';
+      }
+    }
+
+    result += config.spacingOuter + indentation;
+  }
+
+  return result;
+}
+
+var collections = /*#__PURE__*/Object.defineProperty({
+	printIteratorEntries: printIteratorEntries_1,
+	printIteratorValues: printIteratorValues_1,
+	printListItems: printListItems_1,
+	printObjectProperties: printObjectProperties_1
+}, '__esModule', {value: true});
+
+var AsymmetricMatcher = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports.default = exports.test = exports.serialize = void 0;
+
+
+
+var Symbol = global$1['jest-symbol-do-not-touch'] || global$1.Symbol;
+const asymmetricMatcher =
+  typeof Symbol === 'function' && Symbol.for
+    ? Symbol.for('jest.asymmetricMatcher')
+    : 0x1357a5;
+const SPACE = ' ';
+
+const serialize = (val, config, indentation, depth, refs, printer) => {
+  const stringedValue = val.toString();
+
+  if (
+    stringedValue === 'ArrayContaining' ||
+    stringedValue === 'ArrayNotContaining'
+  ) {
+    if (++depth > config.maxDepth) {
+      return '[' + stringedValue + ']';
+    }
+
+    return (
+      stringedValue +
+      SPACE +
+      '[' +
+      (0, collections.printListItems)(
+        val.sample,
+        config,
+        indentation,
+        depth,
+        refs,
+        printer
+      ) +
+      ']'
+    );
+  }
+
+  if (
+    stringedValue === 'ObjectContaining' ||
+    stringedValue === 'ObjectNotContaining'
+  ) {
+    if (++depth > config.maxDepth) {
+      return '[' + stringedValue + ']';
+    }
+
+    return (
+      stringedValue +
+      SPACE +
+      '{' +
+      (0, collections.printObjectProperties)(
+        val.sample,
+        config,
+        indentation,
+        depth,
+        refs,
+        printer
+      ) +
+      '}'
+    );
+  }
+
+  if (
+    stringedValue === 'StringMatching' ||
+    stringedValue === 'StringNotMatching'
+  ) {
+    return (
+      stringedValue +
+      SPACE +
+      printer(val.sample, config, indentation, depth, refs)
+    );
+  }
+
+  if (
+    stringedValue === 'StringContaining' ||
+    stringedValue === 'StringNotContaining'
+  ) {
+    return (
+      stringedValue +
+      SPACE +
+      printer(val.sample, config, indentation, depth, refs)
+    );
+  }
+
+  return val.toAsymmetricMatcher();
+};
+
+exports.serialize = serialize;
+
+const test = val => val && val.$$typeof === asymmetricMatcher;
+
+exports.test = test;
+const plugin = {
+  serialize,
+  test
+};
+var _default = plugin;
+exports.default = _default;
+});
+
+var ansiRegex = ({onlyFirst = false} = {}) => {
+	const pattern = [
+		'[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+		'(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))'
+	].join('|');
+
+	return new RegExp(pattern, onlyFirst ? undefined : 'g');
+};
+
+var ConvertAnsi = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports.default = exports.serialize = exports.test = void 0;
+
+var _ansiRegex = _interopRequireDefault(ansiRegex);
+
+var _ansiStyles = _interopRequireDefault(ansiStyles);
+
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : {default: obj};
+}
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const toHumanReadableAnsi = text =>
+  text.replace((0, _ansiRegex.default)(), match => {
+    switch (match) {
+      case _ansiStyles.default.red.close:
+      case _ansiStyles.default.green.close:
+      case _ansiStyles.default.cyan.close:
+      case _ansiStyles.default.gray.close:
+      case _ansiStyles.default.white.close:
+      case _ansiStyles.default.yellow.close:
+      case _ansiStyles.default.bgRed.close:
+      case _ansiStyles.default.bgGreen.close:
+      case _ansiStyles.default.bgYellow.close:
+      case _ansiStyles.default.inverse.close:
+      case _ansiStyles.default.dim.close:
+      case _ansiStyles.default.bold.close:
+      case _ansiStyles.default.reset.open:
+      case _ansiStyles.default.reset.close:
+        return '</>';
+
+      case _ansiStyles.default.red.open:
+        return '<red>';
+
+      case _ansiStyles.default.green.open:
+        return '<green>';
+
+      case _ansiStyles.default.cyan.open:
+        return '<cyan>';
+
+      case _ansiStyles.default.gray.open:
+        return '<gray>';
+
+      case _ansiStyles.default.white.open:
+        return '<white>';
+
+      case _ansiStyles.default.yellow.open:
+        return '<yellow>';
+
+      case _ansiStyles.default.bgRed.open:
+        return '<bgRed>';
+
+      case _ansiStyles.default.bgGreen.open:
+        return '<bgGreen>';
+
+      case _ansiStyles.default.bgYellow.open:
+        return '<bgYellow>';
+
+      case _ansiStyles.default.inverse.open:
+        return '<inverse>';
+
+      case _ansiStyles.default.dim.open:
+        return '<dim>';
+
+      case _ansiStyles.default.bold.open:
+        return '<bold>';
+
+      default:
+        return '';
+    }
+  });
+
+const test = val =>
+  typeof val === 'string' && !!val.match((0, _ansiRegex.default)());
+
+exports.test = test;
+
+const serialize = (val, config, indentation, depth, refs, printer) =>
+  printer(toHumanReadableAnsi(val), config, indentation, depth, refs);
+
+exports.serialize = serialize;
+const plugin = {
+  serialize,
+  test
+};
+var _default = plugin;
+exports.default = _default;
+});
+
+var DOMCollection$1 = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports.default = exports.serialize = exports.test = void 0;
+
+
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable local/ban-types-eventually */
+const SPACE = ' ';
+const OBJECT_NAMES = ['DOMStringMap', 'NamedNodeMap'];
+const ARRAY_REGEXP = /^(HTML\w*Collection|NodeList)$/;
+
+const testName = name =>
+  OBJECT_NAMES.indexOf(name) !== -1 || ARRAY_REGEXP.test(name);
+
+const test = val =>
+  val &&
+  val.constructor &&
+  !!val.constructor.name &&
+  testName(val.constructor.name);
+
+exports.test = test;
+
+const isNamedNodeMap = collection =>
+  collection.constructor.name === 'NamedNodeMap';
+
+const serialize = (collection, config, indentation, depth, refs, printer) => {
+  const name = collection.constructor.name;
+
+  if (++depth > config.maxDepth) {
+    return '[' + name + ']';
+  }
+
+  return (
+    (config.min ? '' : name + SPACE) +
+    (OBJECT_NAMES.indexOf(name) !== -1
+      ? '{' +
+        (0, collections.printObjectProperties)(
+          isNamedNodeMap(collection)
+            ? Array.from(collection).reduce((props, attribute) => {
+                props[attribute.name] = attribute.value;
+                return props;
+              }, {})
+            : {...collection},
+          config,
+          indentation,
+          depth,
+          refs,
+          printer
+        ) +
+        '}'
+      : '[' +
+        (0, collections.printListItems)(
+          Array.from(collection),
+          config,
+          indentation,
+          depth,
+          refs,
+          printer
+        ) +
+        ']')
+  );
+};
+
+exports.serialize = serialize;
+const plugin = {
+  serialize,
+  test
+};
+var _default = plugin;
+exports.default = _default;
+});
+
+var _default = escapeHTML;
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+function escapeHTML(str) {
+  return str.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+var escapeHTML_1 = /*#__PURE__*/Object.defineProperty({
+	default: _default
+}, '__esModule', {value: true});
+
+var markup = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports.printElementAsLeaf = exports.printElement = exports.printComment = exports.printText = exports.printChildren = exports.printProps = void 0;
+
+var _escapeHTML = _interopRequireDefault(escapeHTML_1);
+
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : {default: obj};
+}
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// Return empty string if keys is empty.
+const printProps = (keys, props, config, indentation, depth, refs, printer) => {
+  const indentationNext = indentation + config.indent;
+  const colors = config.colors;
+  return keys
+    .map(key => {
+      const value = props[key];
+      let printed = printer(value, config, indentationNext, depth, refs);
+
+      if (typeof value !== 'string') {
+        if (printed.indexOf('\n') !== -1) {
+          printed =
+            config.spacingOuter +
+            indentationNext +
+            printed +
+            config.spacingOuter +
+            indentation;
+        }
+
+        printed = '{' + printed + '}';
+      }
+
+      return (
+        config.spacingInner +
+        indentation +
+        colors.prop.open +
+        key +
+        colors.prop.close +
+        '=' +
+        colors.value.open +
+        printed +
+        colors.value.close
+      );
+    })
+    .join('');
+}; // Return empty string if children is empty.
+
+exports.printProps = printProps;
+
+const printChildren = (children, config, indentation, depth, refs, printer) =>
+  children
+    .map(
+      child =>
+        config.spacingOuter +
+        indentation +
+        (typeof child === 'string'
+          ? printText(child, config)
+          : printer(child, config, indentation, depth, refs))
+    )
+    .join('');
+
+exports.printChildren = printChildren;
+
+const printText = (text, config) => {
+  const contentColor = config.colors.content;
+  return (
+    contentColor.open + (0, _escapeHTML.default)(text) + contentColor.close
+  );
+};
+
+exports.printText = printText;
+
+const printComment = (comment, config) => {
+  const commentColor = config.colors.comment;
+  return (
+    commentColor.open +
+    '<!--' +
+    (0, _escapeHTML.default)(comment) +
+    '-->' +
+    commentColor.close
+  );
+}; // Separate the functions to format props, children, and element,
+// so a plugin could override a particular function, if needed.
+// Too bad, so sad: the traditional (but unnecessary) space
+// in a self-closing tagColor requires a second test of printedProps.
+
+exports.printComment = printComment;
+
+const printElement = (
+  type,
+  printedProps,
+  printedChildren,
+  config,
+  indentation
+) => {
+  const tagColor = config.colors.tag;
+  return (
+    tagColor.open +
+    '<' +
+    type +
+    (printedProps &&
+      tagColor.close +
+        printedProps +
+        config.spacingOuter +
+        indentation +
+        tagColor.open) +
+    (printedChildren
+      ? '>' +
+        tagColor.close +
+        printedChildren +
+        config.spacingOuter +
+        indentation +
+        tagColor.open +
+        '</' +
+        type
+      : (printedProps && !config.min ? '' : ' ') + '/') +
+    '>' +
+    tagColor.close
+  );
+};
+
+exports.printElement = printElement;
+
+const printElementAsLeaf = (type, config) => {
+  const tagColor = config.colors.tag;
+  return (
+    tagColor.open +
+    '<' +
+    type +
+    tagColor.close +
+    ' …' +
+    tagColor.open +
+    ' />' +
+    tagColor.close
+  );
+};
+
+exports.printElementAsLeaf = printElementAsLeaf;
+});
+
+var DOMElement$1 = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports.default = exports.serialize = exports.test = void 0;
+
+
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+const COMMENT_NODE = 8;
+const FRAGMENT_NODE = 11;
+const ELEMENT_REGEXP = /^((HTML|SVG)\w*)?Element$/;
+
+const testNode = val => {
+  var _val$hasAttribute;
+
+  const constructorName = val.constructor.name;
+  const {nodeType, tagName} = val;
+  const isCustomElement =
+    (typeof tagName === 'string' && tagName.includes('-')) ||
+    ((_val$hasAttribute = val.hasAttribute) === null ||
+    _val$hasAttribute === void 0
+      ? void 0
+      : _val$hasAttribute.call(val, 'is'));
+  return (
+    (nodeType === ELEMENT_NODE &&
+      (ELEMENT_REGEXP.test(constructorName) || isCustomElement)) ||
+    (nodeType === TEXT_NODE && constructorName === 'Text') ||
+    (nodeType === COMMENT_NODE && constructorName === 'Comment') ||
+    (nodeType === FRAGMENT_NODE && constructorName === 'DocumentFragment')
+  );
+};
+
+const test = val => {
+  var _val$constructor;
+
+  return (
+    (val === null || val === void 0
+      ? void 0
+      : (_val$constructor = val.constructor) === null ||
+        _val$constructor === void 0
+      ? void 0
+      : _val$constructor.name) && testNode(val)
+  );
+};
+
+exports.test = test;
+
+function nodeIsText(node) {
+  return node.nodeType === TEXT_NODE;
+}
+
+function nodeIsComment(node) {
+  return node.nodeType === COMMENT_NODE;
+}
+
+function nodeIsFragment(node) {
+  return node.nodeType === FRAGMENT_NODE;
+}
+
+const serialize = (node, config, indentation, depth, refs, printer) => {
+  if (nodeIsText(node)) {
+    return (0, markup.printText)(node.data, config);
+  }
+
+  if (nodeIsComment(node)) {
+    return (0, markup.printComment)(node.data, config);
+  }
+
+  const type = nodeIsFragment(node)
+    ? `DocumentFragment`
+    : node.tagName.toLowerCase();
+
+  if (++depth > config.maxDepth) {
+    return (0, markup.printElementAsLeaf)(type, config);
+  }
+
+  return (0, markup.printElement)(
+    type,
+    (0, markup.printProps)(
+      nodeIsFragment(node)
+        ? []
+        : Array.from(node.attributes)
+            .map(attr => attr.name)
+            .sort(),
+      nodeIsFragment(node)
+        ? {}
+        : Array.from(node.attributes).reduce((props, attribute) => {
+            props[attribute.name] = attribute.value;
+            return props;
+          }, {}),
+      config,
+      indentation + config.indent,
+      depth,
+      refs,
+      printer
+    ),
+    (0, markup.printChildren)(
+      Array.prototype.slice.call(node.childNodes || node.children),
+      config,
+      indentation + config.indent,
+      depth,
+      refs,
+      printer
+    ),
+    config,
+    indentation
+  );
+};
+
+exports.serialize = serialize;
+const plugin = {
+  serialize,
+  test
+};
+var _default = plugin;
+exports.default = _default;
+});
+
+var Immutable = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports.default = exports.test = exports.serialize = void 0;
+
+
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// SENTINEL constants are from https://github.com/facebook/immutable-js
+const IS_ITERABLE_SENTINEL = '@@__IMMUTABLE_ITERABLE__@@';
+const IS_LIST_SENTINEL = '@@__IMMUTABLE_LIST__@@';
+const IS_KEYED_SENTINEL = '@@__IMMUTABLE_KEYED__@@';
+const IS_MAP_SENTINEL = '@@__IMMUTABLE_MAP__@@';
+const IS_ORDERED_SENTINEL = '@@__IMMUTABLE_ORDERED__@@';
+const IS_RECORD_SENTINEL = '@@__IMMUTABLE_RECORD__@@'; // immutable v4
+
+const IS_SEQ_SENTINEL = '@@__IMMUTABLE_SEQ__@@';
+const IS_SET_SENTINEL = '@@__IMMUTABLE_SET__@@';
+const IS_STACK_SENTINEL = '@@__IMMUTABLE_STACK__@@';
+
+const getImmutableName = name => 'Immutable.' + name;
+
+const printAsLeaf = name => '[' + name + ']';
+
+const SPACE = ' ';
+const LAZY = '…'; // Seq is lazy if it calls a method like filter
+
+const printImmutableEntries = (
+  val,
+  config,
+  indentation,
+  depth,
+  refs,
+  printer,
+  type
+) =>
+  ++depth > config.maxDepth
+    ? printAsLeaf(getImmutableName(type))
+    : getImmutableName(type) +
+      SPACE +
+      '{' +
+      (0, collections.printIteratorEntries)(
+        val.entries(),
+        config,
+        indentation,
+        depth,
+        refs,
+        printer
+      ) +
+      '}'; // Record has an entries method because it is a collection in immutable v3.
+// Return an iterator for Immutable Record from version v3 or v4.
+
+function getRecordEntries(val) {
+  let i = 0;
+  return {
+    next() {
+      if (i < val._keys.length) {
+        const key = val._keys[i++];
+        return {
+          done: false,
+          value: [key, val.get(key)]
+        };
+      }
+
+      return {
+        done: true,
+        value: undefined
+      };
+    }
+  };
+}
+
+const printImmutableRecord = (
+  val,
+  config,
+  indentation,
+  depth,
+  refs,
+  printer
+) => {
+  // _name property is defined only for an Immutable Record instance
+  // which was constructed with a second optional descriptive name arg
+  const name = getImmutableName(val._name || 'Record');
+  return ++depth > config.maxDepth
+    ? printAsLeaf(name)
+    : name +
+        SPACE +
+        '{' +
+        (0, collections.printIteratorEntries)(
+          getRecordEntries(val),
+          config,
+          indentation,
+          depth,
+          refs,
+          printer
+        ) +
+        '}';
+};
+
+const printImmutableSeq = (val, config, indentation, depth, refs, printer) => {
+  const name = getImmutableName('Seq');
+
+  if (++depth > config.maxDepth) {
+    return printAsLeaf(name);
+  }
+
+  if (val[IS_KEYED_SENTINEL]) {
+    return (
+      name +
+      SPACE +
+      '{' + // from Immutable collection of entries or from ECMAScript object
+      (val._iter || val._object
+        ? (0, collections.printIteratorEntries)(
+            val.entries(),
+            config,
+            indentation,
+            depth,
+            refs,
+            printer
+          )
+        : LAZY) +
+      '}'
+    );
+  }
+
+  return (
+    name +
+    SPACE +
+    '[' +
+    (val._iter || // from Immutable collection of values
+    val._array || // from ECMAScript array
+    val._collection || // from ECMAScript collection in immutable v4
+    val._iterable // from ECMAScript collection in immutable v3
+      ? (0, collections.printIteratorValues)(
+          val.values(),
+          config,
+          indentation,
+          depth,
+          refs,
+          printer
+        )
+      : LAZY) +
+    ']'
+  );
+};
+
+const printImmutableValues = (
+  val,
+  config,
+  indentation,
+  depth,
+  refs,
+  printer,
+  type
+) =>
+  ++depth > config.maxDepth
+    ? printAsLeaf(getImmutableName(type))
+    : getImmutableName(type) +
+      SPACE +
+      '[' +
+      (0, collections.printIteratorValues)(
+        val.values(),
+        config,
+        indentation,
+        depth,
+        refs,
+        printer
+      ) +
+      ']';
+
+const serialize = (val, config, indentation, depth, refs, printer) => {
+  if (val[IS_MAP_SENTINEL]) {
+    return printImmutableEntries(
+      val,
+      config,
+      indentation,
+      depth,
+      refs,
+      printer,
+      val[IS_ORDERED_SENTINEL] ? 'OrderedMap' : 'Map'
+    );
+  }
+
+  if (val[IS_LIST_SENTINEL]) {
+    return printImmutableValues(
+      val,
+      config,
+      indentation,
+      depth,
+      refs,
+      printer,
+      'List'
+    );
+  }
+
+  if (val[IS_SET_SENTINEL]) {
+    return printImmutableValues(
+      val,
+      config,
+      indentation,
+      depth,
+      refs,
+      printer,
+      val[IS_ORDERED_SENTINEL] ? 'OrderedSet' : 'Set'
+    );
+  }
+
+  if (val[IS_STACK_SENTINEL]) {
+    return printImmutableValues(
+      val,
+      config,
+      indentation,
+      depth,
+      refs,
+      printer,
+      'Stack'
+    );
+  }
+
+  if (val[IS_SEQ_SENTINEL]) {
+    return printImmutableSeq(val, config, indentation, depth, refs, printer);
+  } // For compatibility with immutable v3 and v4, let record be the default.
+
+  return printImmutableRecord(val, config, indentation, depth, refs, printer);
+}; // Explicitly comparing sentinel properties to true avoids false positive
+// when mock identity-obj-proxy returns the key as the value for any key.
+
+exports.serialize = serialize;
+
+const test = val =>
+  val &&
+  (val[IS_ITERABLE_SENTINEL] === true || val[IS_RECORD_SENTINEL] === true);
+
+exports.test = test;
+const plugin = {
+  serialize,
+  test
+};
+var _default = plugin;
+exports.default = _default;
+});
+
+/** @license React v17.0.2
+ * react-is.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+var b=60103,c=60106,d=60107,e=60108,f$8=60114,g=60109,h=60110,k=60112,l=60113,m=60120,n=60115,p=60116,q=60121,r=60122,u=60117,v=60129,w=60131;
+if("function"===typeof Symbol&&Symbol.for){var x=Symbol.for;b=x("react.element");c=x("react.portal");d=x("react.fragment");e=x("react.strict_mode");f$8=x("react.profiler");g=x("react.provider");h=x("react.context");k=x("react.forward_ref");l=x("react.suspense");m=x("react.suspense_list");n=x("react.memo");p=x("react.lazy");q=x("react.block");r=x("react.server.block");u=x("react.fundamental");v=x("react.debug_trace_mode");w=x("react.legacy_hidden");}
+function y(a){if("object"===typeof a&&null!==a){var t=a.$$typeof;switch(t){case b:switch(a=a.type,a){case d:case f$8:case e:case l:case m:return a;default:switch(a=a&&a.$$typeof,a){case h:case k:case p:case n:case g:return a;default:return t}}case c:return t}}}var z=g,A=b,B=k,C=d,D=p,E=n,F=c,G=f$8,H=e,I=l;var ContextConsumer=h;var ContextProvider=z;var Element=A;var ForwardRef=B;var Fragment=C;var Lazy=D;var Memo=E;var Portal=F;var Profiler=G;var StrictMode=H;
+var Suspense=I;var isAsyncMode=function(){return !1};var isConcurrentMode=function(){return !1};var isContextConsumer=function(a){return y(a)===h};var isContextProvider=function(a){return y(a)===g};var isElement$1=function(a){return "object"===typeof a&&null!==a&&a.$$typeof===b};var isForwardRef=function(a){return y(a)===k};var isFragment=function(a){return y(a)===d};var isLazy=function(a){return y(a)===p};var isMemo=function(a){return y(a)===n};
+var isPortal=function(a){return y(a)===c};var isProfiler=function(a){return y(a)===f$8};var isStrictMode=function(a){return y(a)===e};var isSuspense=function(a){return y(a)===l};var isValidElementType=function(a){return "string"===typeof a||"function"===typeof a||a===d||a===f$8||a===v||a===e||a===l||a===m||a===w||"object"===typeof a&&null!==a&&(a.$$typeof===p||a.$$typeof===n||a.$$typeof===g||a.$$typeof===h||a.$$typeof===k||a.$$typeof===u||a.$$typeof===q||a[0]===r)?!0:!1};
+var typeOf=y;
+
+var reactIs_production_min = {
+	ContextConsumer: ContextConsumer,
+	ContextProvider: ContextProvider,
+	Element: Element,
+	ForwardRef: ForwardRef,
+	Fragment: Fragment,
+	Lazy: Lazy,
+	Memo: Memo,
+	Portal: Portal,
+	Profiler: Profiler,
+	StrictMode: StrictMode,
+	Suspense: Suspense,
+	isAsyncMode: isAsyncMode,
+	isConcurrentMode: isConcurrentMode,
+	isContextConsumer: isContextConsumer,
+	isContextProvider: isContextProvider,
+	isElement: isElement$1,
+	isForwardRef: isForwardRef,
+	isFragment: isFragment,
+	isLazy: isLazy,
+	isMemo: isMemo,
+	isPortal: isPortal,
+	isProfiler: isProfiler,
+	isStrictMode: isStrictMode,
+	isSuspense: isSuspense,
+	isValidElementType: isValidElementType,
+	typeOf: typeOf
+};
+
+var reactIs_development = createCommonjsModule(function (module, exports) {
+
+if (process$1.env.NODE_ENV !== "production") {
+  (function() {
+
+// ATTENTION
+// When adding new symbols to this file,
+// Please consider also adding to 'react-devtools-shared/src/backend/ReactSymbols'
+// The Symbol used to tag the ReactElement-like types. If there is no native Symbol
+// nor polyfill, then a plain number is used for performance.
+var REACT_ELEMENT_TYPE = 0xeac7;
+var REACT_PORTAL_TYPE = 0xeaca;
+var REACT_FRAGMENT_TYPE = 0xeacb;
+var REACT_STRICT_MODE_TYPE = 0xeacc;
+var REACT_PROFILER_TYPE = 0xead2;
+var REACT_PROVIDER_TYPE = 0xeacd;
+var REACT_CONTEXT_TYPE = 0xeace;
+var REACT_FORWARD_REF_TYPE = 0xead0;
+var REACT_SUSPENSE_TYPE = 0xead1;
+var REACT_SUSPENSE_LIST_TYPE = 0xead8;
+var REACT_MEMO_TYPE = 0xead3;
+var REACT_LAZY_TYPE = 0xead4;
+var REACT_BLOCK_TYPE = 0xead9;
+var REACT_SERVER_BLOCK_TYPE = 0xeada;
+var REACT_FUNDAMENTAL_TYPE = 0xead5;
+var REACT_DEBUG_TRACING_MODE_TYPE = 0xeae1;
+var REACT_LEGACY_HIDDEN_TYPE = 0xeae3;
+
+if (typeof Symbol === 'function' && Symbol.for) {
+  var symbolFor = Symbol.for;
+  REACT_ELEMENT_TYPE = symbolFor('react.element');
+  REACT_PORTAL_TYPE = symbolFor('react.portal');
+  REACT_FRAGMENT_TYPE = symbolFor('react.fragment');
+  REACT_STRICT_MODE_TYPE = symbolFor('react.strict_mode');
+  REACT_PROFILER_TYPE = symbolFor('react.profiler');
+  REACT_PROVIDER_TYPE = symbolFor('react.provider');
+  REACT_CONTEXT_TYPE = symbolFor('react.context');
+  REACT_FORWARD_REF_TYPE = symbolFor('react.forward_ref');
+  REACT_SUSPENSE_TYPE = symbolFor('react.suspense');
+  REACT_SUSPENSE_LIST_TYPE = symbolFor('react.suspense_list');
+  REACT_MEMO_TYPE = symbolFor('react.memo');
+  REACT_LAZY_TYPE = symbolFor('react.lazy');
+  REACT_BLOCK_TYPE = symbolFor('react.block');
+  REACT_SERVER_BLOCK_TYPE = symbolFor('react.server.block');
+  REACT_FUNDAMENTAL_TYPE = symbolFor('react.fundamental');
+  symbolFor('react.scope');
+  symbolFor('react.opaque.id');
+  REACT_DEBUG_TRACING_MODE_TYPE = symbolFor('react.debug_trace_mode');
+  symbolFor('react.offscreen');
+  REACT_LEGACY_HIDDEN_TYPE = symbolFor('react.legacy_hidden');
+}
+
+// Filter certain DOM attributes (e.g. src, href) if their values are empty strings.
+
+var enableScopeAPI = false; // Experimental Create Event Handle API.
+
+function isValidElementType(type) {
+  if (typeof type === 'string' || typeof type === 'function') {
+    return true;
+  } // Note: typeof might be other than 'symbol' or 'number' (e.g. if it's a polyfill).
+
+
+  if (type === REACT_FRAGMENT_TYPE || type === REACT_PROFILER_TYPE || type === REACT_DEBUG_TRACING_MODE_TYPE || type === REACT_STRICT_MODE_TYPE || type === REACT_SUSPENSE_TYPE || type === REACT_SUSPENSE_LIST_TYPE || type === REACT_LEGACY_HIDDEN_TYPE || enableScopeAPI ) {
+    return true;
+  }
+
+  if (typeof type === 'object' && type !== null) {
+    if (type.$$typeof === REACT_LAZY_TYPE || type.$$typeof === REACT_MEMO_TYPE || type.$$typeof === REACT_PROVIDER_TYPE || type.$$typeof === REACT_CONTEXT_TYPE || type.$$typeof === REACT_FORWARD_REF_TYPE || type.$$typeof === REACT_FUNDAMENTAL_TYPE || type.$$typeof === REACT_BLOCK_TYPE || type[0] === REACT_SERVER_BLOCK_TYPE) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function typeOf(object) {
+  if (typeof object === 'object' && object !== null) {
+    var $$typeof = object.$$typeof;
+
+    switch ($$typeof) {
+      case REACT_ELEMENT_TYPE:
+        var type = object.type;
+
+        switch (type) {
+          case REACT_FRAGMENT_TYPE:
+          case REACT_PROFILER_TYPE:
+          case REACT_STRICT_MODE_TYPE:
+          case REACT_SUSPENSE_TYPE:
+          case REACT_SUSPENSE_LIST_TYPE:
+            return type;
+
+          default:
+            var $$typeofType = type && type.$$typeof;
+
+            switch ($$typeofType) {
+              case REACT_CONTEXT_TYPE:
+              case REACT_FORWARD_REF_TYPE:
+              case REACT_LAZY_TYPE:
+              case REACT_MEMO_TYPE:
+              case REACT_PROVIDER_TYPE:
+                return $$typeofType;
+
+              default:
+                return $$typeof;
+            }
+
+        }
+
+      case REACT_PORTAL_TYPE:
+        return $$typeof;
+    }
+  }
+
+  return undefined;
+}
+var ContextConsumer = REACT_CONTEXT_TYPE;
+var ContextProvider = REACT_PROVIDER_TYPE;
+var Element = REACT_ELEMENT_TYPE;
+var ForwardRef = REACT_FORWARD_REF_TYPE;
+var Fragment = REACT_FRAGMENT_TYPE;
+var Lazy = REACT_LAZY_TYPE;
+var Memo = REACT_MEMO_TYPE;
+var Portal = REACT_PORTAL_TYPE;
+var Profiler = REACT_PROFILER_TYPE;
+var StrictMode = REACT_STRICT_MODE_TYPE;
+var Suspense = REACT_SUSPENSE_TYPE;
+var hasWarnedAboutDeprecatedIsAsyncMode = false;
+var hasWarnedAboutDeprecatedIsConcurrentMode = false; // AsyncMode should be deprecated
+
+function isAsyncMode(object) {
+  {
+    if (!hasWarnedAboutDeprecatedIsAsyncMode) {
+      hasWarnedAboutDeprecatedIsAsyncMode = true; // Using console['warn'] to evade Babel and ESLint
+
+      console['warn']('The ReactIs.isAsyncMode() alias has been deprecated, ' + 'and will be removed in React 18+.');
+    }
+  }
+
+  return false;
+}
+function isConcurrentMode(object) {
+  {
+    if (!hasWarnedAboutDeprecatedIsConcurrentMode) {
+      hasWarnedAboutDeprecatedIsConcurrentMode = true; // Using console['warn'] to evade Babel and ESLint
+
+      console['warn']('The ReactIs.isConcurrentMode() alias has been deprecated, ' + 'and will be removed in React 18+.');
+    }
+  }
+
+  return false;
+}
+function isContextConsumer(object) {
+  return typeOf(object) === REACT_CONTEXT_TYPE;
+}
+function isContextProvider(object) {
+  return typeOf(object) === REACT_PROVIDER_TYPE;
+}
+function isElement(object) {
+  return typeof object === 'object' && object !== null && object.$$typeof === REACT_ELEMENT_TYPE;
+}
+function isForwardRef(object) {
+  return typeOf(object) === REACT_FORWARD_REF_TYPE;
+}
+function isFragment(object) {
+  return typeOf(object) === REACT_FRAGMENT_TYPE;
+}
+function isLazy(object) {
+  return typeOf(object) === REACT_LAZY_TYPE;
+}
+function isMemo(object) {
+  return typeOf(object) === REACT_MEMO_TYPE;
+}
+function isPortal(object) {
+  return typeOf(object) === REACT_PORTAL_TYPE;
+}
+function isProfiler(object) {
+  return typeOf(object) === REACT_PROFILER_TYPE;
+}
+function isStrictMode(object) {
+  return typeOf(object) === REACT_STRICT_MODE_TYPE;
+}
+function isSuspense(object) {
+  return typeOf(object) === REACT_SUSPENSE_TYPE;
+}
+
+exports.ContextConsumer = ContextConsumer;
+exports.ContextProvider = ContextProvider;
+exports.Element = Element;
+exports.ForwardRef = ForwardRef;
+exports.Fragment = Fragment;
+exports.Lazy = Lazy;
+exports.Memo = Memo;
+exports.Portal = Portal;
+exports.Profiler = Profiler;
+exports.StrictMode = StrictMode;
+exports.Suspense = Suspense;
+exports.isAsyncMode = isAsyncMode;
+exports.isConcurrentMode = isConcurrentMode;
+exports.isContextConsumer = isContextConsumer;
+exports.isContextProvider = isContextProvider;
+exports.isElement = isElement;
+exports.isForwardRef = isForwardRef;
+exports.isFragment = isFragment;
+exports.isLazy = isLazy;
+exports.isMemo = isMemo;
+exports.isPortal = isPortal;
+exports.isProfiler = isProfiler;
+exports.isStrictMode = isStrictMode;
+exports.isSuspense = isSuspense;
+exports.isValidElementType = isValidElementType;
+exports.typeOf = typeOf;
+  })();
+}
+});
+
+var reactIs = createCommonjsModule(function (module) {
+
+if (process$1.env.NODE_ENV === 'production') {
+  module.exports = reactIs_production_min;
+} else {
+  module.exports = reactIs_development;
+}
+});
+
+var ReactElement = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports.default = exports.test = exports.serialize = void 0;
+
+var ReactIs = _interopRequireWildcard(reactIs);
+
+
+
+function _getRequireWildcardCache() {
+  if (typeof WeakMap !== 'function') return null;
+  var cache = new WeakMap();
+  _getRequireWildcardCache = function () {
+    return cache;
+  };
+  return cache;
+}
+
+function _interopRequireWildcard(obj) {
+  if (obj && obj.__esModule) {
+    return obj;
+  }
+  if (obj === null || (typeof obj !== 'object' && typeof obj !== 'function')) {
+    return {default: obj};
+  }
+  var cache = _getRequireWildcardCache();
+  if (cache && cache.has(obj)) {
+    return cache.get(obj);
+  }
+  var newObj = {};
+  var hasPropertyDescriptor =
+    Object.defineProperty && Object.getOwnPropertyDescriptor;
+  for (var key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      var desc = hasPropertyDescriptor
+        ? Object.getOwnPropertyDescriptor(obj, key)
+        : null;
+      if (desc && (desc.get || desc.set)) {
+        Object.defineProperty(newObj, key, desc);
+      } else {
+        newObj[key] = obj[key];
+      }
+    }
+  }
+  newObj.default = obj;
+  if (cache) {
+    cache.set(obj, newObj);
+  }
+  return newObj;
+}
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// Given element.props.children, or subtree during recursive traversal,
+// return flattened array of children.
+const getChildren = (arg, children = []) => {
+  if (Array.isArray(arg)) {
+    arg.forEach(item => {
+      getChildren(item, children);
+    });
+  } else if (arg != null && arg !== false) {
+    children.push(arg);
+  }
+
+  return children;
+};
+
+const getType = element => {
+  const type = element.type;
+
+  if (typeof type === 'string') {
+    return type;
+  }
+
+  if (typeof type === 'function') {
+    return type.displayName || type.name || 'Unknown';
+  }
+
+  if (ReactIs.isFragment(element)) {
+    return 'React.Fragment';
+  }
+
+  if (ReactIs.isSuspense(element)) {
+    return 'React.Suspense';
+  }
+
+  if (typeof type === 'object' && type !== null) {
+    if (ReactIs.isContextProvider(element)) {
+      return 'Context.Provider';
+    }
+
+    if (ReactIs.isContextConsumer(element)) {
+      return 'Context.Consumer';
+    }
+
+    if (ReactIs.isForwardRef(element)) {
+      if (type.displayName) {
+        return type.displayName;
+      }
+
+      const functionName = type.render.displayName || type.render.name || '';
+      return functionName !== ''
+        ? 'ForwardRef(' + functionName + ')'
+        : 'ForwardRef';
+    }
+
+    if (ReactIs.isMemo(element)) {
+      const functionName =
+        type.displayName || type.type.displayName || type.type.name || '';
+      return functionName !== '' ? 'Memo(' + functionName + ')' : 'Memo';
+    }
+  }
+
+  return 'UNDEFINED';
+};
+
+const getPropKeys = element => {
+  const {props} = element;
+  return Object.keys(props)
+    .filter(key => key !== 'children' && props[key] !== undefined)
+    .sort();
+};
+
+const serialize = (element, config, indentation, depth, refs, printer) =>
+  ++depth > config.maxDepth
+    ? (0, markup.printElementAsLeaf)(getType(element), config)
+    : (0, markup.printElement)(
+        getType(element),
+        (0, markup.printProps)(
+          getPropKeys(element),
+          element.props,
+          config,
+          indentation + config.indent,
+          depth,
+          refs,
+          printer
+        ),
+        (0, markup.printChildren)(
+          getChildren(element.props.children),
+          config,
+          indentation + config.indent,
+          depth,
+          refs,
+          printer
+        ),
+        config,
+        indentation
+      );
+
+exports.serialize = serialize;
+
+const test = val => val && ReactIs.isElement(val);
+
+exports.test = test;
+const plugin = {
+  serialize,
+  test
+};
+var _default = plugin;
+exports.default = _default;
+});
+
+var ReactTestComponent = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports.default = exports.test = exports.serialize = void 0;
+
+
+
+var Symbol = global$1['jest-symbol-do-not-touch'] || global$1.Symbol;
+const testSymbol =
+  typeof Symbol === 'function' && Symbol.for
+    ? Symbol.for('react.test.json')
+    : 0xea71357;
+
+const getPropKeys = object => {
+  const {props} = object;
+  return props
+    ? Object.keys(props)
+        .filter(key => props[key] !== undefined)
+        .sort()
+    : [];
+};
+
+const serialize = (object, config, indentation, depth, refs, printer) =>
+  ++depth > config.maxDepth
+    ? (0, markup.printElementAsLeaf)(object.type, config)
+    : (0, markup.printElement)(
+        object.type,
+        object.props
+          ? (0, markup.printProps)(
+              getPropKeys(object),
+              object.props,
+              config,
+              indentation + config.indent,
+              depth,
+              refs,
+              printer
+            )
+          : '',
+        object.children
+          ? (0, markup.printChildren)(
+              object.children,
+              config,
+              indentation + config.indent,
+              depth,
+              refs,
+              printer
+            )
+          : '',
+        config,
+        indentation
+      );
+
+exports.serialize = serialize;
+
+const test = val => val && val.$$typeof === testSymbol;
+
+exports.test = test;
+const plugin = {
+  serialize,
+  test
+};
+var _default = plugin;
+exports.default = _default;
+});
+
+var _ansiStyles = _interopRequireDefault(ansiStyles);
+
+
+
+var _AsymmetricMatcher = _interopRequireDefault(
+  AsymmetricMatcher
+);
+
+var _ConvertAnsi = _interopRequireDefault(ConvertAnsi);
+
+var _DOMCollection = _interopRequireDefault(DOMCollection$1);
+
+var _DOMElement = _interopRequireDefault(DOMElement$1);
+
+var _Immutable = _interopRequireDefault(Immutable);
+
+var _ReactElement = _interopRequireDefault(ReactElement);
+
+var _ReactTestComponent = _interopRequireDefault(
+  ReactTestComponent
+);
+
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : {default: obj};
+}
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable local/ban-types-eventually */
+const toString$5 = Object.prototype.toString;
+const toISOString$1 = Date.prototype.toISOString;
+const errorToString = Error.prototype.toString;
+const regExpToString = RegExp.prototype.toString;
+/**
+ * Explicitly comparing typeof constructor to function avoids undefined as name
+ * when mock identity-obj-proxy returns the key as the value for any key.
+ */
+
+const getConstructorName = val =>
+  (typeof val.constructor === 'function' && val.constructor.name) || 'Object';
+/* global window */
+
+/** Is val is equal to global window object? Works even if it does not exist :) */
+
+const isWindow = val => typeof window !== 'undefined' && val === window;
+
+const SYMBOL_REGEXP = /^Symbol\((.*)\)(.*)$/;
+const NEWLINE_REGEXP = /\n/gi;
+
+class PrettyFormatPluginError extends Error {
+  constructor(message, stack) {
+    super(message);
+    this.stack = stack;
+    this.name = this.constructor.name;
+  }
+}
+
+function isToStringedArrayType(toStringed) {
+  return (
+    toStringed === '[object Array]' ||
+    toStringed === '[object ArrayBuffer]' ||
+    toStringed === '[object DataView]' ||
+    toStringed === '[object Float32Array]' ||
+    toStringed === '[object Float64Array]' ||
+    toStringed === '[object Int8Array]' ||
+    toStringed === '[object Int16Array]' ||
+    toStringed === '[object Int32Array]' ||
+    toStringed === '[object Uint8Array]' ||
+    toStringed === '[object Uint8ClampedArray]' ||
+    toStringed === '[object Uint16Array]' ||
+    toStringed === '[object Uint32Array]'
+  );
+}
+
+function printNumber(val) {
+  return Object.is(val, -0) ? '-0' : String(val);
+}
+
+function printBigInt(val) {
+  return String(`${val}n`);
+}
+
+function printFunction(val, printFunctionName) {
+  if (!printFunctionName) {
+    return '[Function]';
+  }
+
+  return '[Function ' + (val.name || 'anonymous') + ']';
+}
+
+function printSymbol(val) {
+  return String(val).replace(SYMBOL_REGEXP, 'Symbol($1)');
+}
+
+function printError(val) {
+  return '[' + errorToString.call(val) + ']';
+}
+/**
+ * The first port of call for printing an object, handles most of the
+ * data-types in JS.
+ */
+
+function printBasicValue(val, printFunctionName, escapeRegex, escapeString) {
+  if (val === true || val === false) {
+    return '' + val;
+  }
+
+  if (val === undefined) {
+    return 'undefined';
+  }
+
+  if (val === null) {
+    return 'null';
+  }
+
+  const typeOf = typeof val;
+
+  if (typeOf === 'number') {
+    return printNumber(val);
+  }
+
+  if (typeOf === 'bigint') {
+    return printBigInt(val);
+  }
+
+  if (typeOf === 'string') {
+    if (escapeString) {
+      return '"' + val.replace(/"|\\/g, '\\$&') + '"';
+    }
+
+    return '"' + val + '"';
+  }
+
+  if (typeOf === 'function') {
+    return printFunction(val, printFunctionName);
+  }
+
+  if (typeOf === 'symbol') {
+    return printSymbol(val);
+  }
+
+  const toStringed = toString$5.call(val);
+
+  if (toStringed === '[object WeakMap]') {
+    return 'WeakMap {}';
+  }
+
+  if (toStringed === '[object WeakSet]') {
+    return 'WeakSet {}';
+  }
+
+  if (
+    toStringed === '[object Function]' ||
+    toStringed === '[object GeneratorFunction]'
+  ) {
+    return printFunction(val, printFunctionName);
+  }
+
+  if (toStringed === '[object Symbol]') {
+    return printSymbol(val);
+  }
+
+  if (toStringed === '[object Date]') {
+    return isNaN(+val) ? 'Date { NaN }' : toISOString$1.call(val);
+  }
+
+  if (toStringed === '[object Error]') {
+    return printError(val);
+  }
+
+  if (toStringed === '[object RegExp]') {
+    if (escapeRegex) {
+      // https://github.com/benjamingr/RegExp.escape/blob/master/polyfill.js
+      return regExpToString.call(val).replace(/[\\^$*+?.()|[\]{}]/g, '\\$&');
+    }
+
+    return regExpToString.call(val);
+  }
+
+  if (val instanceof Error) {
+    return printError(val);
+  }
+
+  return null;
+}
+/**
+ * Handles more complex objects ( such as objects with circular references.
+ * maps and sets etc )
+ */
+
+function printComplexValue(
+  val,
+  config,
+  indentation,
+  depth,
+  refs,
+  hasCalledToJSON
+) {
+  if (refs.indexOf(val) !== -1) {
+    return '[Circular]';
+  }
+
+  refs = refs.slice();
+  refs.push(val);
+  const hitMaxDepth = ++depth > config.maxDepth;
+  const min = config.min;
+
+  if (
+    config.callToJSON &&
+    !hitMaxDepth &&
+    val.toJSON &&
+    typeof val.toJSON === 'function' &&
+    !hasCalledToJSON
+  ) {
+    return printer(val.toJSON(), config, indentation, depth, refs, true);
+  }
+
+  const toStringed = toString$5.call(val);
+
+  if (toStringed === '[object Arguments]') {
+    return hitMaxDepth
+      ? '[Arguments]'
+      : (min ? '' : 'Arguments ') +
+          '[' +
+          (0, collections.printListItems)(
+            val,
+            config,
+            indentation,
+            depth,
+            refs,
+            printer
+          ) +
+          ']';
+  }
+
+  if (isToStringedArrayType(toStringed)) {
+    return hitMaxDepth
+      ? '[' + val.constructor.name + ']'
+      : (min ? '' : val.constructor.name + ' ') +
+          '[' +
+          (0, collections.printListItems)(
+            val,
+            config,
+            indentation,
+            depth,
+            refs,
+            printer
+          ) +
+          ']';
+  }
+
+  if (toStringed === '[object Map]') {
+    return hitMaxDepth
+      ? '[Map]'
+      : 'Map {' +
+          (0, collections.printIteratorEntries)(
+            val.entries(),
+            config,
+            indentation,
+            depth,
+            refs,
+            printer,
+            ' => '
+          ) +
+          '}';
+  }
+
+  if (toStringed === '[object Set]') {
+    return hitMaxDepth
+      ? '[Set]'
+      : 'Set {' +
+          (0, collections.printIteratorValues)(
+            val.values(),
+            config,
+            indentation,
+            depth,
+            refs,
+            printer
+          ) +
+          '}';
+  } // Avoid failure to serialize global window object in jsdom test environment.
+  // For example, not even relevant if window is prop of React element.
+
+  return hitMaxDepth || isWindow(val)
+    ? '[' + getConstructorName(val) + ']'
+    : (min ? '' : getConstructorName(val) + ' ') +
+        '{' +
+        (0, collections.printObjectProperties)(
+          val,
+          config,
+          indentation,
+          depth,
+          refs,
+          printer
+        ) +
+        '}';
+}
+
+function isNewPlugin(plugin) {
+  return plugin.serialize != null;
+}
+
+function printPlugin(plugin, val, config, indentation, depth, refs) {
+  let printed;
+
+  try {
+    printed = isNewPlugin(plugin)
+      ? plugin.serialize(val, config, indentation, depth, refs, printer)
+      : plugin.print(
+          val,
+          valChild => printer(valChild, config, indentation, depth, refs),
+          str => {
+            const indentationNext = indentation + config.indent;
+            return (
+              indentationNext +
+              str.replace(NEWLINE_REGEXP, '\n' + indentationNext)
+            );
+          },
+          {
+            edgeSpacing: config.spacingOuter,
+            min: config.min,
+            spacing: config.spacingInner
+          },
+          config.colors
+        );
+  } catch (error) {
+    throw new PrettyFormatPluginError(error.message, error.stack);
+  }
+
+  if (typeof printed !== 'string') {
+    throw new Error(
+      `pretty-format: Plugin must return type "string" but instead returned "${typeof printed}".`
+    );
+  }
+
+  return printed;
+}
+
+function findPlugin(plugins, val) {
+  for (let p = 0; p < plugins.length; p++) {
+    try {
+      if (plugins[p].test(val)) {
+        return plugins[p];
+      }
+    } catch (error) {
+      throw new PrettyFormatPluginError(error.message, error.stack);
+    }
+  }
+
+  return null;
+}
+
+function printer(val, config, indentation, depth, refs, hasCalledToJSON) {
+  const plugin = findPlugin(config.plugins, val);
+
+  if (plugin !== null) {
+    return printPlugin(plugin, val, config, indentation, depth, refs);
+  }
+
+  const basicResult = printBasicValue(
+    val,
+    config.printFunctionName,
+    config.escapeRegex,
+    config.escapeString
+  );
+
+  if (basicResult !== null) {
+    return basicResult;
+  }
+
+  return printComplexValue(
+    val,
+    config,
+    indentation,
+    depth,
+    refs,
+    hasCalledToJSON
+  );
+}
+
+const DEFAULT_THEME = {
+  comment: 'gray',
+  content: 'reset',
+  prop: 'yellow',
+  tag: 'cyan',
+  value: 'green'
+};
+const DEFAULT_THEME_KEYS = Object.keys(DEFAULT_THEME);
+const DEFAULT_OPTIONS = {
+  callToJSON: true,
+  escapeRegex: false,
+  escapeString: true,
+  highlight: false,
+  indent: 2,
+  maxDepth: Infinity,
+  min: false,
+  plugins: [],
+  printFunctionName: true,
+  theme: DEFAULT_THEME
+};
+
+function validateOptions(options) {
+  Object.keys(options).forEach(key => {
+    if (!DEFAULT_OPTIONS.hasOwnProperty(key)) {
+      throw new Error(`pretty-format: Unknown option "${key}".`);
+    }
+  });
+
+  if (options.min && options.indent !== undefined && options.indent !== 0) {
+    throw new Error(
+      'pretty-format: Options "min" and "indent" cannot be used together.'
+    );
+  }
+
+  if (options.theme !== undefined) {
+    if (options.theme === null) {
+      throw new Error(`pretty-format: Option "theme" must not be null.`);
+    }
+
+    if (typeof options.theme !== 'object') {
+      throw new Error(
+        `pretty-format: Option "theme" must be of type "object" but instead received "${typeof options.theme}".`
+      );
+    }
+  }
+}
+
+const getColorsHighlight = options =>
+  DEFAULT_THEME_KEYS.reduce((colors, key) => {
+    const value =
+      options.theme && options.theme[key] !== undefined
+        ? options.theme[key]
+        : DEFAULT_THEME[key];
+    const color = value && _ansiStyles.default[value];
+
+    if (
+      color &&
+      typeof color.close === 'string' &&
+      typeof color.open === 'string'
+    ) {
+      colors[key] = color;
+    } else {
+      throw new Error(
+        `pretty-format: Option "theme" has a key "${key}" whose value "${value}" is undefined in ansi-styles.`
+      );
+    }
+
+    return colors;
+  }, Object.create(null));
+
+const getColorsEmpty = () =>
+  DEFAULT_THEME_KEYS.reduce((colors, key) => {
+    colors[key] = {
+      close: '',
+      open: ''
+    };
+    return colors;
+  }, Object.create(null));
+
+const getPrintFunctionName = options =>
+  options && options.printFunctionName !== undefined
+    ? options.printFunctionName
+    : DEFAULT_OPTIONS.printFunctionName;
+
+const getEscapeRegex = options =>
+  options && options.escapeRegex !== undefined
+    ? options.escapeRegex
+    : DEFAULT_OPTIONS.escapeRegex;
+
+const getEscapeString = options =>
+  options && options.escapeString !== undefined
+    ? options.escapeString
+    : DEFAULT_OPTIONS.escapeString;
+
+const getConfig$1 = options => ({
+  callToJSON:
+    options && options.callToJSON !== undefined
+      ? options.callToJSON
+      : DEFAULT_OPTIONS.callToJSON,
+  colors:
+    options && options.highlight
+      ? getColorsHighlight(options)
+      : getColorsEmpty(),
+  escapeRegex: getEscapeRegex(options),
+  escapeString: getEscapeString(options),
+  indent:
+    options && options.min
+      ? ''
+      : createIndent(
+          options && options.indent !== undefined
+            ? options.indent
+            : DEFAULT_OPTIONS.indent
+        ),
+  maxDepth:
+    options && options.maxDepth !== undefined
+      ? options.maxDepth
+      : DEFAULT_OPTIONS.maxDepth,
+  min: options && options.min !== undefined ? options.min : DEFAULT_OPTIONS.min,
+  plugins:
+    options && options.plugins !== undefined
+      ? options.plugins
+      : DEFAULT_OPTIONS.plugins,
+  printFunctionName: getPrintFunctionName(options),
+  spacingInner: options && options.min ? ' ' : '\n',
+  spacingOuter: options && options.min ? '' : '\n'
+});
+
+function createIndent(indent) {
+  return new Array(indent + 1).join(' ');
+}
+/**
+ * Returns a presentation string of your `val` object
+ * @param val any potential JavaScript object
+ * @param options Custom settings
+ */
+
+function prettyFormat(val, options) {
+  if (options) {
+    validateOptions(options);
+
+    if (options.plugins) {
+      const plugin = findPlugin(options.plugins, val);
+
+      if (plugin !== null) {
+        return printPlugin(plugin, val, getConfig$1(options), '', 0, []);
+      }
+    }
+  }
+
+  const basicResult = printBasicValue(
+    val,
+    getPrintFunctionName(options),
+    getEscapeRegex(options),
+    getEscapeString(options)
+  );
+
+  if (basicResult !== null) {
+    return basicResult;
+  }
+
+  return printComplexValue(val, getConfig$1(options), '', 0, []);
+}
+
+prettyFormat.plugins = {
+  AsymmetricMatcher: _AsymmetricMatcher.default,
+  ConvertAnsi: _ConvertAnsi.default,
+  DOMCollection: _DOMCollection.default,
+  DOMElement: _DOMElement.default,
+  Immutable: _Immutable.default,
+  ReactElement: _ReactElement.default,
+  ReactTestComponent: _ReactTestComponent.default
+};
+var build$1 = prettyFormat;
+
+/**
+ * @source {https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from#Polyfill}
+ * but without thisArg (too hard to type, no need to `this`)
+ */
+var toStr = Object.prototype.toString;
+function isCallable$2(fn) {
+  return typeof fn === "function" || toStr.call(fn) === "[object Function]";
+}
+function toInteger(value) {
+  var number = Number(value);
+  if (isNaN(number)) {
+    return 0;
+  }
+  if (number === 0 || !isFinite(number)) {
+    return number;
+  }
+  return (number > 0 ? 1 : -1) * Math.floor(Math.abs(number));
+}
+var maxSafeInteger = Math.pow(2, 53) - 1;
+function toLength$2(value) {
+  var len = toInteger(value);
+  return Math.min(Math.max(len, 0), maxSafeInteger);
+}
+/**
+ * Creates an array from an iterable object.
+ * @param iterable An iterable object to convert to an array.
+ */
+
+/**
+ * Creates an array from an iterable object.
+ * @param iterable An iterable object to convert to an array.
+ * @param mapfn A mapping function to call on every element of the array.
+ * @param thisArg Value of 'this' used to invoke the mapfn.
+ */
+function arrayFrom$1(arrayLike, mapFn) {
+  // 1. Let C be the this value.
+  // edit(@eps1lon): we're not calling it as Array.from
+  var C = Array;
+
+  // 2. Let items be ToObject(arrayLike).
+  var items = Object(arrayLike);
+
+  // 3. ReturnIfAbrupt(items).
+  if (arrayLike == null) {
+    throw new TypeError("Array.from requires an array-like object - not null or undefined");
+  }
+
+  // 4. If mapfn is undefined, then let mapping be false.
+  // const mapFn = arguments.length > 1 ? arguments[1] : void undefined;
+
+  if (typeof mapFn !== "undefined") {
+    // 5. else
+    // 5. a If IsCallable(mapfn) is false, throw a TypeError exception.
+    if (!isCallable$2(mapFn)) {
+      throw new TypeError("Array.from: when provided, the second argument must be a function");
+    }
+  }
+
+  // 10. Let lenValue be Get(items, "length").
+  // 11. Let len be ToLength(lenValue).
+  var len = toLength$2(items.length);
+
+  // 13. If IsConstructor(C) is true, then
+  // 13. a. Let A be the result of calling the [[Construct]] internal method
+  // of C with an argument list containing the single item len.
+  // 14. a. Else, Let A be ArrayCreate(len).
+  var A = isCallable$2(C) ? Object(new C(len)) : new Array(len);
+
+  // 16. Let k be 0.
+  var k = 0;
+  // 17. Repeat, while k < len… (also steps a - h)
+  var kValue;
+  while (k < len) {
+    kValue = items[k];
+    if (mapFn) {
+      A[k] = mapFn(kValue, k);
+    } else {
+      A[k] = kValue;
+    }
+    k += 1;
+  }
+  // 18. Let putStatus be Put(A, "length", len, true).
+  A.length = len;
+  // 20. Return A.
+  return A;
+}
+
+function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, _toPropertyKey(descriptor.key), descriptor); } }
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
+function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return _typeof(key) === "symbol" ? key : String(key); }
+function _toPrimitive(input, hint) { if (_typeof(input) !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (_typeof(res) !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+// for environments without Set we fallback to arrays with unique members
+var SetLike = /*#__PURE__*/function () {
+  function SetLike() {
+    var items = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
+    _classCallCheck(this, SetLike);
+    _defineProperty(this, "items", void 0);
+    this.items = items;
+  }
+  _createClass(SetLike, [{
+    key: "add",
+    value: function add(value) {
+      if (this.has(value) === false) {
+        this.items.push(value);
+      }
+      return this;
+    }
+  }, {
+    key: "clear",
+    value: function clear() {
+      this.items = [];
+    }
+  }, {
+    key: "delete",
+    value: function _delete(value) {
+      var previousLength = this.items.length;
+      this.items = this.items.filter(function (item) {
+        return item !== value;
+      });
+      return previousLength !== this.items.length;
+    }
+  }, {
+    key: "forEach",
+    value: function forEach(callbackfn) {
+      var _this = this;
+      this.items.forEach(function (item) {
+        callbackfn(item, item, _this);
+      });
+    }
+  }, {
+    key: "has",
+    value: function has(value) {
+      return this.items.indexOf(value) !== -1;
+    }
+  }, {
+    key: "size",
+    get: function get() {
+      return this.items.length;
+    }
+  }]);
+  return SetLike;
+}();
+var SetLike$1 = typeof Set === "undefined" ? Set : SetLike;
+
+// https://w3c.github.io/html-aria/#document-conformance-requirements-for-use-of-aria-attributes-in-html
+
+/**
+ * Safe Element.localName for all supported environments
+ * @param element
+ */
+function getLocalName(element) {
+  var _element$localName;
+  return (// eslint-disable-next-line no-restricted-properties -- actual guard for environments without localName
+    (_element$localName = element.localName) !== null && _element$localName !== void 0 ? _element$localName :
+    // eslint-disable-next-line no-restricted-properties -- required for the fallback
+    element.tagName.toLowerCase()
+  );
+}
+var localNameToRoleMappings = {
+  article: "article",
+  aside: "complementary",
+  button: "button",
+  datalist: "listbox",
+  dd: "definition",
+  details: "group",
+  dialog: "dialog",
+  dt: "term",
+  fieldset: "group",
+  figure: "figure",
+  // WARNING: Only with an accessible name
+  form: "form",
+  footer: "contentinfo",
+  h1: "heading",
+  h2: "heading",
+  h3: "heading",
+  h4: "heading",
+  h5: "heading",
+  h6: "heading",
+  header: "banner",
+  hr: "separator",
+  html: "document",
+  legend: "legend",
+  li: "listitem",
+  math: "math",
+  main: "main",
+  menu: "list",
+  nav: "navigation",
+  ol: "list",
+  optgroup: "group",
+  // WARNING: Only in certain context
+  option: "option",
+  output: "status",
+  progress: "progressbar",
+  // WARNING: Only with an accessible name
+  section: "region",
+  summary: "button",
+  table: "table",
+  tbody: "rowgroup",
+  textarea: "textbox",
+  tfoot: "rowgroup",
+  // WARNING: Only in certain context
+  td: "cell",
+  th: "columnheader",
+  thead: "rowgroup",
+  tr: "row",
+  ul: "list"
+};
+var prohibitedAttributes = {
+  caption: new Set(["aria-label", "aria-labelledby"]),
+  code: new Set(["aria-label", "aria-labelledby"]),
+  deletion: new Set(["aria-label", "aria-labelledby"]),
+  emphasis: new Set(["aria-label", "aria-labelledby"]),
+  generic: new Set(["aria-label", "aria-labelledby", "aria-roledescription"]),
+  insertion: new Set(["aria-label", "aria-labelledby"]),
+  paragraph: new Set(["aria-label", "aria-labelledby"]),
+  presentation: new Set(["aria-label", "aria-labelledby"]),
+  strong: new Set(["aria-label", "aria-labelledby"]),
+  subscript: new Set(["aria-label", "aria-labelledby"]),
+  superscript: new Set(["aria-label", "aria-labelledby"])
+};
+
+/**
+ *
+ * @param element
+ * @param role The role used for this element. This is specified to control whether you want to use the implicit or explicit role.
+ */
+function hasGlobalAriaAttributes(element, role) {
+  // https://rawgit.com/w3c/aria/stable/#global_states
+  // commented attributes are deprecated
+  return ["aria-atomic", "aria-busy", "aria-controls", "aria-current", "aria-describedby", "aria-details",
+  // "disabled",
+  "aria-dropeffect",
+  // "errormessage",
+  "aria-flowto", "aria-grabbed",
+  // "haspopup",
+  "aria-hidden",
+  // "invalid",
+  "aria-keyshortcuts", "aria-label", "aria-labelledby", "aria-live", "aria-owns", "aria-relevant", "aria-roledescription"].some(function (attributeName) {
+    var _prohibitedAttributes;
+    return element.hasAttribute(attributeName) && !((_prohibitedAttributes = prohibitedAttributes[role]) !== null && _prohibitedAttributes !== void 0 && _prohibitedAttributes.has(attributeName));
+  });
+}
+function ignorePresentationalRole(element, implicitRole) {
+  // https://rawgit.com/w3c/aria/stable/#conflict_resolution_presentation_none
+  return hasGlobalAriaAttributes(element, implicitRole);
+}
+function getRole(element) {
+  var explicitRole = getExplicitRole(element);
+  if (explicitRole === null || explicitRole === "presentation") {
+    var implicitRole = getImplicitRole(element);
+    if (explicitRole !== "presentation" || ignorePresentationalRole(element, implicitRole || "")) {
+      return implicitRole;
+    }
+  }
+  return explicitRole;
+}
+function getImplicitRole(element) {
+  var mappedByTag = localNameToRoleMappings[getLocalName(element)];
+  if (mappedByTag !== undefined) {
+    return mappedByTag;
+  }
+  switch (getLocalName(element)) {
+    case "a":
+    case "area":
+    case "link":
+      if (element.hasAttribute("href")) {
+        return "link";
+      }
+      break;
+    case "img":
+      if (element.getAttribute("alt") === "" && !ignorePresentationalRole(element, "img")) {
+        return "presentation";
+      }
+      return "img";
+    case "input":
+      {
+        var _ref = element,
+          type = _ref.type;
+        switch (type) {
+          case "button":
+          case "image":
+          case "reset":
+          case "submit":
+            return "button";
+          case "checkbox":
+          case "radio":
+            return type;
+          case "range":
+            return "slider";
+          case "email":
+          case "tel":
+          case "text":
+          case "url":
+            if (element.hasAttribute("list")) {
+              return "combobox";
+            }
+            return "textbox";
+          case "search":
+            if (element.hasAttribute("list")) {
+              return "combobox";
+            }
+            return "searchbox";
+          case "number":
+            return "spinbutton";
+          default:
+            return null;
+        }
+      }
+    case "select":
+      if (element.hasAttribute("multiple") || element.size > 1) {
+        return "listbox";
+      }
+      return "combobox";
+  }
+  return null;
+}
+function getExplicitRole(element) {
+  var role = element.getAttribute("role");
+  if (role !== null) {
+    var explicitRole = role.trim().split(" ")[0];
+    // String.prototype.split(sep, limit) will always return an array with at least one member
+    // as long as limit is either undefined or > 0
+    if (explicitRole.length > 0) {
+      return explicitRole;
+    }
+  }
+  return null;
+}
+
+function isElement(node) {
+  return node !== null && node.nodeType === node.ELEMENT_NODE;
+}
+function isHTMLTableCaptionElement(node) {
+  return isElement(node) && getLocalName(node) === "caption";
+}
+function isHTMLInputElement(node) {
+  return isElement(node) && getLocalName(node) === "input";
+}
+function isHTMLOptGroupElement(node) {
+  return isElement(node) && getLocalName(node) === "optgroup";
+}
+function isHTMLSelectElement(node) {
+  return isElement(node) && getLocalName(node) === "select";
+}
+function isHTMLTableElement(node) {
+  return isElement(node) && getLocalName(node) === "table";
+}
+function isHTMLTextAreaElement(node) {
+  return isElement(node) && getLocalName(node) === "textarea";
+}
+function safeWindow(node) {
+  var _ref = node.ownerDocument === null ? node : node.ownerDocument,
+    defaultView = _ref.defaultView;
+  if (defaultView === null) {
+    throw new TypeError("no window available");
+  }
+  return defaultView;
+}
+function isHTMLFieldSetElement(node) {
+  return isElement(node) && getLocalName(node) === "fieldset";
+}
+function isHTMLLegendElement(node) {
+  return isElement(node) && getLocalName(node) === "legend";
+}
+function isHTMLSlotElement(node) {
+  return isElement(node) && getLocalName(node) === "slot";
+}
+function isSVGElement(node) {
+  return isElement(node) && node.ownerSVGElement !== undefined;
+}
+function isSVGSVGElement(node) {
+  return isElement(node) && getLocalName(node) === "svg";
+}
+function isSVGTitleElement(node) {
+  return isSVGElement(node) && getLocalName(node) === "title";
+}
+
+/**
+ *
+ * @param {Node} node -
+ * @param {string} attributeName -
+ * @returns {Element[]} -
+ */
+function queryIdRefs(node, attributeName) {
+  if (isElement(node) && node.hasAttribute(attributeName)) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- safe due to hasAttribute check
+    var ids = node.getAttribute(attributeName).split(" ");
+
+    // Browsers that don't support shadow DOM won't have getRootNode
+    var root = node.getRootNode ? node.getRootNode() : node.ownerDocument;
+    return ids.map(function (id) {
+      return root.getElementById(id);
+    }).filter(function (element) {
+      return element !== null;
+    }
+    // TODO: why does this not narrow?
+    );
+  }
+
+  return [];
+}
+function hasAnyConcreteRoles(node, roles) {
+  if (isElement(node)) {
+    return roles.indexOf(getRole(node)) !== -1;
+  }
+  return false;
+}
+
+/**
+ * implements https://w3c.github.io/accname/
+ */
+
+/**
+ *  A string of characters where all carriage returns, newlines, tabs, and form-feeds are replaced with a single space, and multiple spaces are reduced to a single space. The string contains only character data; it does not contain any markup.
+ */
+
+/**
+ *
+ * @param {string} string -
+ * @returns {FlatString} -
+ */
+function asFlatString(s) {
+  return s.trim().replace(/\s\s+/g, " ");
+}
+
+/**
+ *
+ * @param node -
+ * @param options - These are not optional to prevent accidentally calling it without options in `computeAccessibleName`
+ * @returns {boolean} -
+ */
+function isHidden(node, getComputedStyleImplementation) {
+  if (!isElement(node)) {
+    return false;
+  }
+  if (node.hasAttribute("hidden") || node.getAttribute("aria-hidden") === "true") {
+    return true;
+  }
+  var style = getComputedStyleImplementation(node);
+  return style.getPropertyValue("display") === "none" || style.getPropertyValue("visibility") === "hidden";
+}
+
+/**
+ * @param {Node} node -
+ * @returns {boolean} - As defined in step 2E of https://w3c.github.io/accname/#mapping_additional_nd_te
+ */
+function isControl(node) {
+  return hasAnyConcreteRoles(node, ["button", "combobox", "listbox", "textbox"]) || hasAbstractRole(node, "range");
+}
+function hasAbstractRole(node, role) {
+  if (!isElement(node)) {
+    return false;
+  }
+  switch (role) {
+    case "range":
+      return hasAnyConcreteRoles(node, ["meter", "progressbar", "scrollbar", "slider", "spinbutton"]);
+    default:
+      throw new TypeError("No knowledge about abstract role '".concat(role, "'. This is likely a bug :("));
+  }
+}
+
+/**
+ * element.querySelectorAll but also considers owned tree
+ * @param element
+ * @param selectors
+ */
+function querySelectorAllSubtree(element, selectors) {
+  var elements = arrayFrom$1(element.querySelectorAll(selectors));
+  queryIdRefs(element, "aria-owns").forEach(function (root) {
+    // babel transpiles this assuming an iterator
+    elements.push.apply(elements, arrayFrom$1(root.querySelectorAll(selectors)));
+  });
+  return elements;
+}
+function querySelectedOptions(listbox) {
+  if (isHTMLSelectElement(listbox)) {
+    // IE11 polyfill
+    return listbox.selectedOptions || querySelectorAllSubtree(listbox, "[selected]");
+  }
+  return querySelectorAllSubtree(listbox, '[aria-selected="true"]');
+}
+function isMarkedPresentational(node) {
+  return hasAnyConcreteRoles(node, ["none", "presentation"]);
+}
+
+/**
+ * Elements specifically listed in html-aam
+ *
+ * We don't need this for `label` or `legend` elements.
+ * Their implicit roles already allow "naming from content".
+ *
+ * sources:
+ *
+ * - https://w3c.github.io/html-aam/#table-element
+ */
+function isNativeHostLanguageTextAlternativeElement(node) {
+  return isHTMLTableCaptionElement(node);
+}
+
+/**
+ * https://w3c.github.io/aria/#namefromcontent
+ */
+function allowsNameFromContent(node) {
+  return hasAnyConcreteRoles(node, ["button", "cell", "checkbox", "columnheader", "gridcell", "heading", "label", "legend", "link", "menuitem", "menuitemcheckbox", "menuitemradio", "option", "radio", "row", "rowheader", "switch", "tab", "tooltip", "treeitem"]);
+}
+
+/**
+ * TODO https://github.com/eps1lon/dom-accessibility-api/issues/100
+ */
+function isDescendantOfNativeHostLanguageTextAlternativeElement(
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- not implemented yet
+node) {
+  return false;
+}
+function getValueOfTextbox(element) {
+  if (isHTMLInputElement(element) || isHTMLTextAreaElement(element)) {
+    return element.value;
+  }
+  // https://github.com/eps1lon/dom-accessibility-api/issues/4
+  return element.textContent || "";
+}
+function getTextualContent(declaration) {
+  var content = declaration.getPropertyValue("content");
+  if (/^["'].*["']$/.test(content)) {
+    return content.slice(1, -1);
+  }
+  return "";
+}
+
+/**
+ * https://html.spec.whatwg.org/multipage/forms.html#category-label
+ * TODO: form-associated custom elements
+ * @param element
+ */
+function isLabelableElement(element) {
+  var localName = getLocalName(element);
+  return localName === "button" || localName === "input" && element.getAttribute("type") !== "hidden" || localName === "meter" || localName === "output" || localName === "progress" || localName === "select" || localName === "textarea";
+}
+
+/**
+ * > [...], then the first such descendant in tree order is the label element's labeled control.
+ * -- https://html.spec.whatwg.org/multipage/forms.html#labeled-control
+ * @param element
+ */
+function findLabelableElement(element) {
+  if (isLabelableElement(element)) {
+    return element;
+  }
+  var labelableElement = null;
+  element.childNodes.forEach(function (childNode) {
+    if (labelableElement === null && isElement(childNode)) {
+      var descendantLabelableElement = findLabelableElement(childNode);
+      if (descendantLabelableElement !== null) {
+        labelableElement = descendantLabelableElement;
+      }
+    }
+  });
+  return labelableElement;
+}
+
+/**
+ * Polyfill of HTMLLabelElement.control
+ * https://html.spec.whatwg.org/multipage/forms.html#labeled-control
+ * @param label
+ */
+function getControlOfLabel(label) {
+  if (label.control !== undefined) {
+    return label.control;
+  }
+  var htmlFor = label.getAttribute("for");
+  if (htmlFor !== null) {
+    return label.ownerDocument.getElementById(htmlFor);
+  }
+  return findLabelableElement(label);
+}
+
+/**
+ * Polyfill of HTMLInputElement.labels
+ * https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/labels
+ * @param element
+ */
+function getLabels$1(element) {
+  var labelsProperty = element.labels;
+  if (labelsProperty === null) {
+    return labelsProperty;
+  }
+  if (labelsProperty !== undefined) {
+    return arrayFrom$1(labelsProperty);
+  }
+
+  // polyfill
+  if (!isLabelableElement(element)) {
+    return null;
+  }
+  var document = element.ownerDocument;
+  return arrayFrom$1(document.querySelectorAll("label")).filter(function (label) {
+    return getControlOfLabel(label) === element;
+  });
+}
+
+/**
+ * Gets the contents of a slot used for computing the accname
+ * @param slot
+ */
+function getSlotContents(slot) {
+  // Computing the accessible name for elements containing slots is not
+  // currently defined in the spec. This implementation reflects the
+  // behavior of NVDA 2020.2/Firefox 81 and iOS VoiceOver/Safari 13.6.
+  var assignedNodes = slot.assignedNodes();
+  if (assignedNodes.length === 0) {
+    // if no nodes are assigned to the slot, it displays the default content
+    return arrayFrom$1(slot.childNodes);
+  }
+  return assignedNodes;
+}
+
+/**
+ * implements https://w3c.github.io/accname/#mapping_additional_nd_te
+ * @param root
+ * @param options
+ * @returns
+ */
+function computeTextAlternative(root) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  var consultedNodes = new SetLike$1();
+  var window = safeWindow(root);
+  var _options$compute = options.compute,
+    compute = _options$compute === void 0 ? "name" : _options$compute,
+    _options$computedStyl = options.computedStyleSupportsPseudoElements,
+    computedStyleSupportsPseudoElements = _options$computedStyl === void 0 ? options.getComputedStyle !== undefined : _options$computedStyl,
+    _options$getComputedS = options.getComputedStyle,
+    getComputedStyle = _options$getComputedS === void 0 ? window.getComputedStyle.bind(window) : _options$getComputedS,
+    _options$hidden = options.hidden,
+    hidden = _options$hidden === void 0 ? false : _options$hidden;
+
+  // 2F.i
+  function computeMiscTextAlternative(node, context) {
+    var accumulatedText = "";
+    if (isElement(node) && computedStyleSupportsPseudoElements) {
+      var pseudoBefore = getComputedStyle(node, "::before");
+      var beforeContent = getTextualContent(pseudoBefore);
+      accumulatedText = "".concat(beforeContent, " ").concat(accumulatedText);
+    }
+
+    // FIXME: Including aria-owns is not defined in the spec
+    // But it is required in the web-platform-test
+    var childNodes = isHTMLSlotElement(node) ? getSlotContents(node) : arrayFrom$1(node.childNodes).concat(queryIdRefs(node, "aria-owns"));
+    childNodes.forEach(function (child) {
+      var result = computeTextAlternative(child, {
+        isEmbeddedInLabel: context.isEmbeddedInLabel,
+        isReferenced: false,
+        recursion: true
+      });
+      // TODO: Unclear why display affects delimiter
+      // see https://github.com/w3c/accname/issues/3
+      var display = isElement(child) ? getComputedStyle(child).getPropertyValue("display") : "inline";
+      var separator = display !== "inline" ? " " : "";
+      // trailing separator for wpt tests
+      accumulatedText += "".concat(separator).concat(result).concat(separator);
+    });
+    if (isElement(node) && computedStyleSupportsPseudoElements) {
+      var pseudoAfter = getComputedStyle(node, "::after");
+      var afterContent = getTextualContent(pseudoAfter);
+      accumulatedText = "".concat(accumulatedText, " ").concat(afterContent);
+    }
+    return accumulatedText.trim();
+  }
+
+  /**
+   *
+   * @param element
+   * @param attributeName
+   * @returns A string non-empty string or `null`
+   */
+  function useAttribute(element, attributeName) {
+    var attribute = element.getAttributeNode(attributeName);
+    if (attribute !== null && !consultedNodes.has(attribute) && attribute.value.trim() !== "") {
+      consultedNodes.add(attribute);
+      return attribute.value;
+    }
+    return null;
+  }
+  function computeTooltipAttributeValue(node) {
+    if (!isElement(node)) {
+      return null;
+    }
+    return useAttribute(node, "title");
+  }
+  function computeElementTextAlternative(node) {
+    if (!isElement(node)) {
+      return null;
+    }
+
+    // https://w3c.github.io/html-aam/#fieldset-and-legend-elements
+    if (isHTMLFieldSetElement(node)) {
+      consultedNodes.add(node);
+      var children = arrayFrom$1(node.childNodes);
+      for (var i = 0; i < children.length; i += 1) {
+        var child = children[i];
+        if (isHTMLLegendElement(child)) {
+          return computeTextAlternative(child, {
+            isEmbeddedInLabel: false,
+            isReferenced: false,
+            recursion: false
+          });
+        }
+      }
+    } else if (isHTMLTableElement(node)) {
+      // https://w3c.github.io/html-aam/#table-element
+      consultedNodes.add(node);
+      var _children = arrayFrom$1(node.childNodes);
+      for (var _i = 0; _i < _children.length; _i += 1) {
+        var _child = _children[_i];
+        if (isHTMLTableCaptionElement(_child)) {
+          return computeTextAlternative(_child, {
+            isEmbeddedInLabel: false,
+            isReferenced: false,
+            recursion: false
+          });
+        }
+      }
+    } else if (isSVGSVGElement(node)) {
+      // https://www.w3.org/TR/svg-aam-1.0/
+      consultedNodes.add(node);
+      var _children2 = arrayFrom$1(node.childNodes);
+      for (var _i2 = 0; _i2 < _children2.length; _i2 += 1) {
+        var _child2 = _children2[_i2];
+        if (isSVGTitleElement(_child2)) {
+          return _child2.textContent;
+        }
+      }
+      return null;
+    } else if (getLocalName(node) === "img" || getLocalName(node) === "area") {
+      // https://w3c.github.io/html-aam/#area-element
+      // https://w3c.github.io/html-aam/#img-element
+      var nameFromAlt = useAttribute(node, "alt");
+      if (nameFromAlt !== null) {
+        return nameFromAlt;
+      }
+    } else if (isHTMLOptGroupElement(node)) {
+      var nameFromLabel = useAttribute(node, "label");
+      if (nameFromLabel !== null) {
+        return nameFromLabel;
+      }
+    }
+    if (isHTMLInputElement(node) && (node.type === "button" || node.type === "submit" || node.type === "reset")) {
+      // https://w3c.github.io/html-aam/#input-type-text-input-type-password-input-type-search-input-type-tel-input-type-email-input-type-url-and-textarea-element-accessible-description-computation
+      var nameFromValue = useAttribute(node, "value");
+      if (nameFromValue !== null) {
+        return nameFromValue;
+      }
+
+      // TODO: l10n
+      if (node.type === "submit") {
+        return "Submit";
+      }
+      // TODO: l10n
+      if (node.type === "reset") {
+        return "Reset";
+      }
+    }
+    var labels = getLabels$1(node);
+    if (labels !== null && labels.length !== 0) {
+      consultedNodes.add(node);
+      return arrayFrom$1(labels).map(function (element) {
+        return computeTextAlternative(element, {
+          isEmbeddedInLabel: true,
+          isReferenced: false,
+          recursion: true
+        });
+      }).filter(function (label) {
+        return label.length > 0;
+      }).join(" ");
+    }
+
+    // https://w3c.github.io/html-aam/#input-type-image-accessible-name-computation
+    // TODO: wpt test consider label elements but html-aam does not mention them
+    // We follow existing implementations over spec
+    if (isHTMLInputElement(node) && node.type === "image") {
+      var _nameFromAlt = useAttribute(node, "alt");
+      if (_nameFromAlt !== null) {
+        return _nameFromAlt;
+      }
+      var nameFromTitle = useAttribute(node, "title");
+      if (nameFromTitle !== null) {
+        return nameFromTitle;
+      }
+
+      // TODO: l10n
+      return "Submit Query";
+    }
+    if (hasAnyConcreteRoles(node, ["button"])) {
+      // https://www.w3.org/TR/html-aam-1.0/#button-element
+      var nameFromSubTree = computeMiscTextAlternative(node, {
+        isEmbeddedInLabel: false,
+        isReferenced: false
+      });
+      if (nameFromSubTree !== "") {
+        return nameFromSubTree;
+      }
+    }
+    return null;
+  }
+  function computeTextAlternative(current, context) {
+    if (consultedNodes.has(current)) {
+      return "";
+    }
+
+    // 2A
+    if (!hidden && isHidden(current, getComputedStyle) && !context.isReferenced) {
+      consultedNodes.add(current);
+      return "";
+    }
+
+    // 2B
+    var labelAttributeNode = isElement(current) ? current.getAttributeNode("aria-labelledby") : null;
+    // TODO: Do we generally need to block query IdRefs of attributes we have already consulted?
+    var labelElements = labelAttributeNode !== null && !consultedNodes.has(labelAttributeNode) ? queryIdRefs(current, "aria-labelledby") : [];
+    if (compute === "name" && !context.isReferenced && labelElements.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Can't be null here otherwise labelElements would be empty
+      consultedNodes.add(labelAttributeNode);
+      return labelElements.map(function (element) {
+        // TODO: Chrome will consider repeated values i.e. use a node multiple times while we'll bail out in computeTextAlternative.
+        return computeTextAlternative(element, {
+          isEmbeddedInLabel: context.isEmbeddedInLabel,
+          isReferenced: true,
+          // this isn't recursion as specified, otherwise we would skip
+          // `aria-label` in
+          // <input id="myself" aria-label="foo" aria-labelledby="myself"
+          recursion: false
+        });
+      }).join(" ");
+    }
+
+    // 2C
+    // Changed from the spec in anticipation of https://github.com/w3c/accname/issues/64
+    // spec says we should only consider skipping if we have a non-empty label
+    var skipToStep2E = context.recursion && isControl(current) && compute === "name";
+    if (!skipToStep2E) {
+      var ariaLabel = (isElement(current) && current.getAttribute("aria-label") || "").trim();
+      if (ariaLabel !== "" && compute === "name") {
+        consultedNodes.add(current);
+        return ariaLabel;
+      }
+
+      // 2D
+      if (!isMarkedPresentational(current)) {
+        var elementTextAlternative = computeElementTextAlternative(current);
+        if (elementTextAlternative !== null) {
+          consultedNodes.add(current);
+          return elementTextAlternative;
+        }
+      }
+    }
+
+    // special casing, cheating to make tests pass
+    // https://github.com/w3c/accname/issues/67
+    if (hasAnyConcreteRoles(current, ["menu"])) {
+      consultedNodes.add(current);
+      return "";
+    }
+
+    // 2E
+    if (skipToStep2E || context.isEmbeddedInLabel || context.isReferenced) {
+      if (hasAnyConcreteRoles(current, ["combobox", "listbox"])) {
+        consultedNodes.add(current);
+        var selectedOptions = querySelectedOptions(current);
+        if (selectedOptions.length === 0) {
+          // defined per test `name_heading_combobox`
+          return isHTMLInputElement(current) ? current.value : "";
+        }
+        return arrayFrom$1(selectedOptions).map(function (selectedOption) {
+          return computeTextAlternative(selectedOption, {
+            isEmbeddedInLabel: context.isEmbeddedInLabel,
+            isReferenced: false,
+            recursion: true
+          });
+        }).join(" ");
+      }
+      if (hasAbstractRole(current, "range")) {
+        consultedNodes.add(current);
+        if (current.hasAttribute("aria-valuetext")) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- safe due to hasAttribute guard
+          return current.getAttribute("aria-valuetext");
+        }
+        if (current.hasAttribute("aria-valuenow")) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- safe due to hasAttribute guard
+          return current.getAttribute("aria-valuenow");
+        }
+        // Otherwise, use the value as specified by a host language attribute.
+        return current.getAttribute("value") || "";
+      }
+      if (hasAnyConcreteRoles(current, ["textbox"])) {
+        consultedNodes.add(current);
+        return getValueOfTextbox(current);
+      }
+    }
+
+    // 2F: https://w3c.github.io/accname/#step2F
+    if (allowsNameFromContent(current) || isElement(current) && context.isReferenced || isNativeHostLanguageTextAlternativeElement(current) || isDescendantOfNativeHostLanguageTextAlternativeElement()) {
+      var accumulatedText2F = computeMiscTextAlternative(current, {
+        isEmbeddedInLabel: context.isEmbeddedInLabel,
+        isReferenced: false
+      });
+      if (accumulatedText2F !== "") {
+        consultedNodes.add(current);
+        return accumulatedText2F;
+      }
+    }
+    if (current.nodeType === current.TEXT_NODE) {
+      consultedNodes.add(current);
+      return current.textContent || "";
+    }
+    if (context.recursion) {
+      consultedNodes.add(current);
+      return computeMiscTextAlternative(current, {
+        isEmbeddedInLabel: context.isEmbeddedInLabel,
+        isReferenced: false
+      });
+    }
+    var tooltipAttributeValue = computeTooltipAttributeValue(current);
+    if (tooltipAttributeValue !== null) {
+      consultedNodes.add(current);
+      return tooltipAttributeValue;
+    }
+
+    // TODO should this be reachable?
+    consultedNodes.add(current);
+    return "";
+  }
+  return asFlatString(computeTextAlternative(root, {
+    isEmbeddedInLabel: false,
+    // by spec computeAccessibleDescription starts with the referenced elements as roots
+    isReferenced: compute === "description",
+    recursion: false
+  }));
+}
+
+/**
+ * https://w3c.github.io/aria/#namefromprohibited
+ */
+function prohibitsNaming(node) {
+  return hasAnyConcreteRoles(node, ["caption", "code", "deletion", "emphasis", "generic", "insertion", "paragraph", "presentation", "strong", "subscript", "superscript"]);
+}
+
+/**
+ * implements https://w3c.github.io/accname/#mapping_additional_nd_name
+ * @param root
+ * @param options
+ * @returns
+ */
+function computeAccessibleName(root) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  if (prohibitsNaming(root)) {
+    return "";
+  }
+  return computeTextAlternative(root, options);
+}
+
+var interopRequireDefault = createCommonjsModule(function (module) {
+function _interopRequireDefault(e) {
+  return e && e.__esModule ? e : {
+    "default": e
+  };
+}
+module.exports = _interopRequireDefault, module.exports.__esModule = true, module.exports["default"] = module.exports;
+});
+
+var check = function (it) {
+  return it && it.Math === Math && it;
+};
+
+// https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
+var globalThis_1 =
+  // eslint-disable-next-line es/no-global-this -- safe
+  check(typeof globalThis == 'object' && globalThis) ||
+  check(typeof window == 'object' && window) ||
+  // eslint-disable-next-line no-restricted-globals -- safe
+  check(typeof self == 'object' && self) ||
+  check(typeof global$1 == 'object' && global$1) ||
+  check(typeof undefined == 'object' && undefined) ||
+  // eslint-disable-next-line no-new-func -- fallback
+  (function () { return this; })() || Function('return this')();
+
+var fails$1 = function (exec) {
+  try {
+    return !!exec();
+  } catch (error) {
+    return true;
+  }
+};
+
+var fails = fails$1;
+
+var functionBindNative = !fails(function () {
+  // eslint-disable-next-line es/no-function-prototype-bind -- safe
+  var test = (function () { /* empty */ }).bind();
+  // eslint-disable-next-line no-prototype-builtins -- safe
+  return typeof test != 'function' || test.hasOwnProperty('prototype');
+});
+
+var NATIVE_BIND = functionBindNative;
+
+var FunctionPrototype$3 = Function.prototype;
+var apply$1 = FunctionPrototype$3.apply;
+var call$3 = FunctionPrototype$3.call;
+
+// eslint-disable-next-line es/no-function-prototype-bind, es/no-reflect -- safe
+var functionApply = typeof Reflect == 'object' && Reflect.apply || (NATIVE_BIND ? call$3.bind(apply$1) : function () {
+  return call$3.apply(apply$1, arguments);
+});
+
+var FunctionPrototype$2 = Function.prototype;
+var call$2 = FunctionPrototype$2.call;
+// eslint-disable-next-line es/no-function-prototype-bind -- safe
+var uncurryThisWithBind = NATIVE_BIND && FunctionPrototype$2.bind.bind(call$2, call$2);
+
+var functionUncurryThis = NATIVE_BIND ? uncurryThisWithBind : function (fn) {
+  return function () {
+    return call$2.apply(fn, arguments);
+  };
+};
+
+var uncurryThis$1 = functionUncurryThis;
+
+var toString$4 = uncurryThis$1({}.toString);
+var stringSlice$2 = uncurryThis$1(''.slice);
+
+var classofRaw = function (it) {
+  return stringSlice$2(toString$4(it), 8, -1);
+};
+
+var classof$2 = classofRaw;
+
+var functionUncurryThisClause = function (fn) {
+  // Nashorn bug:
+  //   https://github.com/zloirock/core-js/issues/1128
+  //   https://github.com/zloirock/core-js/issues/1130
+  if (classof$2(fn) === 'Function') return uncurryThis$1(fn);
+};
+
+// https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
+var documentAll = typeof document == 'object' && document.all;
+
+// `IsCallable` abstract operation
+// https://tc39.es/ecma262/#sec-iscallable
+// eslint-disable-next-line unicorn/no-typeof-undefined -- required for testing
+var isCallable$1 = typeof documentAll == 'undefined' && documentAll !== undefined ? function (argument) {
+  return typeof argument == 'function' || argument === documentAll;
+} : function (argument) {
+  return typeof argument == 'function';
+};
+
+// Detect IE8's incomplete defineProperty implementation
+var descriptors = !fails(function () {
+  // eslint-disable-next-line es/no-object-defineproperty -- required for testing
+  return Object.defineProperty({}, 1, { get: function () { return 7; } })[1] !== 7;
+});
+
+var call$1 = Function.prototype.call;
+// eslint-disable-next-line es/no-function-prototype-bind -- safe
+var functionCall = NATIVE_BIND ? call$1.bind(call$1) : function () {
+  return call$1.apply(call$1, arguments);
+};
+
+var $propertyIsEnumerable$1 = {}.propertyIsEnumerable;
+// eslint-disable-next-line es/no-object-getownpropertydescriptor -- safe
+var getOwnPropertyDescriptor$2 = Object.getOwnPropertyDescriptor;
+
+// Nashorn ~ JDK8 bug
+var NASHORN_BUG = getOwnPropertyDescriptor$2 && !$propertyIsEnumerable$1.call({ 1: 2 }, 1);
+
+// `Object.prototype.propertyIsEnumerable` method implementation
+// https://tc39.es/ecma262/#sec-object.prototype.propertyisenumerable
+var f$7 = NASHORN_BUG ? function propertyIsEnumerable(V) {
+  var descriptor = getOwnPropertyDescriptor$2(this, V);
+  return !!descriptor && descriptor.enumerable;
+} : $propertyIsEnumerable$1;
+
+var objectPropertyIsEnumerable = {
+	f: f$7
+};
+
+var createPropertyDescriptor$1 = function (bitmap, value) {
+  return {
+    enumerable: !(bitmap & 1),
+    configurable: !(bitmap & 2),
+    writable: !(bitmap & 4),
+    value: value
+  };
+};
+
+var $Object$4 = Object;
+var split = uncurryThis$1(''.split);
+
+// fallback for non-array-like ES3 and non-enumerable old V8 strings
+var indexedObject = fails(function () {
+  // throws an error in rhino, see https://github.com/mozilla/rhino/issues/346
+  // eslint-disable-next-line no-prototype-builtins -- safe
+  return !$Object$4('z').propertyIsEnumerable(0);
+}) ? function (it) {
+  return classof$2(it) === 'String' ? split(it, '') : $Object$4(it);
+} : $Object$4;
+
+// we can't use just `it == null` since of `document.all` special case
+// https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot-aec
+var isNullOrUndefined$1 = function (it) {
+  return it === null || it === undefined;
+};
+
+var isNullOrUndefined = isNullOrUndefined$1;
+
+var $TypeError$d = TypeError;
+
+// `RequireObjectCoercible` abstract operation
+// https://tc39.es/ecma262/#sec-requireobjectcoercible
+var requireObjectCoercible$1 = function (it) {
+  if (isNullOrUndefined(it)) throw new $TypeError$d("Can't call method on " + it);
+  return it;
+};
+
+var IndexedObject = indexedObject;
+
+var requireObjectCoercible = requireObjectCoercible$1;
+
+// toObject with fallback for non-array-like ES3 strings
+
+
+
+var toIndexedObject$1 = function (it) {
+  return IndexedObject(requireObjectCoercible(it));
+};
+
+var isCallable = isCallable$1;
+
+var isObject$1 = function (it) {
+  return typeof it == 'object' ? it !== null : isCallable(it);
+};
+
+var path$1 = {};
+
+var path = path$1;
+
+var globalThis$1 = globalThis_1;
+
+var aFunction = function (variable) {
+  return isCallable(variable) ? variable : undefined;
+};
+
+var getBuiltIn$1 = function (namespace, method) {
+  return arguments.length < 2 ? aFunction(path[namespace]) || aFunction(globalThis$1[namespace])
+    : path[namespace] && path[namespace][method] || globalThis$1[namespace] && globalThis$1[namespace][method];
+};
+
+var objectIsPrototypeOf = uncurryThis$1({}.isPrototypeOf);
+
+var navigator = globalThis$1.navigator;
+var userAgent$1 = navigator && navigator.userAgent;
+
+var environmentUserAgent = userAgent$1 ? String(userAgent$1) : '';
+
+var userAgent = environmentUserAgent;
+
+var process = globalThis$1.process;
+var Deno = globalThis$1.Deno;
+var versions = process && process.versions || Deno && Deno.version;
+var v8 = versions && versions.v8;
+var match, version;
+
+if (v8) {
+  match = v8.split('.');
+  // in old Chrome, versions of V8 isn't V8 = Chrome / 10
+  // but their correct versions are not interesting for us
+  version = match[0] > 0 && match[0] < 4 ? 1 : +(match[0] + match[1]);
+}
+
+// BrowserFS NodeJS `process` polyfill incorrectly set `.v8` to `0.0`
+// so check `userAgent` even if `.v8` exists, but 0
+if (!version && userAgent) {
+  match = userAgent.match(/Edge\/(\d+)/);
+  if (!match || match[1] >= 74) {
+    match = userAgent.match(/Chrome\/(\d+)/);
+    if (match) version = +match[1];
+  }
+}
+
+var environmentV8Version = version;
+
+var V8_VERSION = environmentV8Version;
+
+/* eslint-disable es/no-symbol -- required for testing */
+
+
+
+
+var $String$5 = globalThis$1.String;
+
+// eslint-disable-next-line es/no-object-getownpropertysymbols -- required for testing
+var symbolConstructorDetection = !!Object.getOwnPropertySymbols && !fails(function () {
+  var symbol = Symbol('symbol detection');
+  // Chrome 38 Symbol has incorrect toString conversion
+  // `get-own-property-symbols` polyfill symbols converted to object are not Symbol instances
+  // nb: Do not call `String` directly to avoid this being optimized out to `symbol+''` which will,
+  // of course, fail.
+  return !$String$5(symbol) || !(Object(symbol) instanceof Symbol) ||
+    // Chrome 38-40 symbols are not inherited from DOM collections prototypes to instances
+    !Symbol.sham && V8_VERSION && V8_VERSION < 41;
+});
+
+var NATIVE_SYMBOL = symbolConstructorDetection;
+
+/* eslint-disable es/no-symbol -- required for testing */
+
+
+var useSymbolAsUid = NATIVE_SYMBOL &&
+  !Symbol.sham &&
+  typeof Symbol.iterator == 'symbol';
+
+var getBuiltIn = getBuiltIn$1;
+
+var isPrototypeOf = objectIsPrototypeOf;
+
+var USE_SYMBOL_AS_UID = useSymbolAsUid;
+
+var $Object$3 = Object;
+
+var isSymbol$1 = USE_SYMBOL_AS_UID ? function (it) {
+  return typeof it == 'symbol';
+} : function (it) {
+  var $Symbol = getBuiltIn('Symbol');
+  return isCallable($Symbol) && isPrototypeOf($Symbol.prototype, $Object$3(it));
+};
+
+var $String$4 = String;
+
+var tryToString$1 = function (argument) {
+  try {
+    return $String$4(argument);
+  } catch (error) {
+    return 'Object';
+  }
+};
+
+var tryToString = tryToString$1;
+
+var $TypeError$c = TypeError;
+
+// `Assert: IsCallable(argument) is true`
+var aCallable$1 = function (argument) {
+  if (isCallable(argument)) return argument;
+  throw new $TypeError$c(tryToString(argument) + ' is not a function');
+};
+
+var aCallable = aCallable$1;
+
+// `GetMethod` abstract operation
+// https://tc39.es/ecma262/#sec-getmethod
+var getMethod$1 = function (V, P) {
+  var func = V[P];
+  return isNullOrUndefined(func) ? undefined : aCallable(func);
+};
+
+var call = functionCall;
+
+var isObject = isObject$1;
+
+var $TypeError$b = TypeError;
+
+// `OrdinaryToPrimitive` abstract operation
+// https://tc39.es/ecma262/#sec-ordinarytoprimitive
+var ordinaryToPrimitive$1 = function (input, pref) {
+  var fn, val;
+  if (pref === 'string' && isCallable(fn = input.toString) && !isObject(val = call(fn, input))) return val;
+  if (isCallable(fn = input.valueOf) && !isObject(val = call(fn, input))) return val;
+  if (pref !== 'string' && isCallable(fn = input.toString) && !isObject(val = call(fn, input))) return val;
+  throw new $TypeError$b("Can't convert object to primitive value");
+};
+
+var isPure = true;
+
+// eslint-disable-next-line es/no-object-defineproperty -- safe
+var defineProperty$d = Object.defineProperty;
+
+var defineGlobalProperty$1 = function (key, value) {
+  try {
+    defineProperty$d(globalThis$1, key, { value: value, configurable: true, writable: true });
+  } catch (error) {
+    globalThis$1[key] = value;
+  } return value;
+};
+
+var IS_PURE = isPure;
+
+var defineGlobalProperty = defineGlobalProperty$1;
+
+var sharedStore = createCommonjsModule(function (module) {
+
+
+
+
+var SHARED = '__core-js_shared__';
+var store = module.exports = globalThis$1[SHARED] || defineGlobalProperty(SHARED, {});
+
+(store.versions || (store.versions = [])).push({
+  version: '3.40.0',
+  mode: IS_PURE ? 'pure' : 'global',
+  copyright: '© 2014-2025 Denis Pushkarev (zloirock.ru)',
+  license: 'https://github.com/zloirock/core-js/blob/v3.40.0/LICENSE',
+  source: 'https://github.com/zloirock/core-js'
+});
+});
+
+var store$1 = sharedStore;
+
+var shared$2 = function (key, value) {
+  return store$1[key] || (store$1[key] = value || {});
+};
+
+var $Object$2 = Object;
+
+// `ToObject` abstract operation
+// https://tc39.es/ecma262/#sec-toobject
+var toObject$2 = function (argument) {
+  return $Object$2(requireObjectCoercible(argument));
+};
+
+var toObject$1 = toObject$2;
+
+var hasOwnProperty$1 = uncurryThis$1({}.hasOwnProperty);
+
+// `HasOwnProperty` abstract operation
+// https://tc39.es/ecma262/#sec-hasownproperty
+// eslint-disable-next-line es/no-object-hasown -- safe
+var hasOwnProperty_1 = Object.hasOwn || function hasOwn(it, key) {
+  return hasOwnProperty$1(toObject$1(it), key);
+};
+
+var id = 0;
+var postfix = Math.random();
+var toString$3 = uncurryThis$1(1.0.toString);
+
+var uid$1 = function (key) {
+  return 'Symbol(' + (key === undefined ? '' : key) + ')_' + toString$3(++id + postfix, 36);
+};
+
+var shared$1 = shared$2;
+
+var hasOwn = hasOwnProperty_1;
+
+var uid = uid$1;
+
+var Symbol$3 = globalThis$1.Symbol;
+var WellKnownSymbolsStore$2 = shared$1('wks');
+var createWellKnownSymbol = USE_SYMBOL_AS_UID ? Symbol$3['for'] || Symbol$3 : Symbol$3 && Symbol$3.withoutSetter || uid;
+
+var wellKnownSymbol$1 = function (name) {
+  if (!hasOwn(WellKnownSymbolsStore$2, name)) {
+    WellKnownSymbolsStore$2[name] = NATIVE_SYMBOL && hasOwn(Symbol$3, name)
+      ? Symbol$3[name]
+      : createWellKnownSymbol('Symbol.' + name);
+  } return WellKnownSymbolsStore$2[name];
+};
+
+var isSymbol = isSymbol$1;
+
+var getMethod = getMethod$1;
+
+var ordinaryToPrimitive = ordinaryToPrimitive$1;
+
+var wellKnownSymbol = wellKnownSymbol$1;
+
+var $TypeError$a = TypeError;
+var TO_PRIMITIVE = wellKnownSymbol('toPrimitive');
+
+// `ToPrimitive` abstract operation
+// https://tc39.es/ecma262/#sec-toprimitive
+var toPrimitive$6 = function (input, pref) {
+  if (!isObject(input) || isSymbol(input)) return input;
+  var exoticToPrim = getMethod(input, TO_PRIMITIVE);
+  var result;
+  if (exoticToPrim) {
+    if (pref === undefined) pref = 'default';
+    result = call(exoticToPrim, input, pref);
+    if (!isObject(result) || isSymbol(result)) return result;
+    throw new $TypeError$a("Can't convert object to primitive value");
+  }
+  if (pref === undefined) pref = 'number';
+  return ordinaryToPrimitive(input, pref);
+};
+
+var toPrimitive$5 = toPrimitive$6;
+
+// `ToPropertyKey` abstract operation
+// https://tc39.es/ecma262/#sec-topropertykey
+var toPropertyKey$1 = function (argument) {
+  var key = toPrimitive$5(argument, 'string');
+  return isSymbol(key) ? key : key + '';
+};
+
+var document$1 = globalThis$1.document;
+// typeof document.createElement is 'object' in old IE
+var EXISTS$1 = isObject(document$1) && isObject(document$1.createElement);
+
+var documentCreateElement$1 = function (it) {
+  return EXISTS$1 ? document$1.createElement(it) : {};
+};
+
+var DESCRIPTORS = descriptors;
+
+var documentCreateElement = documentCreateElement$1;
+
+// Thanks to IE8 for its funny defineProperty
+var ie8DomDefine = !DESCRIPTORS && !fails(function () {
+  // eslint-disable-next-line es/no-object-defineproperty -- required for testing
+  return Object.defineProperty(documentCreateElement('div'), 'a', {
+    get: function () { return 7; }
+  }).a !== 7;
+});
+
+var propertyIsEnumerableModule = objectPropertyIsEnumerable;
+
+var createPropertyDescriptor = createPropertyDescriptor$1;
+
+var toIndexedObject = toIndexedObject$1;
+
+var toPropertyKey = toPropertyKey$1;
+
+var IE8_DOM_DEFINE = ie8DomDefine;
+
+// eslint-disable-next-line es/no-object-getownpropertydescriptor -- safe
+var $getOwnPropertyDescriptor$2 = Object.getOwnPropertyDescriptor;
+
+// `Object.getOwnPropertyDescriptor` method
+// https://tc39.es/ecma262/#sec-object.getownpropertydescriptor
+var f$6 = DESCRIPTORS ? $getOwnPropertyDescriptor$2 : function getOwnPropertyDescriptor(O, P) {
+  O = toIndexedObject(O);
+  P = toPropertyKey(P);
+  if (IE8_DOM_DEFINE) try {
+    return $getOwnPropertyDescriptor$2(O, P);
+  } catch (error) { /* empty */ }
+  if (hasOwn(O, P)) return createPropertyDescriptor(!call(propertyIsEnumerableModule.f, O, P), O[P]);
+};
+
+var objectGetOwnPropertyDescriptor = {
+	f: f$6
+};
+
+var replacement = /#|\.prototype\./;
+
+var isForced$1 = function (feature, detection) {
+  var value = data[normalize$1(feature)];
+  return value === POLYFILL ? true
+    : value === NATIVE ? false
+    : isCallable(detection) ? fails(detection)
+    : !!detection;
+};
+
+var normalize$1 = isForced$1.normalize = function (string) {
+  return String(string).replace(replacement, '.').toLowerCase();
+};
+
+var data = isForced$1.data = {};
+var NATIVE = isForced$1.NATIVE = 'N';
+var POLYFILL = isForced$1.POLYFILL = 'P';
+
+var isForced_1 = isForced$1;
+
+var uncurryThis = functionUncurryThisClause;
+
+var bind$1 = uncurryThis(uncurryThis.bind);
+
+// optional / simple context binding
+var functionBindContext = function (fn, that) {
+  aCallable(fn);
+  return that === undefined ? fn : NATIVE_BIND ? bind$1(fn, that) : function (/* ...args */) {
+    return fn.apply(that, arguments);
+  };
+};
+
+// V8 ~ Chrome 36-
+// https://bugs.chromium.org/p/v8/issues/detail?id=3334
+var v8PrototypeDefineBug = DESCRIPTORS && fails(function () {
+  // eslint-disable-next-line es/no-object-defineproperty -- required for testing
+  return Object.defineProperty(function () { /* empty */ }, 'prototype', {
+    value: 42,
+    writable: false
+  }).prototype !== 42;
+});
+
+var $String$3 = String;
+var $TypeError$9 = TypeError;
+
+// `Assert: Type(argument) is Object`
+var anObject$1 = function (argument) {
+  if (isObject(argument)) return argument;
+  throw new $TypeError$9($String$3(argument) + ' is not an object');
+};
+
+var V8_PROTOTYPE_DEFINE_BUG = v8PrototypeDefineBug;
+
+var anObject = anObject$1;
+
+var $TypeError$8 = TypeError;
+// eslint-disable-next-line es/no-object-defineproperty -- safe
+var $defineProperty$1 = Object.defineProperty;
+// eslint-disable-next-line es/no-object-getownpropertydescriptor -- safe
+var $getOwnPropertyDescriptor$1 = Object.getOwnPropertyDescriptor;
+var ENUMERABLE = 'enumerable';
+var CONFIGURABLE$1 = 'configurable';
+var WRITABLE = 'writable';
+
+// `Object.defineProperty` method
+// https://tc39.es/ecma262/#sec-object.defineproperty
+var f$5 = DESCRIPTORS ? V8_PROTOTYPE_DEFINE_BUG ? function defineProperty(O, P, Attributes) {
+  anObject(O);
+  P = toPropertyKey(P);
+  anObject(Attributes);
+  if (typeof O === 'function' && P === 'prototype' && 'value' in Attributes && WRITABLE in Attributes && !Attributes[WRITABLE]) {
+    var current = $getOwnPropertyDescriptor$1(O, P);
+    if (current && current[WRITABLE]) {
+      O[P] = Attributes.value;
+      Attributes = {
+        configurable: CONFIGURABLE$1 in Attributes ? Attributes[CONFIGURABLE$1] : current[CONFIGURABLE$1],
+        enumerable: ENUMERABLE in Attributes ? Attributes[ENUMERABLE] : current[ENUMERABLE],
+        writable: false
+      };
+    }
+  } return $defineProperty$1(O, P, Attributes);
+} : $defineProperty$1 : function defineProperty(O, P, Attributes) {
+  anObject(O);
+  P = toPropertyKey(P);
+  anObject(Attributes);
+  if (IE8_DOM_DEFINE) try {
+    return $defineProperty$1(O, P, Attributes);
+  } catch (error) { /* empty */ }
+  if ('get' in Attributes || 'set' in Attributes) throw new $TypeError$8('Accessors not supported');
+  if ('value' in Attributes) O[P] = Attributes.value;
+  return O;
+};
+
+var objectDefineProperty = {
+	f: f$5
+};
+
+var require$$0$r = objectDefineProperty;
+
+var createNonEnumerableProperty$1 = DESCRIPTORS ? function (object, key, value) {
+  return require$$0$r.f(object, key, createPropertyDescriptor(1, value));
+} : function (object, key, value) {
+  object[key] = value;
+  return object;
+};
+
+var apply = functionApply;
+
+var getOwnPropertyDescriptorModule = objectGetOwnPropertyDescriptor;
+
+var isForced = isForced_1;
+
+var bind = functionBindContext;
+
+var createNonEnumerableProperty = createNonEnumerableProperty$1;
+
+var getOwnPropertyDescriptor$1 = getOwnPropertyDescriptorModule.f;
+
+
+
+
+
+// add debugging info
+
+
+var wrapConstructor = function (NativeConstructor) {
+  var Wrapper = function (a, b, c) {
+    if (this instanceof Wrapper) {
+      switch (arguments.length) {
+        case 0: return new NativeConstructor();
+        case 1: return new NativeConstructor(a);
+        case 2: return new NativeConstructor(a, b);
+      } return new NativeConstructor(a, b, c);
+    } return apply(NativeConstructor, this, arguments);
+  };
+  Wrapper.prototype = NativeConstructor.prototype;
+  return Wrapper;
+};
+
+/*
+  options.target         - name of the target object
+  options.global         - target is the global object
+  options.stat           - export as static methods of target
+  options.proto          - export as prototype methods of target
+  options.real           - real prototype method for the `pure` version
+  options.forced         - export even if the native feature is available
+  options.bind           - bind methods to the target, required for the `pure` version
+  options.wrap           - wrap constructors to preventing global pollution, required for the `pure` version
+  options.unsafe         - use the simple assignment of property instead of delete + defineProperty
+  options.sham           - add a flag to not completely full polyfills
+  options.enumerable     - export as enumerable property
+  options.dontCallGetSet - prevent calling a getter on target
+  options.name           - the .name of the function if it does not match the key
+*/
+var _export = function (options, source) {
+  var TARGET = options.target;
+  var GLOBAL = options.global;
+  var STATIC = options.stat;
+  var PROTO = options.proto;
+
+  var nativeSource = GLOBAL ? globalThis$1 : STATIC ? globalThis$1[TARGET] : globalThis$1[TARGET] && globalThis$1[TARGET].prototype;
+
+  var target = GLOBAL ? path : path[TARGET] || createNonEnumerableProperty(path, TARGET, {})[TARGET];
+  var targetPrototype = target.prototype;
+
+  var FORCED, USE_NATIVE, VIRTUAL_PROTOTYPE;
+  var key, sourceProperty, targetProperty, nativeProperty, resultProperty, descriptor;
+
+  for (key in source) {
+    FORCED = isForced(GLOBAL ? key : TARGET + (STATIC ? '.' : '#') + key, options.forced);
+    // contains in native
+    USE_NATIVE = !FORCED && nativeSource && hasOwn(nativeSource, key);
+
+    targetProperty = target[key];
+
+    if (USE_NATIVE) if (options.dontCallGetSet) {
+      descriptor = getOwnPropertyDescriptor$1(nativeSource, key);
+      nativeProperty = descriptor && descriptor.value;
+    } else nativeProperty = nativeSource[key];
+
+    // export native or implementation
+    sourceProperty = (USE_NATIVE && nativeProperty) ? nativeProperty : source[key];
+
+    if (!FORCED && !PROTO && typeof targetProperty == typeof sourceProperty) continue;
+
+    // bind methods to global for calling from export context
+    if (options.bind && USE_NATIVE) resultProperty = bind(sourceProperty, globalThis$1);
+    // wrap global constructors for prevent changes in this version
+    else if (options.wrap && USE_NATIVE) resultProperty = wrapConstructor(sourceProperty);
+    // make static versions for prototype methods
+    else if (PROTO && isCallable(sourceProperty)) resultProperty = uncurryThis(sourceProperty);
+    // default case
+    else resultProperty = sourceProperty;
+
+    // add a flag to not completely full polyfills
+    if (options.sham || (sourceProperty && sourceProperty.sham) || (targetProperty && targetProperty.sham)) {
+      createNonEnumerableProperty(resultProperty, 'sham', true);
+    }
+
+    createNonEnumerableProperty(target, key, resultProperty);
+
+    if (PROTO) {
+      VIRTUAL_PROTOTYPE = TARGET + 'Prototype';
+      if (!hasOwn(path, VIRTUAL_PROTOTYPE)) {
+        createNonEnumerableProperty(path, VIRTUAL_PROTOTYPE, {});
+      }
+      // export virtual prototype methods
+      createNonEnumerableProperty(path[VIRTUAL_PROTOTYPE], key, sourceProperty);
+      // export real prototype methods
+      if (options.real && targetPrototype && (FORCED || !targetPrototype[key])) {
+        createNonEnumerableProperty(targetPrototype, key, sourceProperty);
+      }
+    }
+  }
+};
+
+var $ = _export;
+
+var defineProperty$c = require$$0$r.f;
+
+// `Object.defineProperty` method
+// https://tc39.es/ecma262/#sec-object.defineproperty
+// eslint-disable-next-line es/no-object-defineproperty -- safe
+$({ target: 'Object', stat: true, forced: Object.defineProperty !== defineProperty$c, sham: !DESCRIPTORS }, {
+  defineProperty: defineProperty$c
+});
+
+var defineProperty_1 = createCommonjsModule(function (module) {
+
+
+
+var Object = path.Object;
+
+var defineProperty = module.exports = function defineProperty(it, key, desc) {
+  return Object.defineProperty(it, key, desc);
+};
+
+if (Object.defineProperty.sham) defineProperty.sham = true;
+});
+
+var parent$D = defineProperty_1;
+
+var defineProperty$b = parent$D;
+
+var parent$C = defineProperty$b;
+
+var defineProperty$a = parent$C;
+
+var addToUnscopables$1 = function () { /* empty */ };
+
+var iterators = {};
+
+var WeakMap$2 = globalThis$1.WeakMap;
+
+var weakMapBasicDetection = isCallable(WeakMap$2) && /native code/.test(String(WeakMap$2));
+
+var keys$7 = shared$1('keys');
+
+var sharedKey$1 = function (key) {
+  return keys$7[key] || (keys$7[key] = uid(key));
+};
+
+var hiddenKeys$2 = {};
+
+var NATIVE_WEAK_MAP = weakMapBasicDetection;
+
+var sharedKey = sharedKey$1;
+
+var hiddenKeys$1 = hiddenKeys$2;
+
+var OBJECT_ALREADY_INITIALIZED = 'Object already initialized';
+var TypeError$2 = globalThis$1.TypeError;
+var WeakMap$1 = globalThis$1.WeakMap;
+var set$4, get$1, has$6;
+
+var enforce = function (it) {
+  return has$6(it) ? get$1(it) : set$4(it, {});
+};
+
+var getterFor = function (TYPE) {
+  return function (it) {
+    var state;
+    if (!isObject(it) || (state = get$1(it)).type !== TYPE) {
+      throw new TypeError$2('Incompatible receiver, ' + TYPE + ' required');
+    } return state;
+  };
+};
+
+if (NATIVE_WEAK_MAP || store$1.state) {
+  var store = store$1.state || (store$1.state = new WeakMap$1());
+  /* eslint-disable no-self-assign -- prototype methods protection */
+  store.get = store.get;
+  store.has = store.has;
+  store.set = store.set;
+  /* eslint-enable no-self-assign -- prototype methods protection */
+  set$4 = function (it, metadata) {
+    if (store.has(it)) throw new TypeError$2(OBJECT_ALREADY_INITIALIZED);
+    metadata.facade = it;
+    store.set(it, metadata);
+    return metadata;
+  };
+  get$1 = function (it) {
+    return store.get(it) || {};
+  };
+  has$6 = function (it) {
+    return store.has(it);
+  };
+} else {
+  var STATE = sharedKey('state');
+  hiddenKeys$1[STATE] = true;
+  set$4 = function (it, metadata) {
+    if (hasOwn(it, STATE)) throw new TypeError$2(OBJECT_ALREADY_INITIALIZED);
+    metadata.facade = it;
+    createNonEnumerableProperty(it, STATE, metadata);
+    return metadata;
+  };
+  get$1 = function (it) {
+    return hasOwn(it, STATE) ? it[STATE] : {};
+  };
+  has$6 = function (it) {
+    return hasOwn(it, STATE);
+  };
+}
+
+var internalState = {
+  set: set$4,
+  get: get$1,
+  has: has$6,
+  enforce: enforce,
+  getterFor: getterFor
+};
+
+var FunctionPrototype$1 = Function.prototype;
+// eslint-disable-next-line es/no-object-getownpropertydescriptor -- safe
+var getDescriptor = DESCRIPTORS && Object.getOwnPropertyDescriptor;
+
+var EXISTS = hasOwn(FunctionPrototype$1, 'name');
+// additional protection from minified / mangled / dropped function names
+var PROPER = EXISTS && (function something() { /* empty */ }).name === 'something';
+var CONFIGURABLE = EXISTS && (!DESCRIPTORS || (DESCRIPTORS && getDescriptor(FunctionPrototype$1, 'name').configurable));
+
+var functionName = {
+  EXISTS: EXISTS,
+  PROPER: PROPER,
+  CONFIGURABLE: CONFIGURABLE
+};
+
+var ceil$1 = Math.ceil;
+var floor = Math.floor;
+
+// `Math.trunc` method
+// https://tc39.es/ecma262/#sec-math.trunc
+// eslint-disable-next-line es/no-math-trunc -- safe
+var mathTrunc = Math.trunc || function trunc(x) {
+  var n = +x;
+  return (n > 0 ? floor : ceil$1)(n);
+};
+
+var trunc = mathTrunc;
+
+// `ToIntegerOrInfinity` abstract operation
+// https://tc39.es/ecma262/#sec-tointegerorinfinity
+var toIntegerOrInfinity$1 = function (argument) {
+  var number = +argument;
+  // eslint-disable-next-line no-self-compare -- NaN check
+  return number !== number || number === 0 ? 0 : trunc(number);
+};
+
+var toIntegerOrInfinity = toIntegerOrInfinity$1;
+
+var max$2 = Math.max;
+var min$1 = Math.min;
+
+// Helper for a popular repeating case of the spec:
+// Let integer be ? ToInteger(index).
+// If integer < 0, let result be max((length + integer), 0); else let result be min(integer, length).
+var toAbsoluteIndex$1 = function (index, length) {
+  var integer = toIntegerOrInfinity(index);
+  return integer < 0 ? max$2(integer + length, 0) : min$1(integer, length);
+};
+
+var min = Math.min;
+
+// `ToLength` abstract operation
+// https://tc39.es/ecma262/#sec-tolength
+var toLength$1 = function (argument) {
+  var len = toIntegerOrInfinity(argument);
+  return len > 0 ? min(len, 0x1FFFFFFFFFFFFF) : 0; // 2 ** 53 - 1 == 9007199254740991
+};
+
+var toLength = toLength$1;
+
+// `LengthOfArrayLike` abstract operation
+// https://tc39.es/ecma262/#sec-lengthofarraylike
+var lengthOfArrayLike$1 = function (obj) {
+  return toLength(obj.length);
+};
+
+var toAbsoluteIndex = toAbsoluteIndex$1;
+
+var lengthOfArrayLike = lengthOfArrayLike$1;
+
+// `Array.prototype.{ indexOf, includes }` methods implementation
+var createMethod$3 = function (IS_INCLUDES) {
+  return function ($this, el, fromIndex) {
+    var O = toIndexedObject($this);
+    var length = lengthOfArrayLike(O);
+    if (length === 0) return !IS_INCLUDES && -1;
+    var index = toAbsoluteIndex(fromIndex, length);
+    var value;
+    // Array#includes uses SameValueZero equality algorithm
+    // eslint-disable-next-line no-self-compare -- NaN check
+    if (IS_INCLUDES && el !== el) while (length > index) {
+      value = O[index++];
+      // eslint-disable-next-line no-self-compare -- NaN check
+      if (value !== value) return true;
+    // Array#indexOf ignores holes, Array#includes - not
+    } else for (;length > index; index++) {
+      if ((IS_INCLUDES || index in O) && O[index] === el) return IS_INCLUDES || index || 0;
+    } return !IS_INCLUDES && -1;
+  };
+};
+
+var arrayIncludes = {
+  // `Array.prototype.includes` method
+  // https://tc39.es/ecma262/#sec-array.prototype.includes
+  includes: createMethod$3(true),
+  // `Array.prototype.indexOf` method
+  // https://tc39.es/ecma262/#sec-array.prototype.indexof
+  indexOf: createMethod$3(false)
+};
+
+var require$$0$q = arrayIncludes;
+
+var indexOf = require$$0$q.indexOf;
+
+
+var push$a = uncurryThis$1([].push);
+
+var objectKeysInternal = function (object, names) {
+  var O = toIndexedObject(object);
+  var i = 0;
+  var result = [];
+  var key;
+  for (key in O) !hasOwn(hiddenKeys$1, key) && hasOwn(O, key) && push$a(result, key);
+  // Don't enum bug & hidden keys
+  while (names.length > i) if (hasOwn(O, key = names[i++])) {
+    ~indexOf(result, key) || push$a(result, key);
+  }
+  return result;
+};
+
+// IE8- don't enum bug keys
+var enumBugKeys$1 = [
+  'constructor',
+  'hasOwnProperty',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+  'toLocaleString',
+  'toString',
+  'valueOf'
+];
+
+var internalObjectKeys = objectKeysInternal;
+
+var enumBugKeys = enumBugKeys$1;
+
+// `Object.keys` method
+// https://tc39.es/ecma262/#sec-object.keys
+// eslint-disable-next-line es/no-object-keys -- safe
+var objectKeys = Object.keys || function keys(O) {
+  return internalObjectKeys(O, enumBugKeys);
+};
+
+var nativeKeys = objectKeys;
+
+// `Object.defineProperties` method
+// https://tc39.es/ecma262/#sec-object.defineproperties
+// eslint-disable-next-line es/no-object-defineproperties -- safe
+var f$4 = DESCRIPTORS && !V8_PROTOTYPE_DEFINE_BUG ? Object.defineProperties : function defineProperties(O, Properties) {
+  anObject(O);
+  var props = toIndexedObject(Properties);
+  var keys = nativeKeys(Properties);
+  var length = keys.length;
+  var index = 0;
+  var key;
+  while (length > index) require$$0$r.f(O, key = keys[index++], props[key]);
+  return O;
+};
+
+var objectDefineProperties = {
+	f: f$4
+};
+
+var html$1 = getBuiltIn('document', 'documentElement');
+
+var definePropertiesModule = objectDefineProperties;
+
+var html = html$1;
+
+/* global ActiveXObject -- old IE, WSH */
+
+
+
+
+
+
+
+
+var GT = '>';
+var LT = '<';
+var PROTOTYPE$1 = 'prototype';
+var SCRIPT = 'script';
+var IE_PROTO$1 = sharedKey('IE_PROTO');
+
+var EmptyConstructor = function () { /* empty */ };
+
+var scriptTag = function (content) {
+  return LT + SCRIPT + GT + content + LT + '/' + SCRIPT + GT;
+};
+
+// Create object with fake `null` prototype: use ActiveX Object with cleared prototype
+var NullProtoObjectViaActiveX = function (activeXDocument) {
+  activeXDocument.write(scriptTag(''));
+  activeXDocument.close();
+  var temp = activeXDocument.parentWindow.Object;
+  // eslint-disable-next-line no-useless-assignment -- avoid memory leak
+  activeXDocument = null;
+  return temp;
+};
+
+// Create object with fake `null` prototype: use iframe Object with cleared prototype
+var NullProtoObjectViaIFrame = function () {
+  // Thrash, waste and sodomy: IE GC bug
+  var iframe = documentCreateElement('iframe');
+  var JS = 'java' + SCRIPT + ':';
+  var iframeDocument;
+  iframe.style.display = 'none';
+  html.appendChild(iframe);
+  // https://github.com/zloirock/core-js/issues/475
+  iframe.src = String(JS);
+  iframeDocument = iframe.contentWindow.document;
+  iframeDocument.open();
+  iframeDocument.write(scriptTag('document.F=Object'));
+  iframeDocument.close();
+  return iframeDocument.F;
+};
+
+// Check for document.domain and active x support
+// No need to use active x approach when document.domain is not set
+// see https://github.com/es-shims/es5-shim/issues/150
+// variation of https://github.com/kitcambridge/es5-shim/commit/4f738ac066346
+// avoid IE GC bug
+var activeXDocument;
+var NullProtoObject = function () {
+  try {
+    activeXDocument = new ActiveXObject('htmlfile');
+  } catch (error) { /* ignore */ }
+  NullProtoObject = typeof document != 'undefined'
+    ? document.domain && activeXDocument
+      ? NullProtoObjectViaActiveX(activeXDocument) // old IE
+      : NullProtoObjectViaIFrame()
+    : NullProtoObjectViaActiveX(activeXDocument); // WSH
+  var length = enumBugKeys.length;
+  while (length--) delete NullProtoObject[PROTOTYPE$1][enumBugKeys[length]];
+  return NullProtoObject();
+};
+
+hiddenKeys$1[IE_PROTO$1] = true;
+
+// `Object.create` method
+// https://tc39.es/ecma262/#sec-object.create
+// eslint-disable-next-line es/no-object-create -- safe
+var objectCreate = Object.create || function create(O, Properties) {
+  var result;
+  if (O !== null) {
+    EmptyConstructor[PROTOTYPE$1] = anObject(O);
+    result = new EmptyConstructor();
+    EmptyConstructor[PROTOTYPE$1] = null;
+    // add "__proto__" for Object.getPrototypeOf polyfill
+    result[IE_PROTO$1] = O;
+  } else result = NullProtoObject();
+  return Properties === undefined ? result : definePropertiesModule.f(result, Properties);
+};
+
+var correctPrototypeGetter = !fails(function () {
+  function F() { /* empty */ }
+  F.prototype.constructor = null;
+  // eslint-disable-next-line es/no-object-getprototypeof -- required for testing
+  return Object.getPrototypeOf(new F()) !== F.prototype;
+});
+
+var CORRECT_PROTOTYPE_GETTER = correctPrototypeGetter;
+
+var IE_PROTO = sharedKey('IE_PROTO');
+var $Object$1 = Object;
+var ObjectPrototype$1 = $Object$1.prototype;
+
+// `Object.getPrototypeOf` method
+// https://tc39.es/ecma262/#sec-object.getprototypeof
+// eslint-disable-next-line es/no-object-getprototypeof -- safe
+var objectGetPrototypeOf = CORRECT_PROTOTYPE_GETTER ? $Object$1.getPrototypeOf : function (O) {
+  var object = toObject$1(O);
+  if (hasOwn(object, IE_PROTO)) return object[IE_PROTO];
+  var constructor = object.constructor;
+  if (isCallable(constructor) && object instanceof constructor) {
+    return constructor.prototype;
+  } return object instanceof $Object$1 ? ObjectPrototype$1 : null;
+};
+
+var defineBuiltIn$1 = function (target, key, value, options) {
+  if (options && options.enumerable) target[key] = value;
+  else createNonEnumerableProperty(target, key, value);
+  return target;
+};
+
+var nativeObjectCreate = objectCreate;
+
+var getPrototypeOf = objectGetPrototypeOf;
+
+var defineBuiltIn = defineBuiltIn$1;
+
+var ITERATOR$4 = wellKnownSymbol('iterator');
+var BUGGY_SAFARI_ITERATORS$1 = false;
+
+// `%IteratorPrototype%` object
+// https://tc39.es/ecma262/#sec-%iteratorprototype%-object
+var IteratorPrototype$2, PrototypeOfArrayIteratorPrototype, arrayIterator;
+
+/* eslint-disable es/no-array-prototype-keys -- safe */
+if ([].keys) {
+  arrayIterator = [].keys();
+  // Safari 8 has buggy iterators w/o `next`
+  if (!('next' in arrayIterator)) BUGGY_SAFARI_ITERATORS$1 = true;
+  else {
+    PrototypeOfArrayIteratorPrototype = getPrototypeOf(getPrototypeOf(arrayIterator));
+    if (PrototypeOfArrayIteratorPrototype !== Object.prototype) IteratorPrototype$2 = PrototypeOfArrayIteratorPrototype;
+  }
+}
+
+var NEW_ITERATOR_PROTOTYPE = !isObject(IteratorPrototype$2) || fails(function () {
+  var test = {};
+  // FF44- legacy iterators case
+  return IteratorPrototype$2[ITERATOR$4].call(test) !== test;
+});
+
+if (NEW_ITERATOR_PROTOTYPE) IteratorPrototype$2 = {};
+else if (IS_PURE) IteratorPrototype$2 = nativeObjectCreate(IteratorPrototype$2);
+
+// `%IteratorPrototype%[@@iterator]()` method
+// https://tc39.es/ecma262/#sec-%iteratorprototype%-@@iterator
+if (!isCallable(IteratorPrototype$2[ITERATOR$4])) {
+  defineBuiltIn(IteratorPrototype$2, ITERATOR$4, function () {
+    return this;
+  });
+}
+
+var iteratorsCore = {
+  IteratorPrototype: IteratorPrototype$2,
+  BUGGY_SAFARI_ITERATORS: BUGGY_SAFARI_ITERATORS$1
+};
+
+var TO_STRING_TAG$2 = wellKnownSymbol('toStringTag');
+var test = {};
+
+test[TO_STRING_TAG$2] = 'z';
+
+var toStringTagSupport = String(test) === '[object z]';
+
+var TO_STRING_TAG_SUPPORT = toStringTagSupport;
+
+var TO_STRING_TAG$1 = wellKnownSymbol('toStringTag');
+var $Object = Object;
+
+// ES3 wrong here
+var CORRECT_ARGUMENTS = classof$2(function () { return arguments; }()) === 'Arguments';
+
+// fallback for IE11 Script Access Denied error
+var tryGet = function (it, key) {
+  try {
+    return it[key];
+  } catch (error) { /* empty */ }
+};
+
+// getting tag from ES6+ `Object.prototype.toString`
+var classof$1 = TO_STRING_TAG_SUPPORT ? classof$2 : function (it) {
+  var O, tag, result;
+  return it === undefined ? 'Undefined' : it === null ? 'Null'
+    // @@toStringTag case
+    : typeof (tag = tryGet(O = $Object(it), TO_STRING_TAG$1)) == 'string' ? tag
+    // builtinTag case
+    : CORRECT_ARGUMENTS ? classof$2(O)
+    // ES3 arguments fallback
+    : (result = classof$2(O)) === 'Object' && isCallable(O.callee) ? 'Arguments' : result;
+};
+
+var classof = classof$1;
+
+// `Object.prototype.toString` method implementation
+// https://tc39.es/ecma262/#sec-object.prototype.tostring
+var objectToString = TO_STRING_TAG_SUPPORT ? {}.toString : function toString() {
+  return '[object ' + classof(this) + ']';
+};
+
+var toString$2 = objectToString;
+
+var defineProperty$9 = require$$0$r.f;
+
+
+
+
+
+var TO_STRING_TAG = wellKnownSymbol('toStringTag');
+
+var setToStringTag$1 = function (it, TAG, STATIC, SET_METHOD) {
+  var target = STATIC ? it : it && it.prototype;
+  if (target) {
+    if (!hasOwn(target, TO_STRING_TAG)) {
+      defineProperty$9(target, TO_STRING_TAG, { configurable: true, value: TAG });
+    }
+    if (SET_METHOD && !TO_STRING_TAG_SUPPORT) {
+      createNonEnumerableProperty(target, 'toString', toString$2);
+    }
+  }
+};
+
+var IteratorsCore = iteratorsCore;
+
+var setToStringTag = setToStringTag$1;
+
+var Iterators = iterators;
+
+var IteratorPrototype$1 = IteratorsCore.IteratorPrototype;
+
+
+
+
+
+var returnThis$1 = function () { return this; };
+
+var iteratorCreateConstructor = function (IteratorConstructor, NAME, next, ENUMERABLE_NEXT) {
+  var TO_STRING_TAG = NAME + ' Iterator';
+  IteratorConstructor.prototype = nativeObjectCreate(IteratorPrototype$1, { next: createPropertyDescriptor(+!ENUMERABLE_NEXT, next) });
+  setToStringTag(IteratorConstructor, TO_STRING_TAG, false, true);
+  Iterators[TO_STRING_TAG] = returnThis$1;
+  return IteratorConstructor;
+};
+
+var functionUncurryThisAccessor = function (object, key, method) {
+  try {
+    // eslint-disable-next-line es/no-object-getownpropertydescriptor -- safe
+    return uncurryThis$1(aCallable(Object.getOwnPropertyDescriptor(object, key)[method]));
+  } catch (error) { /* empty */ }
+};
+
+var isPossiblePrototype$1 = function (argument) {
+  return isObject(argument) || argument === null;
+};
+
+var isPossiblePrototype = isPossiblePrototype$1;
+
+var $String$2 = String;
+var $TypeError$7 = TypeError;
+
+var aPossiblePrototype$1 = function (argument) {
+  if (isPossiblePrototype(argument)) return argument;
+  throw new $TypeError$7("Can't set " + $String$2(argument) + ' as a prototype');
+};
+
+var uncurryThisAccessor = functionUncurryThisAccessor;
+
+var aPossiblePrototype = aPossiblePrototype$1;
+
+/* eslint-disable no-proto -- safe */
+
+
+
+
+
+// `Object.setPrototypeOf` method
+// https://tc39.es/ecma262/#sec-object.setprototypeof
+// Works with __proto__ only. Old v8 can't work with null proto objects.
+// eslint-disable-next-line es/no-object-setprototypeof -- safe
+var objectSetPrototypeOf = Object.setPrototypeOf || ('__proto__' in {} ? function () {
+  var CORRECT_SETTER = false;
+  var test = {};
+  var setter;
+  try {
+    setter = uncurryThisAccessor(Object.prototype, '__proto__', 'set');
+    setter(test, []);
+    CORRECT_SETTER = test instanceof Array;
+  } catch (error) { /* empty */ }
+  return function setPrototypeOf(O, proto) {
+    requireObjectCoercible(O);
+    aPossiblePrototype(proto);
+    if (!isObject(O)) return O;
+    if (CORRECT_SETTER) setter(O, proto);
+    else O.__proto__ = proto;
+    return O;
+  };
+}() : undefined);
+
+var FunctionName = functionName;
+
+var createIteratorConstructor = iteratorCreateConstructor;
+
+var setPrototypeOf = objectSetPrototypeOf;
+
+var PROPER_FUNCTION_NAME = FunctionName.PROPER;
+var CONFIGURABLE_FUNCTION_NAME = FunctionName.CONFIGURABLE;
+var IteratorPrototype = IteratorsCore.IteratorPrototype;
+var BUGGY_SAFARI_ITERATORS = IteratorsCore.BUGGY_SAFARI_ITERATORS;
+var ITERATOR$3 = wellKnownSymbol('iterator');
+var KEYS = 'keys';
+var VALUES = 'values';
+var ENTRIES = 'entries';
+
+var returnThis = function () { return this; };
+
+var iteratorDefine = function (Iterable, NAME, IteratorConstructor, next, DEFAULT, IS_SET, FORCED) {
+  createIteratorConstructor(IteratorConstructor, NAME, next);
+
+  var getIterationMethod = function (KIND) {
+    if (KIND === DEFAULT && defaultIterator) return defaultIterator;
+    if (!BUGGY_SAFARI_ITERATORS && KIND && KIND in IterablePrototype) return IterablePrototype[KIND];
+
+    switch (KIND) {
+      case KEYS: return function keys() { return new IteratorConstructor(this, KIND); };
+      case VALUES: return function values() { return new IteratorConstructor(this, KIND); };
+      case ENTRIES: return function entries() { return new IteratorConstructor(this, KIND); };
+    }
+
+    return function () { return new IteratorConstructor(this); };
+  };
+
+  var TO_STRING_TAG = NAME + ' Iterator';
+  var INCORRECT_VALUES_NAME = false;
+  var IterablePrototype = Iterable.prototype;
+  var nativeIterator = IterablePrototype[ITERATOR$3]
+    || IterablePrototype['@@iterator']
+    || DEFAULT && IterablePrototype[DEFAULT];
+  var defaultIterator = !BUGGY_SAFARI_ITERATORS && nativeIterator || getIterationMethod(DEFAULT);
+  var anyNativeIterator = NAME === 'Array' ? IterablePrototype.entries || nativeIterator : nativeIterator;
+  var CurrentIteratorPrototype, methods, KEY;
+
+  // fix native
+  if (anyNativeIterator) {
+    CurrentIteratorPrototype = getPrototypeOf(anyNativeIterator.call(new Iterable()));
+    if (CurrentIteratorPrototype !== Object.prototype && CurrentIteratorPrototype.next) {
+      if (!IS_PURE && getPrototypeOf(CurrentIteratorPrototype) !== IteratorPrototype) {
+        if (setPrototypeOf) {
+          setPrototypeOf(CurrentIteratorPrototype, IteratorPrototype);
+        } else if (!isCallable(CurrentIteratorPrototype[ITERATOR$3])) {
+          defineBuiltIn(CurrentIteratorPrototype, ITERATOR$3, returnThis);
+        }
+      }
+      // Set @@toStringTag to native iterators
+      setToStringTag(CurrentIteratorPrototype, TO_STRING_TAG, true, true);
+      if (IS_PURE) Iterators[TO_STRING_TAG] = returnThis;
+    }
+  }
+
+  // fix Array.prototype.{ values, @@iterator }.name in V8 / FF
+  if (PROPER_FUNCTION_NAME && DEFAULT === VALUES && nativeIterator && nativeIterator.name !== VALUES) {
+    if (!IS_PURE && CONFIGURABLE_FUNCTION_NAME) {
+      createNonEnumerableProperty(IterablePrototype, 'name', VALUES);
+    } else {
+      INCORRECT_VALUES_NAME = true;
+      defaultIterator = function values() { return call(nativeIterator, this); };
+    }
+  }
+
+  // export additional methods
+  if (DEFAULT) {
+    methods = {
+      values: getIterationMethod(VALUES),
+      keys: IS_SET ? defaultIterator : getIterationMethod(KEYS),
+      entries: getIterationMethod(ENTRIES)
+    };
+    if (FORCED) for (KEY in methods) {
+      if (BUGGY_SAFARI_ITERATORS || INCORRECT_VALUES_NAME || !(KEY in IterablePrototype)) {
+        defineBuiltIn(IterablePrototype, KEY, methods[KEY]);
+      }
+    } else $({ target: NAME, proto: true, forced: BUGGY_SAFARI_ITERATORS || INCORRECT_VALUES_NAME }, methods);
+  }
+
+  // define iterator
+  if ((!IS_PURE || FORCED) && IterablePrototype[ITERATOR$3] !== defaultIterator) {
+    defineBuiltIn(IterablePrototype, ITERATOR$3, defaultIterator, { name: DEFAULT });
+  }
+  Iterators[NAME] = defaultIterator;
+
+  return methods;
+};
+
+// `CreateIterResultObject` abstract operation
+// https://tc39.es/ecma262/#sec-createiterresultobject
+var createIterResultObject$1 = function (value, done) {
+  return { value: value, done: done };
+};
+
+var addToUnscopables = addToUnscopables$1;
+
+var InternalStateModule = internalState;
+
+var defineIterator = iteratorDefine;
+
+var createIterResultObject = createIterResultObject$1;
+
+var defineProperty$8 = require$$0$r.f;
+
+
+
+
+
+var ARRAY_ITERATOR = 'Array Iterator';
+var setInternalState$4 = InternalStateModule.set;
+var getInternalState$2 = InternalStateModule.getterFor(ARRAY_ITERATOR);
+
+// `Array.prototype.entries` method
+// https://tc39.es/ecma262/#sec-array.prototype.entries
+// `Array.prototype.keys` method
+// https://tc39.es/ecma262/#sec-array.prototype.keys
+// `Array.prototype.values` method
+// https://tc39.es/ecma262/#sec-array.prototype.values
+// `Array.prototype[@@iterator]` method
+// https://tc39.es/ecma262/#sec-array.prototype-@@iterator
+// `CreateArrayIterator` internal method
+// https://tc39.es/ecma262/#sec-createarrayiterator
+defineIterator(Array, 'Array', function (iterated, kind) {
+  setInternalState$4(this, {
+    type: ARRAY_ITERATOR,
+    target: toIndexedObject(iterated), // target
+    index: 0,                          // next index
+    kind: kind                         // kind
+  });
+// `%ArrayIteratorPrototype%.next` method
+// https://tc39.es/ecma262/#sec-%arrayiteratorprototype%.next
+}, function () {
+  var state = getInternalState$2(this);
+  var target = state.target;
+  var index = state.index++;
+  if (!target || index >= target.length) {
+    state.target = null;
+    return createIterResultObject(undefined, true);
+  }
+  switch (state.kind) {
+    case 'keys': return createIterResultObject(index, false);
+    case 'values': return createIterResultObject(target[index], false);
+  } return createIterResultObject([index, target[index]], false);
+}, 'values');
+
+// argumentsList[@@iterator] is %ArrayProto_values%
+// https://tc39.es/ecma262/#sec-createunmappedargumentsobject
+// https://tc39.es/ecma262/#sec-createmappedargumentsobject
+var values = Iterators.Arguments = Iterators.Array;
+
+// https://tc39.es/ecma262/#sec-array.prototype-@@unscopables
+addToUnscopables();
+addToUnscopables();
+addToUnscopables();
+
+// V8 ~ Chrome 45- bug
+if (!IS_PURE && DESCRIPTORS && values.name !== 'values') try {
+  defineProperty$8(values, 'name', { value: 'values' });
+} catch (error) { /* empty */ }
+
+var hiddenKeys = enumBugKeys.concat('length', 'prototype');
+
+// `Object.getOwnPropertyNames` method
+// https://tc39.es/ecma262/#sec-object.getownpropertynames
+// eslint-disable-next-line es/no-object-getownpropertynames -- safe
+var f$3 = Object.getOwnPropertyNames || function getOwnPropertyNames(O) {
+  return internalObjectKeys(O, hiddenKeys);
+};
+
+var objectGetOwnPropertyNames = {
+	f: f$3
+};
+
+var arraySlice = uncurryThis$1([].slice);
+
+var getOwnPropertyNamesModule = objectGetOwnPropertyNames;
+
+var nativeSlice = arraySlice;
+
+/* eslint-disable es/no-object-getownpropertynames -- safe */
+
+
+var $getOwnPropertyNames$1 = getOwnPropertyNamesModule.f;
+
+
+var windowNames = typeof window == 'object' && window && Object.getOwnPropertyNames
+  ? Object.getOwnPropertyNames(window) : [];
+
+var getWindowNames = function (it) {
+  try {
+    return $getOwnPropertyNames$1(it);
+  } catch (error) {
+    return nativeSlice(windowNames);
+  }
+};
+
+// fallback for IE11 buggy Object.getOwnPropertyNames with iframe and window
+var f$2 = function getOwnPropertyNames(it) {
+  return windowNames && classof$2(it) === 'Window'
+    ? getWindowNames(it)
+    : $getOwnPropertyNames$1(toIndexedObject(it));
+};
+
+var objectGetOwnPropertyNamesExternal = {
+	f: f$2
+};
+
+// FF26- bug: ArrayBuffers are non-extensible, but Object.isExtensible does not report it
+
+
+var arrayBufferNonExtensible = fails(function () {
+  if (typeof ArrayBuffer == 'function') {
+    var buffer = new ArrayBuffer(8);
+    // eslint-disable-next-line es/no-object-isextensible, es/no-object-defineproperty -- safe
+    if (Object.isExtensible(buffer)) Object.defineProperty(buffer, 'a', { value: 8 });
+  }
+});
+
+var ARRAY_BUFFER_NON_EXTENSIBLE = arrayBufferNonExtensible;
+
+// eslint-disable-next-line es/no-object-isextensible -- safe
+var $isExtensible = Object.isExtensible;
+var FAILS_ON_PRIMITIVES$1 = fails(function () { $isExtensible(1); });
+
+// `Object.isExtensible` method
+// https://tc39.es/ecma262/#sec-object.isextensible
+var objectIsExtensible = (FAILS_ON_PRIMITIVES$1 || ARRAY_BUFFER_NON_EXTENSIBLE) ? function isExtensible(it) {
+  if (!isObject(it)) return false;
+  if (ARRAY_BUFFER_NON_EXTENSIBLE && classof$2(it) === 'ArrayBuffer') return false;
+  return $isExtensible ? $isExtensible(it) : true;
+} : $isExtensible;
+
+var freezing = !fails(function () {
+  // eslint-disable-next-line es/no-object-isextensible, es/no-object-preventextensions -- required for testing
+  return Object.isExtensible(Object.preventExtensions({}));
+});
+
+var getOwnPropertyNamesExternal = objectGetOwnPropertyNamesExternal;
+
+var isExtensible = objectIsExtensible;
+
+var FREEZING = freezing;
+
+var internalMetadata = createCommonjsModule(function (module) {
+
+
+
+
+
+var defineProperty = require$$0$r.f;
+
+
+
+
+
+
+var REQUIRED = false;
+var METADATA = uid('meta');
+var id = 0;
+
+var setMetadata = function (it) {
+  defineProperty(it, METADATA, { value: {
+    objectID: 'O' + id++, // object ID
+    weakData: {}          // weak collections IDs
+  } });
+};
+
+var fastKey = function (it, create) {
+  // return a primitive with prefix
+  if (!isObject(it)) return typeof it == 'symbol' ? it : (typeof it == 'string' ? 'S' : 'P') + it;
+  if (!hasOwn(it, METADATA)) {
+    // can't set metadata to uncaught frozen object
+    if (!isExtensible(it)) return 'F';
+    // not necessary to add metadata
+    if (!create) return 'E';
+    // add missing metadata
+    setMetadata(it);
+  // return object ID
+  } return it[METADATA].objectID;
+};
+
+var getWeakData = function (it, create) {
+  if (!hasOwn(it, METADATA)) {
+    // can't set metadata to uncaught frozen object
+    if (!isExtensible(it)) return true;
+    // not necessary to add metadata
+    if (!create) return false;
+    // add missing metadata
+    setMetadata(it);
+  // return the store of weak collections IDs
+  } return it[METADATA].weakData;
+};
+
+// add metadata on freeze-family methods calling
+var onFreeze = function (it) {
+  if (FREEZING && REQUIRED && isExtensible(it) && !hasOwn(it, METADATA)) setMetadata(it);
+  return it;
+};
+
+var enable = function () {
+  meta.enable = function () { /* empty */ };
+  REQUIRED = true;
+  var getOwnPropertyNames = getOwnPropertyNamesModule.f;
+  var splice = uncurryThis$1([].splice);
+  var test = {};
+  test[METADATA] = 1;
+
+  // prevent exposing of metadata key
+  if (getOwnPropertyNames(test).length) {
+    getOwnPropertyNamesModule.f = function (it) {
+      var result = getOwnPropertyNames(it);
+      for (var i = 0, length = result.length; i < length; i++) {
+        if (result[i] === METADATA) {
+          splice(result, i, 1);
+          break;
+        }
+      } return result;
+    };
+
+    $({ target: 'Object', stat: true, forced: true }, {
+      getOwnPropertyNames: getOwnPropertyNamesExternal.f
+    });
+  }
+};
+
+var meta = module.exports = {
+  enable: enable,
+  fastKey: fastKey,
+  getWeakData: getWeakData,
+  onFreeze: onFreeze
+};
+
+hiddenKeys$1[METADATA] = true;
+});
+
+var ITERATOR$2 = wellKnownSymbol('iterator');
+var ArrayPrototype$7 = Array.prototype;
+
+// check on default Array iterator
+var isArrayIteratorMethod$1 = function (it) {
+  return it !== undefined && (Iterators.Array === it || ArrayPrototype$7[ITERATOR$2] === it);
+};
+
+var ITERATOR$1 = wellKnownSymbol('iterator');
+
+var getIteratorMethod$6 = function (it) {
+  if (!isNullOrUndefined(it)) return getMethod(it, ITERATOR$1)
+    || getMethod(it, '@@iterator')
+    || Iterators[classof(it)];
+};
+
+var getIteratorMethod$5 = getIteratorMethod$6;
+
+var $TypeError$6 = TypeError;
+
+var getIterator$6 = function (argument, usingIterator) {
+  var iteratorMethod = arguments.length < 2 ? getIteratorMethod$5(argument) : usingIterator;
+  if (aCallable(iteratorMethod)) return anObject(call(iteratorMethod, argument));
+  throw new $TypeError$6(tryToString(argument) + ' is not iterable');
+};
+
+var iteratorClose$1 = function (iterator, kind, value) {
+  var innerResult, innerError;
+  anObject(iterator);
+  try {
+    innerResult = getMethod(iterator, 'return');
+    if (!innerResult) {
+      if (kind === 'throw') throw value;
+      return value;
+    }
+    innerResult = call(innerResult, iterator);
+  } catch (error) {
+    innerError = true;
+    innerResult = error;
+  }
+  if (kind === 'throw') throw value;
+  if (innerError) throw innerResult;
+  anObject(innerResult);
+  return value;
+};
+
+var isArrayIteratorMethod = isArrayIteratorMethod$1;
+
+var getIterator$5 = getIterator$6;
+
+var iteratorClose = iteratorClose$1;
+
+var $TypeError$5 = TypeError;
+
+var Result = function (stopped, result) {
+  this.stopped = stopped;
+  this.result = result;
+};
+
+var ResultPrototype = Result.prototype;
+
+var iterate$2 = function (iterable, unboundFunction, options) {
+  var that = options && options.that;
+  var AS_ENTRIES = !!(options && options.AS_ENTRIES);
+  var IS_RECORD = !!(options && options.IS_RECORD);
+  var IS_ITERATOR = !!(options && options.IS_ITERATOR);
+  var INTERRUPTED = !!(options && options.INTERRUPTED);
+  var fn = bind(unboundFunction, that);
+  var iterator, iterFn, index, length, result, next, step;
+
+  var stop = function (condition) {
+    if (iterator) iteratorClose(iterator, 'normal', condition);
+    return new Result(true, condition);
+  };
+
+  var callFn = function (value) {
+    if (AS_ENTRIES) {
+      anObject(value);
+      return INTERRUPTED ? fn(value[0], value[1], stop) : fn(value[0], value[1]);
+    } return INTERRUPTED ? fn(value, stop) : fn(value);
+  };
+
+  if (IS_RECORD) {
+    iterator = iterable.iterator;
+  } else if (IS_ITERATOR) {
+    iterator = iterable;
+  } else {
+    iterFn = getIteratorMethod$5(iterable);
+    if (!iterFn) throw new $TypeError$5(tryToString(iterable) + ' is not iterable');
+    // optimisation for array iterators
+    if (isArrayIteratorMethod(iterFn)) {
+      for (index = 0, length = lengthOfArrayLike(iterable); length > index; index++) {
+        result = callFn(iterable[index]);
+        if (result && isPrototypeOf(ResultPrototype, result)) return result;
+      } return new Result(false);
+    }
+    iterator = getIterator$5(iterable, iterFn);
+  }
+
+  next = IS_RECORD ? iterable.next : iterator.next;
+  while (!(step = call(next, iterator)).done) {
+    try {
+      result = callFn(step.value);
+    } catch (error) {
+      iteratorClose(iterator, 'throw', error);
+    }
+    if (typeof result == 'object' && result && isPrototypeOf(ResultPrototype, result)) return result;
+  } return new Result(false);
+};
+
+var $TypeError$4 = TypeError;
+
+var anInstance$1 = function (it, Prototype) {
+  if (isPrototypeOf(Prototype, it)) return it;
+  throw new $TypeError$4('Incorrect invocation');
+};
+
+// `IsArray` abstract operation
+// https://tc39.es/ecma262/#sec-isarray
+// eslint-disable-next-line es/no-array-isarray -- safe
+var isArray$7 = Array.isArray || function isArray(argument) {
+  return classof$2(argument) === 'Array';
+};
+
+var functionToString = uncurryThis$1(Function.toString);
+
+// this helper broken in `core-js@3.4.1-3.4.4`, so we can't use `shared` helper
+if (!isCallable(store$1.inspectSource)) {
+  store$1.inspectSource = function (it) {
+    return functionToString(it);
+  };
+}
+
+var inspectSource$1 = store$1.inspectSource;
+
+var inspectSource = inspectSource$1;
+
+var noop = function () { /* empty */ };
+var construct = getBuiltIn('Reflect', 'construct');
+var constructorRegExp = /^\s*(?:class|function)\b/;
+var exec$1 = uncurryThis$1(constructorRegExp.exec);
+var INCORRECT_TO_STRING = !constructorRegExp.test(noop);
+
+var isConstructorModern = function isConstructor(argument) {
+  if (!isCallable(argument)) return false;
+  try {
+    construct(noop, [], argument);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+var isConstructorLegacy = function isConstructor(argument) {
+  if (!isCallable(argument)) return false;
+  switch (classof(argument)) {
+    case 'AsyncFunction':
+    case 'GeneratorFunction':
+    case 'AsyncGeneratorFunction': return false;
+  }
+  try {
+    // we can't check .prototype since constructors produced by .bind haven't it
+    // `Function#toString` throws on some built-it function in some legacy engines
+    // (for example, `DOMQuad` and similar in FF41-)
+    return INCORRECT_TO_STRING || !!exec$1(constructorRegExp, inspectSource(argument));
+  } catch (error) {
+    return true;
+  }
+};
+
+isConstructorLegacy.sham = true;
+
+// `IsConstructor` abstract operation
+// https://tc39.es/ecma262/#sec-isconstructor
+var isConstructor$1 = !construct || fails(function () {
+  var called;
+  return isConstructorModern(isConstructorModern.call)
+    || !isConstructorModern(Object)
+    || !isConstructorModern(function () { called = true; })
+    || called;
+}) ? isConstructorLegacy : isConstructorModern;
+
+var isArray$6 = isArray$7;
+
+var isConstructor = isConstructor$1;
+
+var SPECIES$3 = wellKnownSymbol('species');
+var $Array$2 = Array;
+
+// a part of `ArraySpeciesCreate` abstract operation
+// https://tc39.es/ecma262/#sec-arrayspeciescreate
+var arraySpeciesConstructor$1 = function (originalArray) {
+  var C;
+  if (isArray$6(originalArray)) {
+    C = originalArray.constructor;
+    // cross-realm fallback
+    if (isConstructor(C) && (C === $Array$2 || isArray$6(C.prototype))) C = undefined;
+    else if (isObject(C)) {
+      C = C[SPECIES$3];
+      if (C === null) C = undefined;
+    }
+  } return C === undefined ? $Array$2 : C;
+};
+
+var arraySpeciesConstructor = arraySpeciesConstructor$1;
+
+// `ArraySpeciesCreate` abstract operation
+// https://tc39.es/ecma262/#sec-arrayspeciescreate
+var arraySpeciesCreate$1 = function (originalArray, length) {
+  return new (arraySpeciesConstructor(originalArray))(length === 0 ? 0 : length);
+};
+
+var arraySpeciesCreate = arraySpeciesCreate$1;
+
+var push$9 = uncurryThis$1([].push);
+
+// `Array.prototype.{ forEach, map, filter, some, every, find, findIndex, filterReject }` methods implementation
+var createMethod$2 = function (TYPE) {
+  var IS_MAP = TYPE === 1;
+  var IS_FILTER = TYPE === 2;
+  var IS_SOME = TYPE === 3;
+  var IS_EVERY = TYPE === 4;
+  var IS_FIND_INDEX = TYPE === 6;
+  var IS_FILTER_REJECT = TYPE === 7;
+  var NO_HOLES = TYPE === 5 || IS_FIND_INDEX;
+  return function ($this, callbackfn, that, specificCreate) {
+    var O = toObject$1($this);
+    var self = IndexedObject(O);
+    var length = lengthOfArrayLike(self);
+    var boundFunction = bind(callbackfn, that);
+    var index = 0;
+    var create = specificCreate || arraySpeciesCreate;
+    var target = IS_MAP ? create($this, length) : IS_FILTER || IS_FILTER_REJECT ? create($this, 0) : undefined;
+    var value, result;
+    for (;length > index; index++) if (NO_HOLES || index in self) {
+      value = self[index];
+      result = boundFunction(value, index, O);
+      if (TYPE) {
+        if (IS_MAP) target[index] = result; // map
+        else if (result) switch (TYPE) {
+          case 3: return true;              // some
+          case 5: return value;             // find
+          case 6: return index;             // findIndex
+          case 2: push$9(target, value);      // filter
+        } else switch (TYPE) {
+          case 4: return false;             // every
+          case 7: push$9(target, value);      // filterReject
+        }
+      }
+    }
+    return IS_FIND_INDEX ? -1 : IS_SOME || IS_EVERY ? IS_EVERY : target;
+  };
+};
+
+var arrayIteration = {
+  // `Array.prototype.forEach` method
+  // https://tc39.es/ecma262/#sec-array.prototype.foreach
+  forEach: createMethod$2(0),
+  // `Array.prototype.map` method
+  // https://tc39.es/ecma262/#sec-array.prototype.map
+  map: createMethod$2(1),
+  // `Array.prototype.filter` method
+  // https://tc39.es/ecma262/#sec-array.prototype.filter
+  filter: createMethod$2(2),
+  // `Array.prototype.some` method
+  // https://tc39.es/ecma262/#sec-array.prototype.some
+  some: createMethod$2(3),
+  // `Array.prototype.every` method
+  // https://tc39.es/ecma262/#sec-array.prototype.every
+  every: createMethod$2(4),
+  // `Array.prototype.find` method
+  // https://tc39.es/ecma262/#sec-array.prototype.find
+  find: createMethod$2(5),
+  // `Array.prototype.findIndex` method
+  // https://tc39.es/ecma262/#sec-array.prototype.findIndex
+  findIndex: createMethod$2(6),
+  // `Array.prototype.filterReject` method
+  // https://github.com/tc39/proposal-array-filtering
+  filterReject: createMethod$2(7)
+};
+
+var require$$0$p = internalMetadata;
+
+var iterate$1 = iterate$2;
+
+var anInstance = anInstance$1;
+
+var require$$0$o = arrayIteration;
+
+var defineProperty$7 = require$$0$r.f;
+var forEach$5 = require$$0$o.forEach;
+
+
+
+var setInternalState$3 = InternalStateModule.set;
+var internalStateGetterFor$1 = InternalStateModule.getterFor;
+
+var collection$1 = function (CONSTRUCTOR_NAME, wrapper, common) {
+  var IS_MAP = CONSTRUCTOR_NAME.indexOf('Map') !== -1;
+  var IS_WEAK = CONSTRUCTOR_NAME.indexOf('Weak') !== -1;
+  var ADDER = IS_MAP ? 'set' : 'add';
+  var NativeConstructor = globalThis$1[CONSTRUCTOR_NAME];
+  var NativePrototype = NativeConstructor && NativeConstructor.prototype;
+  var exported = {};
+  var Constructor;
+
+  if (!DESCRIPTORS || !isCallable(NativeConstructor)
+    || !(IS_WEAK || NativePrototype.forEach && !fails(function () { new NativeConstructor().entries().next(); }))
+  ) {
+    // create collection constructor
+    Constructor = common.getConstructor(wrapper, CONSTRUCTOR_NAME, IS_MAP, ADDER);
+    require$$0$p.enable();
+  } else {
+    Constructor = wrapper(function (target, iterable) {
+      setInternalState$3(anInstance(target, Prototype), {
+        type: CONSTRUCTOR_NAME,
+        collection: new NativeConstructor()
+      });
+      if (!isNullOrUndefined(iterable)) iterate$1(iterable, target[ADDER], { that: target, AS_ENTRIES: IS_MAP });
+    });
+
+    var Prototype = Constructor.prototype;
+
+    var getInternalState = internalStateGetterFor$1(CONSTRUCTOR_NAME);
+
+    forEach$5(['add', 'clear', 'delete', 'forEach', 'get', 'has', 'set', 'keys', 'values', 'entries'], function (KEY) {
+      var IS_ADDER = KEY === 'add' || KEY === 'set';
+      if (KEY in NativePrototype && !(IS_WEAK && KEY === 'clear')) {
+        createNonEnumerableProperty(Prototype, KEY, function (a, b) {
+          var collection = getInternalState(this).collection;
+          if (!IS_ADDER && IS_WEAK && !isObject(a)) return KEY === 'get' ? undefined : false;
+          var result = collection[KEY](a === 0 ? 0 : a, b);
+          return IS_ADDER ? this : result;
+        });
+      }
+    });
+
+    IS_WEAK || defineProperty$7(Prototype, 'size', {
+      configurable: true,
+      get: function () {
+        return getInternalState(this).collection.size;
+      }
+    });
+  }
+
+  setToStringTag(Constructor, CONSTRUCTOR_NAME, false, true);
+
+  exported[CONSTRUCTOR_NAME] = Constructor;
+  $({ global: true, forced: true }, exported);
+
+  if (!IS_WEAK) common.setStrong(Constructor, CONSTRUCTOR_NAME, IS_MAP);
+
+  return Constructor;
+};
+
+var defineBuiltInAccessor$1 = function (target, name, descriptor) {
+  return require$$0$r.f(target, name, descriptor);
+};
+
+var defineBuiltIns$1 = function (target, src, options) {
+  for (var key in src) {
+    if (options && options.unsafe && target[key]) target[key] = src[key];
+    else defineBuiltIn(target, key, src[key], options);
+  } return target;
+};
+
+var defineBuiltInAccessor = defineBuiltInAccessor$1;
+
+var SPECIES$2 = wellKnownSymbol('species');
+
+var setSpecies$1 = function (CONSTRUCTOR_NAME) {
+  var Constructor = getBuiltIn(CONSTRUCTOR_NAME);
+
+  if (DESCRIPTORS && Constructor && !Constructor[SPECIES$2]) {
+    defineBuiltInAccessor(Constructor, SPECIES$2, {
+      configurable: true,
+      get: function () { return this; }
+    });
+  }
+};
+
+var defineBuiltIns = defineBuiltIns$1;
+
+var setSpecies = setSpecies$1;
+
+var fastKey = require$$0$p.fastKey;
+
+
+var setInternalState$2 = InternalStateModule.set;
+var internalStateGetterFor = InternalStateModule.getterFor;
+
+var collectionStrong$1 = {
+  getConstructor: function (wrapper, CONSTRUCTOR_NAME, IS_MAP, ADDER) {
+    var Constructor = wrapper(function (that, iterable) {
+      anInstance(that, Prototype);
+      setInternalState$2(that, {
+        type: CONSTRUCTOR_NAME,
+        index: nativeObjectCreate(null),
+        first: null,
+        last: null,
+        size: 0
+      });
+      if (!DESCRIPTORS) that.size = 0;
+      if (!isNullOrUndefined(iterable)) iterate$1(iterable, that[ADDER], { that: that, AS_ENTRIES: IS_MAP });
+    });
+
+    var Prototype = Constructor.prototype;
+
+    var getInternalState = internalStateGetterFor(CONSTRUCTOR_NAME);
+
+    var define = function (that, key, value) {
+      var state = getInternalState(that);
+      var entry = getEntry(that, key);
+      var previous, index;
+      // change existing entry
+      if (entry) {
+        entry.value = value;
+      // create new entry
+      } else {
+        state.last = entry = {
+          index: index = fastKey(key, true),
+          key: key,
+          value: value,
+          previous: previous = state.last,
+          next: null,
+          removed: false
+        };
+        if (!state.first) state.first = entry;
+        if (previous) previous.next = entry;
+        if (DESCRIPTORS) state.size++;
+        else that.size++;
+        // add to index
+        if (index !== 'F') state.index[index] = entry;
+      } return that;
+    };
+
+    var getEntry = function (that, key) {
+      var state = getInternalState(that);
+      // fast case
+      var index = fastKey(key);
+      var entry;
+      if (index !== 'F') return state.index[index];
+      // frozen object case
+      for (entry = state.first; entry; entry = entry.next) {
+        if (entry.key === key) return entry;
+      }
+    };
+
+    defineBuiltIns(Prototype, {
+      // `{ Map, Set }.prototype.clear()` methods
+      // https://tc39.es/ecma262/#sec-map.prototype.clear
+      // https://tc39.es/ecma262/#sec-set.prototype.clear
+      clear: function clear() {
+        var that = this;
+        var state = getInternalState(that);
+        var entry = state.first;
+        while (entry) {
+          entry.removed = true;
+          if (entry.previous) entry.previous = entry.previous.next = null;
+          entry = entry.next;
+        }
+        state.first = state.last = null;
+        state.index = nativeObjectCreate(null);
+        if (DESCRIPTORS) state.size = 0;
+        else that.size = 0;
+      },
+      // `{ Map, Set }.prototype.delete(key)` methods
+      // https://tc39.es/ecma262/#sec-map.prototype.delete
+      // https://tc39.es/ecma262/#sec-set.prototype.delete
+      'delete': function (key) {
+        var that = this;
+        var state = getInternalState(that);
+        var entry = getEntry(that, key);
+        if (entry) {
+          var next = entry.next;
+          var prev = entry.previous;
+          delete state.index[entry.index];
+          entry.removed = true;
+          if (prev) prev.next = next;
+          if (next) next.previous = prev;
+          if (state.first === entry) state.first = next;
+          if (state.last === entry) state.last = prev;
+          if (DESCRIPTORS) state.size--;
+          else that.size--;
+        } return !!entry;
+      },
+      // `{ Map, Set }.prototype.forEach(callbackfn, thisArg = undefined)` methods
+      // https://tc39.es/ecma262/#sec-map.prototype.foreach
+      // https://tc39.es/ecma262/#sec-set.prototype.foreach
+      forEach: function forEach(callbackfn /* , that = undefined */) {
+        var state = getInternalState(this);
+        var boundFunction = bind(callbackfn, arguments.length > 1 ? arguments[1] : undefined);
+        var entry;
+        while (entry = entry ? entry.next : state.first) {
+          boundFunction(entry.value, entry.key, this);
+          // revert to the last existing entry
+          while (entry && entry.removed) entry = entry.previous;
+        }
+      },
+      // `{ Map, Set}.prototype.has(key)` methods
+      // https://tc39.es/ecma262/#sec-map.prototype.has
+      // https://tc39.es/ecma262/#sec-set.prototype.has
+      has: function has(key) {
+        return !!getEntry(this, key);
+      }
+    });
+
+    defineBuiltIns(Prototype, IS_MAP ? {
+      // `Map.prototype.get(key)` method
+      // https://tc39.es/ecma262/#sec-map.prototype.get
+      get: function get(key) {
+        var entry = getEntry(this, key);
+        return entry && entry.value;
+      },
+      // `Map.prototype.set(key, value)` method
+      // https://tc39.es/ecma262/#sec-map.prototype.set
+      set: function set(key, value) {
+        return define(this, key === 0 ? 0 : key, value);
+      }
+    } : {
+      // `Set.prototype.add(value)` method
+      // https://tc39.es/ecma262/#sec-set.prototype.add
+      add: function add(value) {
+        return define(this, value = value === 0 ? 0 : value, value);
+      }
+    });
+    if (DESCRIPTORS) defineBuiltInAccessor(Prototype, 'size', {
+      configurable: true,
+      get: function () {
+        return getInternalState(this).size;
+      }
+    });
+    return Constructor;
+  },
+  setStrong: function (Constructor, CONSTRUCTOR_NAME, IS_MAP) {
+    var ITERATOR_NAME = CONSTRUCTOR_NAME + ' Iterator';
+    var getInternalCollectionState = internalStateGetterFor(CONSTRUCTOR_NAME);
+    var getInternalIteratorState = internalStateGetterFor(ITERATOR_NAME);
+    // `{ Map, Set }.prototype.{ keys, values, entries, @@iterator }()` methods
+    // https://tc39.es/ecma262/#sec-map.prototype.entries
+    // https://tc39.es/ecma262/#sec-map.prototype.keys
+    // https://tc39.es/ecma262/#sec-map.prototype.values
+    // https://tc39.es/ecma262/#sec-map.prototype-@@iterator
+    // https://tc39.es/ecma262/#sec-set.prototype.entries
+    // https://tc39.es/ecma262/#sec-set.prototype.keys
+    // https://tc39.es/ecma262/#sec-set.prototype.values
+    // https://tc39.es/ecma262/#sec-set.prototype-@@iterator
+    defineIterator(Constructor, CONSTRUCTOR_NAME, function (iterated, kind) {
+      setInternalState$2(this, {
+        type: ITERATOR_NAME,
+        target: iterated,
+        state: getInternalCollectionState(iterated),
+        kind: kind,
+        last: null
+      });
+    }, function () {
+      var state = getInternalIteratorState(this);
+      var kind = state.kind;
+      var entry = state.last;
+      // revert to the last existing entry
+      while (entry && entry.removed) entry = entry.previous;
+      // get next entry
+      if (!state.target || !(state.last = entry = entry ? entry.next : state.state.first)) {
+        // or finish the iteration
+        state.target = null;
+        return createIterResultObject(undefined, true);
+      }
+      // return step by kind
+      if (kind === 'keys') return createIterResultObject(entry.key, false);
+      if (kind === 'values') return createIterResultObject(entry.value, false);
+      return createIterResultObject([entry.key, entry.value], false);
+    }, IS_MAP ? 'entries' : 'values', !IS_MAP, true);
+
+    // `{ Map, Set }.prototype[@@species]` accessors
+    // https://tc39.es/ecma262/#sec-get-map-@@species
+    // https://tc39.es/ecma262/#sec-get-set-@@species
+    setSpecies(CONSTRUCTOR_NAME);
+  }
+};
+
+var collection = collection$1;
+
+var collectionStrong = collectionStrong$1;
+
+// `Map` constructor
+// https://tc39.es/ecma262/#sec-map-objects
+collection('Map', function (init) {
+  return function Map() { return init(this, arguments.length ? arguments[0] : undefined); };
+}, collectionStrong);
+
+var caller$1 = function (methodName, numArgs) {
+  return numArgs === 1 ? function (object, arg) {
+    return object[methodName](arg);
+  } : function (object, arg1, arg2) {
+    return object[methodName](arg1, arg2);
+  };
+};
+
+var caller = caller$1;
+
+var Map$2 = getBuiltIn('Map');
+
+var mapHelpers = {
+  Map: Map$2,
+  set: caller('set', 2),
+  get: caller('get', 1),
+  has: caller('has', 1),
+  remove: caller('delete', 1),
+  proto: Map$2.prototype
+};
+
+var MapHelpers = mapHelpers;
+
+var Map$1 = MapHelpers.Map;
+var has$5 = MapHelpers.has;
+var get = MapHelpers.get;
+var set$3 = MapHelpers.set;
+var push$8 = uncurryThis$1([].push);
+
+var DOES_NOT_WORK_WITH_PRIMITIVES = IS_PURE || fails(function () {
+  return Map$1.groupBy('ab', function (it) {
+    return it;
+  }).get('a').length !== 1;
+});
+
+// `Map.groupBy` method
+// https://tc39.es/ecma262/#sec-map.groupby
+$({ target: 'Map', stat: true, forced: IS_PURE || DOES_NOT_WORK_WITH_PRIMITIVES }, {
+  groupBy: function groupBy(items, callbackfn) {
+    requireObjectCoercible(items);
+    aCallable(callbackfn);
+    var map = new Map$1();
+    var k = 0;
+    iterate$1(items, function (value) {
+      var key = callbackfn(value, k++);
+      if (!has$5(map, key)) set$3(map, key, [value]);
+      else push$8(get(map, key), value);
+    });
+    return map;
+  }
+});
+
+var $String$1 = String;
+
+var toString$1 = function (argument) {
+  if (classof(argument) === 'Symbol') throw new TypeError('Cannot convert a Symbol value to a string');
+  return $String$1(argument);
+};
+
+var toString = toString$1;
+
+var charAt$2 = uncurryThis$1(''.charAt);
+var charCodeAt$1 = uncurryThis$1(''.charCodeAt);
+var stringSlice$1 = uncurryThis$1(''.slice);
+
+var createMethod$1 = function (CONVERT_TO_STRING) {
+  return function ($this, pos) {
+    var S = toString(requireObjectCoercible($this));
+    var position = toIntegerOrInfinity(pos);
+    var size = S.length;
+    var first, second;
+    if (position < 0 || position >= size) return CONVERT_TO_STRING ? '' : undefined;
+    first = charCodeAt$1(S, position);
+    return first < 0xD800 || first > 0xDBFF || position + 1 === size
+      || (second = charCodeAt$1(S, position + 1)) < 0xDC00 || second > 0xDFFF
+        ? CONVERT_TO_STRING
+          ? charAt$2(S, position)
+          : first
+        : CONVERT_TO_STRING
+          ? stringSlice$1(S, position, position + 2)
+          : (first - 0xD800 << 10) + (second - 0xDC00) + 0x10000;
+  };
+};
+
+var stringMultibyte = {
+  // `String.prototype.codePointAt` method
+  // https://tc39.es/ecma262/#sec-string.prototype.codepointat
+  codeAt: createMethod$1(false),
+  // `String.prototype.at` method
+  // https://github.com/mathiasbynens/String.prototype.at
+  charAt: createMethod$1(true)
+};
+
+var require$$0$n = stringMultibyte;
+
+var charAt$1 = require$$0$n.charAt;
+
+
+
+
+
+var STRING_ITERATOR = 'String Iterator';
+var setInternalState$1 = InternalStateModule.set;
+var getInternalState$1 = InternalStateModule.getterFor(STRING_ITERATOR);
+
+// `String.prototype[@@iterator]` method
+// https://tc39.es/ecma262/#sec-string.prototype-@@iterator
+defineIterator(String, 'String', function (iterated) {
+  setInternalState$1(this, {
+    type: STRING_ITERATOR,
+    string: toString(iterated),
+    index: 0
+  });
+// `%StringIteratorPrototype%.next` method
+// https://tc39.es/ecma262/#sec-%stringiteratorprototype%.next
+}, function next() {
+  var state = getInternalState$1(this);
+  var string = state.string;
+  var index = state.index;
+  var point;
+  if (index >= string.length) return createIterResultObject(undefined, true);
+  point = charAt$1(string, index);
+  state.index += point.length;
+  return createIterResultObject(point, false);
+});
+
+var map$2 = path.Map;
+
+// iterable DOM collections
+// flag - `iterable` interface - 'entries', 'keys', 'values', 'forEach' methods
+var domIterables = {
+  CSSRuleList: 0,
+  CSSStyleDeclaration: 0,
+  CSSValueList: 0,
+  ClientRectList: 0,
+  DOMRectList: 0,
+  DOMStringList: 0,
+  DOMTokenList: 1,
+  DataTransferItemList: 0,
+  FileList: 0,
+  HTMLAllCollection: 0,
+  HTMLCollection: 0,
+  HTMLFormElement: 0,
+  HTMLSelectElement: 0,
+  MediaList: 0,
+  MimeTypeArray: 0,
+  NamedNodeMap: 0,
+  NodeList: 1,
+  PaintRequestList: 0,
+  Plugin: 0,
+  PluginArray: 0,
+  SVGLengthList: 0,
+  SVGNumberList: 0,
+  SVGPathSegList: 0,
+  SVGPointList: 0,
+  SVGStringList: 0,
+  SVGTransformList: 0,
+  SourceBufferList: 0,
+  StyleSheetList: 0,
+  TextTrackCueList: 0,
+  TextTrackList: 0,
+  TouchList: 0
+};
+
+var DOMIterables$3 = domIterables;
+
+for (var COLLECTION_NAME in DOMIterables$3) {
+  setToStringTag(globalThis$1[COLLECTION_NAME], COLLECTION_NAME);
+  Iterators[COLLECTION_NAME] = Iterators.Array;
+}
+
+var parent$B = map$2;
+
+var map$1 = parent$B;
+
+var require$$0$m = map$1;
+
+var map = require$$0$m;
+
+var ariaPropsMap_1 = createCommonjsModule(function (module, exports) {
+
+
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+
+var _map = interopRequireDefault(map);
+
+var ariaPropsMap = new _map.default([['aria-activedescendant', {
+  'type': 'id'
+}], ['aria-atomic', {
+  'type': 'boolean'
+}], ['aria-autocomplete', {
+  'type': 'token',
+  'values': ['inline', 'list', 'both', 'none']
+}], ['aria-busy', {
+  'type': 'boolean'
+}], ['aria-checked', {
+  'type': 'tristate'
+}], ['aria-colcount', {
+  type: 'integer'
+}], ['aria-colindex', {
+  type: 'integer'
+}], ['aria-colspan', {
+  type: 'integer'
+}], ['aria-controls', {
+  'type': 'idlist'
+}], ['aria-current', {
+  type: 'token',
+  values: ['page', 'step', 'location', 'date', 'time', true, false]
+}], ['aria-describedby', {
+  'type': 'idlist'
+}], ['aria-details', {
+  'type': 'id'
+}], ['aria-disabled', {
+  'type': 'boolean'
+}], ['aria-dropeffect', {
+  'type': 'tokenlist',
+  'values': ['copy', 'execute', 'link', 'move', 'none', 'popup']
+}], ['aria-errormessage', {
+  'type': 'id'
+}], ['aria-expanded', {
+  'type': 'boolean',
+  'allowundefined': true
+}], ['aria-flowto', {
+  'type': 'idlist'
+}], ['aria-grabbed', {
+  'type': 'boolean',
+  'allowundefined': true
+}], ['aria-haspopup', {
+  'type': 'token',
+  'values': [false, true, 'menu', 'listbox', 'tree', 'grid', 'dialog']
+}], ['aria-hidden', {
+  'type': 'boolean',
+  'allowundefined': true
+}], ['aria-invalid', {
+  'type': 'token',
+  'values': ['grammar', false, 'spelling', true]
+}], ['aria-keyshortcuts', {
+  type: 'string'
+}], ['aria-label', {
+  'type': 'string'
+}], ['aria-labelledby', {
+  'type': 'idlist'
+}], ['aria-level', {
+  'type': 'integer'
+}], ['aria-live', {
+  'type': 'token',
+  'values': ['assertive', 'off', 'polite']
+}], ['aria-modal', {
+  type: 'boolean'
+}], ['aria-multiline', {
+  'type': 'boolean'
+}], ['aria-multiselectable', {
+  'type': 'boolean'
+}], ['aria-orientation', {
+  'type': 'token',
+  'values': ['vertical', 'undefined', 'horizontal']
+}], ['aria-owns', {
+  'type': 'idlist'
+}], ['aria-placeholder', {
+  type: 'string'
+}], ['aria-posinset', {
+  'type': 'integer'
+}], ['aria-pressed', {
+  'type': 'tristate'
+}], ['aria-readonly', {
+  'type': 'boolean'
+}], ['aria-relevant', {
+  'type': 'tokenlist',
+  'values': ['additions', 'all', 'removals', 'text']
+}], ['aria-required', {
+  'type': 'boolean'
+}], ['aria-roledescription', {
+  type: 'string'
+}], ['aria-rowcount', {
+  type: 'integer'
+}], ['aria-rowindex', {
+  type: 'integer'
+}], ['aria-rowspan', {
+  type: 'integer'
+}], ['aria-selected', {
+  'type': 'boolean',
+  'allowundefined': true
+}], ['aria-setsize', {
+  'type': 'integer'
+}], ['aria-sort', {
+  'type': 'token',
+  'values': ['ascending', 'descending', 'none', 'other']
+}], ['aria-valuemax', {
+  'type': 'number'
+}], ['aria-valuemin', {
+  'type': 'number'
+}], ['aria-valuenow', {
+  'type': 'number'
+}], ['aria-valuetext', {
+  'type': 'string'
+}]]);
+var _default = ariaPropsMap;
+exports.default = _default;
+});
+
+var domMap_1 = createCommonjsModule(function (module, exports) {
+
+
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+
+var _map = interopRequireDefault(map);
+
+var domMap = new _map.default([['a', {
+  reserved: false
+}], ['abbr', {
+  reserved: false
+}], ['acronym', {
+  reserved: false
+}], ['address', {
+  reserved: false
+}], ['applet', {
+  reserved: false
+}], ['area', {
+  reserved: false
+}], ['article', {
+  reserved: false
+}], ['aside', {
+  reserved: false
+}], ['audio', {
+  reserved: false
+}], ['b', {
+  reserved: false
+}], ['base', {
+  reserved: true
+}], ['bdi', {
+  reserved: false
+}], ['bdo', {
+  reserved: false
+}], ['big', {
+  reserved: false
+}], ['blink', {
+  reserved: false
+}], ['blockquote', {
+  reserved: false
+}], ['body', {
+  reserved: false
+}], ['br', {
+  reserved: false
+}], ['button', {
+  reserved: false
+}], ['canvas', {
+  reserved: false
+}], ['caption', {
+  reserved: false
+}], ['center', {
+  reserved: false
+}], ['cite', {
+  reserved: false
+}], ['code', {
+  reserved: false
+}], ['col', {
+  reserved: true
+}], ['colgroup', {
+  reserved: true
+}], ['content', {
+  reserved: false
+}], ['data', {
+  reserved: false
+}], ['datalist', {
+  reserved: false
+}], ['dd', {
+  reserved: false
+}], ['del', {
+  reserved: false
+}], ['details', {
+  reserved: false
+}], ['dfn', {
+  reserved: false
+}], ['dialog', {
+  reserved: false
+}], ['dir', {
+  reserved: false
+}], ['div', {
+  reserved: false
+}], ['dl', {
+  reserved: false
+}], ['dt', {
+  reserved: false
+}], ['em', {
+  reserved: false
+}], ['embed', {
+  reserved: false
+}], ['fieldset', {
+  reserved: false
+}], ['figcaption', {
+  reserved: false
+}], ['figure', {
+  reserved: false
+}], ['font', {
+  reserved: false
+}], ['footer', {
+  reserved: false
+}], ['form', {
+  reserved: false
+}], ['frame', {
+  reserved: false
+}], ['frameset', {
+  reserved: false
+}], ['h1', {
+  reserved: false
+}], ['h2', {
+  reserved: false
+}], ['h3', {
+  reserved: false
+}], ['h4', {
+  reserved: false
+}], ['h5', {
+  reserved: false
+}], ['h6', {
+  reserved: false
+}], ['head', {
+  reserved: true
+}], ['header', {
+  reserved: false
+}], ['hgroup', {
+  reserved: false
+}], ['hr', {
+  reserved: false
+}], ['html', {
+  reserved: true
+}], ['i', {
+  reserved: false
+}], ['iframe', {
+  reserved: false
+}], ['img', {
+  reserved: false
+}], ['input', {
+  reserved: false
+}], ['ins', {
+  reserved: false
+}], ['kbd', {
+  reserved: false
+}], ['keygen', {
+  reserved: false
+}], ['label', {
+  reserved: false
+}], ['legend', {
+  reserved: false
+}], ['li', {
+  reserved: false
+}], ['link', {
+  reserved: true
+}], ['main', {
+  reserved: false
+}], ['map', {
+  reserved: false
+}], ['mark', {
+  reserved: false
+}], ['marquee', {
+  reserved: false
+}], ['menu', {
+  reserved: false
+}], ['menuitem', {
+  reserved: false
+}], ['meta', {
+  reserved: true
+}], ['meter', {
+  reserved: false
+}], ['nav', {
+  reserved: false
+}], ['noembed', {
+  reserved: true
+}], ['noscript', {
+  reserved: true
+}], ['object', {
+  reserved: false
+}], ['ol', {
+  reserved: false
+}], ['optgroup', {
+  reserved: false
+}], ['option', {
+  reserved: false
+}], ['output', {
+  reserved: false
+}], ['p', {
+  reserved: false
+}], ['param', {
+  reserved: true
+}], ['picture', {
+  reserved: true
+}], ['pre', {
+  reserved: false
+}], ['progress', {
+  reserved: false
+}], ['q', {
+  reserved: false
+}], ['rp', {
+  reserved: false
+}], ['rt', {
+  reserved: false
+}], ['rtc', {
+  reserved: false
+}], ['ruby', {
+  reserved: false
+}], ['s', {
+  reserved: false
+}], ['samp', {
+  reserved: false
+}], ['script', {
+  reserved: true
+}], ['section', {
+  reserved: false
+}], ['select', {
+  reserved: false
+}], ['small', {
+  reserved: false
+}], ['source', {
+  reserved: true
+}], ['spacer', {
+  reserved: false
+}], ['span', {
+  reserved: false
+}], ['strike', {
+  reserved: false
+}], ['strong', {
+  reserved: false
+}], ['style', {
+  reserved: true
+}], ['sub', {
+  reserved: false
+}], ['summary', {
+  reserved: false
+}], ['sup', {
+  reserved: false
+}], ['table', {
+  reserved: false
+}], ['tbody', {
+  reserved: false
+}], ['td', {
+  reserved: false
+}], ['textarea', {
+  reserved: false
+}], ['tfoot', {
+  reserved: false
+}], ['th', {
+  reserved: false
+}], ['thead', {
+  reserved: false
+}], ['time', {
+  reserved: false
+}], ['title', {
+  reserved: true
+}], ['tr', {
+  reserved: false
+}], ['track', {
+  reserved: true
+}], ['tt', {
+  reserved: false
+}], ['u', {
+  reserved: false
+}], ['ul', {
+  reserved: false
+}], ['var', {
+  reserved: false
+}], ['video', {
+  reserved: false
+}], ['wbr', {
+  reserved: false
+}], ['xmp', {
+  reserved: false
+}]]);
+var _default = domMap;
+exports.default = _default;
+});
+
+var getIterator_1 = getIterator$5;
+
+var parent$A = getIterator_1;
+
+var getIterator$4 = parent$A;
+
+var parent$z = getIterator$4;
+
+var getIterator$3 = parent$z;
+
+var parent$y = getIterator$3;
+
+var getIterator$2 = parent$y;
+
+var require$$0$l = getIterator$2;
+
+var getIterator$1 = require$$0$l;
+
+var require$$0$k = getIterator$1;
+
+var getIterator = require$$0$k;
+
+// `Array.isArray` method
+// https://tc39.es/ecma262/#sec-array.isarray
+$({ target: 'Array', stat: true }, {
+  isArray: isArray$6
+});
+
+var isArray$5 = path.Array.isArray;
+
+var parent$x = isArray$5;
+
+var isArray$4 = parent$x;
+
+var parent$w = isArray$4;
+
+var isArray$3 = parent$w;
+
+var getIteratorMethod_1 = getIteratorMethod$5;
+
+var parent$v = getIteratorMethod_1;
+
+var getIteratorMethod$4 = parent$v;
+
+var parent$u = getIteratorMethod$4;
+
+var getIteratorMethod$3 = parent$u;
+
+var parent$t = getIteratorMethod$3;
+
+var getIteratorMethod$2 = parent$t;
+
+var require$$0$j = getIteratorMethod$2;
+
+var getIteratorMethod$1 = require$$0$j;
+
+var _getIteratorMethod = getIteratorMethod$1;
+
+var getIteratorMethod = _getIteratorMethod;
+
+var $TypeError$3 = TypeError;
+var MAX_SAFE_INTEGER = 0x1FFFFFFFFFFFFF; // 2 ** 53 - 1 == 9007199254740991
+
+var doesNotExceedSafeInteger$1 = function (it) {
+  if (it > MAX_SAFE_INTEGER) throw $TypeError$3('Maximum allowed index exceeded');
+  return it;
+};
+
+var createProperty$1 = function (object, key, value) {
+  if (DESCRIPTORS) require$$0$r.f(object, key, createPropertyDescriptor(0, value));
+  else object[key] = value;
+};
+
+var SPECIES$1 = wellKnownSymbol('species');
+
+var arrayMethodHasSpeciesSupport$1 = function (METHOD_NAME) {
+  // We can't use this feature detection in V8 since it causes
+  // deoptimization and serious performance degradation
+  // https://github.com/zloirock/core-js/issues/677
+  return V8_VERSION >= 51 || !fails(function () {
+    var array = [];
+    var constructor = array.constructor = {};
+    constructor[SPECIES$1] = function () {
+      return { foo: 1 };
+    };
+    return array[METHOD_NAME](Boolean).foo !== 1;
+  });
+};
+
+var doesNotExceedSafeInteger = doesNotExceedSafeInteger$1;
+
+var createProperty = createProperty$1;
+
+var arrayMethodHasSpeciesSupport = arrayMethodHasSpeciesSupport$1;
+
+var IS_CONCAT_SPREADABLE = wellKnownSymbol('isConcatSpreadable');
+
+// We can't use this feature detection in V8 since it causes
+// deoptimization and serious performance degradation
+// https://github.com/zloirock/core-js/issues/679
+var IS_CONCAT_SPREADABLE_SUPPORT = V8_VERSION >= 51 || !fails(function () {
+  var array = [];
+  array[IS_CONCAT_SPREADABLE] = false;
+  return array.concat()[0] !== array;
+});
+
+var isConcatSpreadable = function (O) {
+  if (!isObject(O)) return false;
+  var spreadable = O[IS_CONCAT_SPREADABLE];
+  return spreadable !== undefined ? !!spreadable : isArray$6(O);
+};
+
+var FORCED$3 = !IS_CONCAT_SPREADABLE_SUPPORT || !arrayMethodHasSpeciesSupport('concat');
+
+// `Array.prototype.concat` method
+// https://tc39.es/ecma262/#sec-array.prototype.concat
+// with adding support of @@isConcatSpreadable and @@species
+$({ target: 'Array', proto: true, arity: 1, forced: FORCED$3 }, {
+  // eslint-disable-next-line no-unused-vars -- required for `.length`
+  concat: function concat(arg) {
+    var O = toObject$1(this);
+    var A = arraySpeciesCreate(O, 0);
+    var n = 0;
+    var i, k, length, len, E;
+    for (i = -1, length = arguments.length; i < length; i++) {
+      E = i === -1 ? O : arguments[i];
+      if (isConcatSpreadable(E)) {
+        len = lengthOfArrayLike(E);
+        doesNotExceedSafeInteger(n + len);
+        for (k = 0; k < len; k++, n++) if (k in E) createProperty(A, n, E[k]);
+      } else {
+        doesNotExceedSafeInteger(n + 1);
+        createProperty(A, n++, E);
+      }
+    }
+    A.length = n;
+    return A;
+  }
+});
+
+// eslint-disable-next-line es/no-object-getownpropertysymbols -- safe
+var f$1 = Object.getOwnPropertySymbols;
+
+var objectGetOwnPropertySymbols = {
+	f: f$1
+};
+
+var f = wellKnownSymbol;
+
+var wellKnownSymbolWrapped = {
+	f: f
+};
+
+var WrappedWellKnownSymbolModule = wellKnownSymbolWrapped;
+
+var defineProperty$6 = require$$0$r.f;
+
+var wellKnownSymbolDefine = function (NAME) {
+  var Symbol = path.Symbol || (path.Symbol = {});
+  if (!hasOwn(Symbol, NAME)) defineProperty$6(Symbol, NAME, {
+    value: WrappedWellKnownSymbolModule.f(NAME)
+  });
+};
+
+var symbolDefineToPrimitive = function () {
+  var Symbol = getBuiltIn('Symbol');
+  var SymbolPrototype = Symbol && Symbol.prototype;
+  var valueOf = SymbolPrototype && SymbolPrototype.valueOf;
+  var TO_PRIMITIVE = wellKnownSymbol('toPrimitive');
+
+  if (SymbolPrototype && !SymbolPrototype[TO_PRIMITIVE]) {
+    // `Symbol.prototype[@@toPrimitive]` method
+    // https://tc39.es/ecma262/#sec-symbol.prototype-@@toprimitive
+    // eslint-disable-next-line no-unused-vars -- required for .length
+    defineBuiltIn(SymbolPrototype, TO_PRIMITIVE, function (hint) {
+      return call(valueOf, this);
+    }, { arity: 1 });
+  }
+};
+
+var getOwnPropertySymbolsModule = objectGetOwnPropertySymbols;
+
+var defineWellKnownSymbol = wellKnownSymbolDefine;
+
+var defineSymbolToPrimitive = symbolDefineToPrimitive;
+
+var $forEach$1 = require$$0$o.forEach;
+
+var HIDDEN = sharedKey('hidden');
+var SYMBOL = 'Symbol';
+var PROTOTYPE = 'prototype';
+
+var setInternalState = InternalStateModule.set;
+var getInternalState = InternalStateModule.getterFor(SYMBOL);
+
+var ObjectPrototype = Object[PROTOTYPE];
+var $Symbol = globalThis$1.Symbol;
+var SymbolPrototype = $Symbol && $Symbol[PROTOTYPE];
+var RangeError$1 = globalThis$1.RangeError;
+var TypeError$1 = globalThis$1.TypeError;
+var QObject = globalThis$1.QObject;
+var nativeGetOwnPropertyDescriptor = getOwnPropertyDescriptorModule.f;
+var nativeDefineProperty = require$$0$r.f;
+var nativeGetOwnPropertyNames = getOwnPropertyNamesExternal.f;
+var nativePropertyIsEnumerable = propertyIsEnumerableModule.f;
+var push$7 = uncurryThis$1([].push);
+
+var AllSymbols = shared$1('symbols');
+var ObjectPrototypeSymbols = shared$1('op-symbols');
+var WellKnownSymbolsStore$1 = shared$1('wks');
+
+// Don't use setters in Qt Script, https://github.com/zloirock/core-js/issues/173
+var USE_SETTER = !QObject || !QObject[PROTOTYPE] || !QObject[PROTOTYPE].findChild;
+
+// fallback for old Android, https://code.google.com/p/v8/issues/detail?id=687
+var fallbackDefineProperty = function (O, P, Attributes) {
+  var ObjectPrototypeDescriptor = nativeGetOwnPropertyDescriptor(ObjectPrototype, P);
+  if (ObjectPrototypeDescriptor) delete ObjectPrototype[P];
+  nativeDefineProperty(O, P, Attributes);
+  if (ObjectPrototypeDescriptor && O !== ObjectPrototype) {
+    nativeDefineProperty(ObjectPrototype, P, ObjectPrototypeDescriptor);
+  }
+};
+
+var setSymbolDescriptor = DESCRIPTORS && fails(function () {
+  return nativeObjectCreate(nativeDefineProperty({}, 'a', {
+    get: function () { return nativeDefineProperty(this, 'a', { value: 7 }).a; }
+  })).a !== 7;
+}) ? fallbackDefineProperty : nativeDefineProperty;
+
+var wrap = function (tag, description) {
+  var symbol = AllSymbols[tag] = nativeObjectCreate(SymbolPrototype);
+  setInternalState(symbol, {
+    type: SYMBOL,
+    tag: tag,
+    description: description
+  });
+  if (!DESCRIPTORS) symbol.description = description;
+  return symbol;
+};
+
+var $defineProperty = function defineProperty(O, P, Attributes) {
+  if (O === ObjectPrototype) $defineProperty(ObjectPrototypeSymbols, P, Attributes);
+  anObject(O);
+  var key = toPropertyKey(P);
+  anObject(Attributes);
+  if (hasOwn(AllSymbols, key)) {
+    if (!Attributes.enumerable) {
+      if (!hasOwn(O, HIDDEN)) nativeDefineProperty(O, HIDDEN, createPropertyDescriptor(1, nativeObjectCreate(null)));
+      O[HIDDEN][key] = true;
+    } else {
+      if (hasOwn(O, HIDDEN) && O[HIDDEN][key]) O[HIDDEN][key] = false;
+      Attributes = nativeObjectCreate(Attributes, { enumerable: createPropertyDescriptor(0, false) });
+    } return setSymbolDescriptor(O, key, Attributes);
+  } return nativeDefineProperty(O, key, Attributes);
+};
+
+var $defineProperties = function defineProperties(O, Properties) {
+  anObject(O);
+  var properties = toIndexedObject(Properties);
+  var keys = nativeKeys(properties).concat($getOwnPropertySymbols(properties));
+  $forEach$1(keys, function (key) {
+    if (!DESCRIPTORS || call($propertyIsEnumerable, properties, key)) $defineProperty(O, key, properties[key]);
+  });
+  return O;
+};
+
+var $create = function create(O, Properties) {
+  return Properties === undefined ? nativeObjectCreate(O) : $defineProperties(nativeObjectCreate(O), Properties);
+};
+
+var $propertyIsEnumerable = function propertyIsEnumerable(V) {
+  var P = toPropertyKey(V);
+  var enumerable = call(nativePropertyIsEnumerable, this, P);
+  if (this === ObjectPrototype && hasOwn(AllSymbols, P) && !hasOwn(ObjectPrototypeSymbols, P)) return false;
+  return enumerable || !hasOwn(this, P) || !hasOwn(AllSymbols, P) || hasOwn(this, HIDDEN) && this[HIDDEN][P]
+    ? enumerable : true;
+};
+
+var $getOwnPropertyDescriptor = function getOwnPropertyDescriptor(O, P) {
+  var it = toIndexedObject(O);
+  var key = toPropertyKey(P);
+  if (it === ObjectPrototype && hasOwn(AllSymbols, key) && !hasOwn(ObjectPrototypeSymbols, key)) return;
+  var descriptor = nativeGetOwnPropertyDescriptor(it, key);
+  if (descriptor && hasOwn(AllSymbols, key) && !(hasOwn(it, HIDDEN) && it[HIDDEN][key])) {
+    descriptor.enumerable = true;
+  }
+  return descriptor;
+};
+
+var $getOwnPropertyNames = function getOwnPropertyNames(O) {
+  var names = nativeGetOwnPropertyNames(toIndexedObject(O));
+  var result = [];
+  $forEach$1(names, function (key) {
+    if (!hasOwn(AllSymbols, key) && !hasOwn(hiddenKeys$1, key)) push$7(result, key);
+  });
+  return result;
+};
+
+var $getOwnPropertySymbols = function (O) {
+  var IS_OBJECT_PROTOTYPE = O === ObjectPrototype;
+  var names = nativeGetOwnPropertyNames(IS_OBJECT_PROTOTYPE ? ObjectPrototypeSymbols : toIndexedObject(O));
+  var result = [];
+  $forEach$1(names, function (key) {
+    if (hasOwn(AllSymbols, key) && (!IS_OBJECT_PROTOTYPE || hasOwn(ObjectPrototype, key))) {
+      push$7(result, AllSymbols[key]);
+    }
+  });
+  return result;
+};
+
+// `Symbol` constructor
+// https://tc39.es/ecma262/#sec-symbol-constructor
+if (!NATIVE_SYMBOL) {
+  $Symbol = function Symbol() {
+    if (isPrototypeOf(SymbolPrototype, this)) throw new TypeError$1('Symbol is not a constructor');
+    var description = !arguments.length || arguments[0] === undefined ? undefined : toString(arguments[0]);
+    var tag = uid(description);
+    var setter = function (value) {
+      var $this = this === undefined ? globalThis$1 : this;
+      if ($this === ObjectPrototype) call(setter, ObjectPrototypeSymbols, value);
+      if (hasOwn($this, HIDDEN) && hasOwn($this[HIDDEN], tag)) $this[HIDDEN][tag] = false;
+      var descriptor = createPropertyDescriptor(1, value);
+      try {
+        setSymbolDescriptor($this, tag, descriptor);
+      } catch (error) {
+        if (!(error instanceof RangeError$1)) throw error;
+        fallbackDefineProperty($this, tag, descriptor);
+      }
+    };
+    if (DESCRIPTORS && USE_SETTER) setSymbolDescriptor(ObjectPrototype, tag, { configurable: true, set: setter });
+    return wrap(tag, description);
+  };
+
+  SymbolPrototype = $Symbol[PROTOTYPE];
+
+  defineBuiltIn(SymbolPrototype, 'toString', function toString() {
+    return getInternalState(this).tag;
+  });
+
+  defineBuiltIn($Symbol, 'withoutSetter', function (description) {
+    return wrap(uid(description), description);
+  });
+
+  propertyIsEnumerableModule.f = $propertyIsEnumerable;
+  require$$0$r.f = $defineProperty;
+  definePropertiesModule.f = $defineProperties;
+  getOwnPropertyDescriptorModule.f = $getOwnPropertyDescriptor;
+  getOwnPropertyNamesModule.f = getOwnPropertyNamesExternal.f = $getOwnPropertyNames;
+  getOwnPropertySymbolsModule.f = $getOwnPropertySymbols;
+
+  WrappedWellKnownSymbolModule.f = function (name) {
+    return wrap(wellKnownSymbol(name), name);
+  };
+
+  if (DESCRIPTORS) {
+    // https://github.com/tc39/proposal-Symbol-description
+    defineBuiltInAccessor(SymbolPrototype, 'description', {
+      configurable: true,
+      get: function description() {
+        return getInternalState(this).description;
+      }
+    });
+    if (!IS_PURE) {
+      defineBuiltIn(ObjectPrototype, 'propertyIsEnumerable', $propertyIsEnumerable, { unsafe: true });
+    }
+  }
+}
+
+$({ global: true, constructor: true, wrap: true, forced: !NATIVE_SYMBOL, sham: !NATIVE_SYMBOL }, {
+  Symbol: $Symbol
+});
+
+$forEach$1(nativeKeys(WellKnownSymbolsStore$1), function (name) {
+  defineWellKnownSymbol(name);
+});
+
+$({ target: SYMBOL, stat: true, forced: !NATIVE_SYMBOL }, {
+  useSetter: function () { USE_SETTER = true; },
+  useSimple: function () { USE_SETTER = false; }
+});
+
+$({ target: 'Object', stat: true, forced: !NATIVE_SYMBOL, sham: !DESCRIPTORS }, {
+  // `Object.create` method
+  // https://tc39.es/ecma262/#sec-object.create
+  create: $create,
+  // `Object.defineProperty` method
+  // https://tc39.es/ecma262/#sec-object.defineproperty
+  defineProperty: $defineProperty,
+  // `Object.defineProperties` method
+  // https://tc39.es/ecma262/#sec-object.defineproperties
+  defineProperties: $defineProperties,
+  // `Object.getOwnPropertyDescriptor` method
+  // https://tc39.es/ecma262/#sec-object.getownpropertydescriptors
+  getOwnPropertyDescriptor: $getOwnPropertyDescriptor
+});
+
+$({ target: 'Object', stat: true, forced: !NATIVE_SYMBOL }, {
+  // `Object.getOwnPropertyNames` method
+  // https://tc39.es/ecma262/#sec-object.getownpropertynames
+  getOwnPropertyNames: $getOwnPropertyNames
+});
+
+// `Symbol.prototype[@@toPrimitive]` method
+// https://tc39.es/ecma262/#sec-symbol.prototype-@@toprimitive
+defineSymbolToPrimitive();
+
+// `Symbol.prototype[@@toStringTag]` property
+// https://tc39.es/ecma262/#sec-symbol.prototype-@@tostringtag
+setToStringTag($Symbol, SYMBOL);
+
+hiddenKeys$1[HIDDEN] = true;
+
+/* eslint-disable es/no-symbol -- safe */
+var symbolRegistryDetection = NATIVE_SYMBOL && !!Symbol['for'] && !!Symbol.keyFor;
+
+var NATIVE_SYMBOL_REGISTRY = symbolRegistryDetection;
+
+var StringToSymbolRegistry = shared$1('string-to-symbol-registry');
+var SymbolToStringRegistry$1 = shared$1('symbol-to-string-registry');
+
+// `Symbol.for` method
+// https://tc39.es/ecma262/#sec-symbol.for
+$({ target: 'Symbol', stat: true, forced: !NATIVE_SYMBOL_REGISTRY }, {
+  'for': function (key) {
+    var string = toString(key);
+    if (hasOwn(StringToSymbolRegistry, string)) return StringToSymbolRegistry[string];
+    var symbol = getBuiltIn('Symbol')(string);
+    StringToSymbolRegistry[string] = symbol;
+    SymbolToStringRegistry$1[symbol] = string;
+    return symbol;
+  }
+});
+
+var SymbolToStringRegistry = shared$1('symbol-to-string-registry');
+
+// `Symbol.keyFor` method
+// https://tc39.es/ecma262/#sec-symbol.keyfor
+$({ target: 'Symbol', stat: true, forced: !NATIVE_SYMBOL_REGISTRY }, {
+  keyFor: function keyFor(sym) {
+    if (!isSymbol(sym)) throw new TypeError(tryToString(sym) + ' is not a symbol');
+    if (hasOwn(SymbolToStringRegistry, sym)) return SymbolToStringRegistry[sym];
+  }
+});
+
+var push$6 = uncurryThis$1([].push);
+
+var getJsonReplacerFunction = function (replacer) {
+  if (isCallable(replacer)) return replacer;
+  if (!isArray$6(replacer)) return;
+  var rawLength = replacer.length;
+  var keys = [];
+  for (var i = 0; i < rawLength; i++) {
+    var element = replacer[i];
+    if (typeof element == 'string') push$6(keys, element);
+    else if (typeof element == 'number' || classof$2(element) === 'Number' || classof$2(element) === 'String') push$6(keys, toString(element));
+  }
+  var keysLength = keys.length;
+  var root = true;
+  return function (key, value) {
+    if (root) {
+      root = false;
+      return value;
+    }
+    if (isArray$6(this)) return value;
+    for (var j = 0; j < keysLength; j++) if (keys[j] === key) return value;
+  };
+};
+
+var getReplacerFunction = getJsonReplacerFunction;
+
+var $String = String;
+var $stringify = getBuiltIn('JSON', 'stringify');
+var exec = uncurryThis$1(/./.exec);
+var charAt = uncurryThis$1(''.charAt);
+var charCodeAt = uncurryThis$1(''.charCodeAt);
+var replace = uncurryThis$1(''.replace);
+var numberToString = uncurryThis$1(1.0.toString);
+
+var tester = /[\uD800-\uDFFF]/g;
+var low = /^[\uD800-\uDBFF]$/;
+var hi = /^[\uDC00-\uDFFF]$/;
+
+var WRONG_SYMBOLS_CONVERSION = !NATIVE_SYMBOL || fails(function () {
+  var symbol = getBuiltIn('Symbol')('stringify detection');
+  // MS Edge converts symbol values to JSON as {}
+  return $stringify([symbol]) !== '[null]'
+    // WebKit converts symbol values to JSON as null
+    || $stringify({ a: symbol }) !== '{}'
+    // V8 throws on boxed symbols
+    || $stringify(Object(symbol)) !== '{}';
+});
+
+// https://github.com/tc39/proposal-well-formed-stringify
+var ILL_FORMED_UNICODE = fails(function () {
+  return $stringify('\uDF06\uD834') !== '"\\udf06\\ud834"'
+    || $stringify('\uDEAD') !== '"\\udead"';
+});
+
+var stringifyWithSymbolsFix = function (it, replacer) {
+  var args = nativeSlice(arguments);
+  var $replacer = getReplacerFunction(replacer);
+  if (!isCallable($replacer) && (it === undefined || isSymbol(it))) return; // IE8 returns string on undefined
+  args[1] = function (key, value) {
+    // some old implementations (like WebKit) could pass numbers as keys
+    if (isCallable($replacer)) value = call($replacer, this, $String(key), value);
+    if (!isSymbol(value)) return value;
+  };
+  return apply($stringify, null, args);
+};
+
+var fixIllFormed = function (match, offset, string) {
+  var prev = charAt(string, offset - 1);
+  var next = charAt(string, offset + 1);
+  if ((exec(low, match) && !exec(hi, next)) || (exec(hi, match) && !exec(low, prev))) {
+    return '\\u' + numberToString(charCodeAt(match, 0), 16);
+  } return match;
+};
+
+if ($stringify) {
+  // `JSON.stringify` method
+  // https://tc39.es/ecma262/#sec-json.stringify
+  $({ target: 'JSON', stat: true, arity: 3, forced: WRONG_SYMBOLS_CONVERSION || ILL_FORMED_UNICODE }, {
+    // eslint-disable-next-line no-unused-vars -- required for `.length`
+    stringify: function stringify(it, replacer, space) {
+      var args = nativeSlice(arguments);
+      var result = apply(WRONG_SYMBOLS_CONVERSION ? stringifyWithSymbolsFix : $stringify, null, args);
+      return ILL_FORMED_UNICODE && typeof result == 'string' ? replace(result, tester, fixIllFormed) : result;
+    }
+  });
+}
+
+// V8 ~ Chrome 38 and 39 `Object.getOwnPropertySymbols` fails on primitives
+// https://bugs.chromium.org/p/v8/issues/detail?id=3443
+var FORCED$2 = !NATIVE_SYMBOL || fails(function () { getOwnPropertySymbolsModule.f(1); });
+
+// `Object.getOwnPropertySymbols` method
+// https://tc39.es/ecma262/#sec-object.getownpropertysymbols
+$({ target: 'Object', stat: true, forced: FORCED$2 }, {
+  getOwnPropertySymbols: function getOwnPropertySymbols(it) {
+    var $getOwnPropertySymbols = getOwnPropertySymbolsModule.f;
+    return $getOwnPropertySymbols ? $getOwnPropertySymbols(toObject$1(it)) : [];
+  }
+});
+
+// `Symbol.asyncIterator` well-known symbol
+// https://tc39.es/ecma262/#sec-symbol.asynciterator
+defineWellKnownSymbol('asyncIterator');
+
+// `Symbol.hasInstance` well-known symbol
+// https://tc39.es/ecma262/#sec-symbol.hasinstance
+defineWellKnownSymbol('hasInstance');
+
+// `Symbol.isConcatSpreadable` well-known symbol
+// https://tc39.es/ecma262/#sec-symbol.isconcatspreadable
+defineWellKnownSymbol('isConcatSpreadable');
+
+// `Symbol.iterator` well-known symbol
+// https://tc39.es/ecma262/#sec-symbol.iterator
+defineWellKnownSymbol('iterator');
+
+// `Symbol.match` well-known symbol
+// https://tc39.es/ecma262/#sec-symbol.match
+defineWellKnownSymbol('match');
+
+// `Symbol.matchAll` well-known symbol
+// https://tc39.es/ecma262/#sec-symbol.matchall
+defineWellKnownSymbol('matchAll');
+
+// `Symbol.replace` well-known symbol
+// https://tc39.es/ecma262/#sec-symbol.replace
+defineWellKnownSymbol('replace');
+
+// `Symbol.search` well-known symbol
+// https://tc39.es/ecma262/#sec-symbol.search
+defineWellKnownSymbol('search');
+
+// `Symbol.species` well-known symbol
+// https://tc39.es/ecma262/#sec-symbol.species
+defineWellKnownSymbol('species');
+
+// `Symbol.split` well-known symbol
+// https://tc39.es/ecma262/#sec-symbol.split
+defineWellKnownSymbol('split');
+
+// `Symbol.toPrimitive` well-known symbol
+// https://tc39.es/ecma262/#sec-symbol.toprimitive
+defineWellKnownSymbol('toPrimitive');
+
+// `Symbol.prototype[@@toPrimitive]` method
+// https://tc39.es/ecma262/#sec-symbol.prototype-@@toprimitive
+defineSymbolToPrimitive();
+
+// `Symbol.toStringTag` well-known symbol
+// https://tc39.es/ecma262/#sec-symbol.tostringtag
+defineWellKnownSymbol('toStringTag');
+
+// `Symbol.prototype[@@toStringTag]` property
+// https://tc39.es/ecma262/#sec-symbol.prototype-@@tostringtag
+setToStringTag(getBuiltIn('Symbol'), 'Symbol');
+
+// `Symbol.unscopables` well-known symbol
+// https://tc39.es/ecma262/#sec-symbol.unscopables
+defineWellKnownSymbol('unscopables');
+
+// JSON[@@toStringTag] property
+// https://tc39.es/ecma262/#sec-json-@@tostringtag
+setToStringTag(globalThis$1.JSON, 'JSON', true);
+
+var symbol$5 = path.Symbol;
+
+var parent$s = symbol$5;
+
+var symbol$4 = parent$s;
+
+var parent$r = symbol$4;
+
+var symbol$3 = parent$r;
+
+// call something on iterator step with safe closing on error
+var callWithSafeIterationClosing$1 = function (iterator, fn, value, ENTRIES) {
+  try {
+    return ENTRIES ? fn(anObject(value)[0], value[1]) : fn(value);
+  } catch (error) {
+    iteratorClose(iterator, 'throw', error);
+  }
+};
+
+var callWithSafeIterationClosing = callWithSafeIterationClosing$1;
+
+var $Array$1 = Array;
+
+// `Array.from` method implementation
+// https://tc39.es/ecma262/#sec-array.from
+var arrayFrom = function from(arrayLike /* , mapfn = undefined, thisArg = undefined */) {
+  var O = toObject$1(arrayLike);
+  var IS_CONSTRUCTOR = isConstructor(this);
+  var argumentsLength = arguments.length;
+  var mapfn = argumentsLength > 1 ? arguments[1] : undefined;
+  var mapping = mapfn !== undefined;
+  if (mapping) mapfn = bind(mapfn, argumentsLength > 2 ? arguments[2] : undefined);
+  var iteratorMethod = getIteratorMethod$5(O);
+  var index = 0;
+  var length, result, step, iterator, next, value;
+  // if the target is not iterable or it's an array with the default iterator - use a simple case
+  if (iteratorMethod && !(this === $Array$1 && isArrayIteratorMethod(iteratorMethod))) {
+    result = IS_CONSTRUCTOR ? new this() : [];
+    iterator = getIterator$5(O, iteratorMethod);
+    next = iterator.next;
+    for (;!(step = call(next, iterator)).done; index++) {
+      value = mapping ? callWithSafeIterationClosing(iterator, mapfn, [step.value, index], true) : step.value;
+      createProperty(result, index, value);
+    }
+  } else {
+    length = lengthOfArrayLike(O);
+    result = IS_CONSTRUCTOR ? new this(length) : $Array$1(length);
+    for (;length > index; index++) {
+      value = mapping ? mapfn(O[index], index) : O[index];
+      createProperty(result, index, value);
+    }
+  }
+  result.length = index;
+  return result;
+};
+
+var ITERATOR = wellKnownSymbol('iterator');
+var SAFE_CLOSING = false;
+
+try {
+  var called = 0;
+  var iteratorWithReturn = {
+    next: function () {
+      return { done: !!called++ };
+    },
+    'return': function () {
+      SAFE_CLOSING = true;
+    }
+  };
+  iteratorWithReturn[ITERATOR] = function () {
+    return this;
+  };
+  // eslint-disable-next-line es/no-array-from, no-throw-literal -- required for testing
+  Array.from(iteratorWithReturn, function () { throw 2; });
+} catch (error) { /* empty */ }
+
+var checkCorrectnessOfIteration$1 = function (exec, SKIP_CLOSING) {
+  try {
+    if (!SKIP_CLOSING && !SAFE_CLOSING) return false;
+  } catch (error) { return false; } // workaround of old WebKit + `eval` bug
+  var ITERATION_SUPPORT = false;
+  try {
+    var object = {};
+    object[ITERATOR] = function () {
+      return {
+        next: function () {
+          return { done: ITERATION_SUPPORT = true };
+        }
+      };
+    };
+    exec(object);
+  } catch (error) { /* empty */ }
+  return ITERATION_SUPPORT;
+};
+
+var from$6 = arrayFrom;
+
+var checkCorrectnessOfIteration = checkCorrectnessOfIteration$1;
+
+var INCORRECT_ITERATION = !checkCorrectnessOfIteration(function (iterable) {
+  // eslint-disable-next-line es/no-array-from -- required for testing
+  Array.from(iterable);
+});
+
+// `Array.from` method
+// https://tc39.es/ecma262/#sec-array.from
+$({ target: 'Array', stat: true, forced: INCORRECT_ITERATION }, {
+  from: from$6
+});
+
+var from$5 = path.Array.from;
+
+var parent$q = from$5;
+
+var from$4 = parent$q;
+
+var parent$p = from$4;
+
+var from$3 = parent$p;
+
+var HAS_SPECIES_SUPPORT = arrayMethodHasSpeciesSupport('slice');
+
+var SPECIES = wellKnownSymbol('species');
+var $Array = Array;
+var max$1 = Math.max;
+
+// `Array.prototype.slice` method
+// https://tc39.es/ecma262/#sec-array.prototype.slice
+// fallback for not array-like ES3 strings and DOM objects
+$({ target: 'Array', proto: true, forced: !HAS_SPECIES_SUPPORT }, {
+  slice: function slice(start, end) {
+    var O = toIndexedObject(this);
+    var length = lengthOfArrayLike(O);
+    var k = toAbsoluteIndex(start, length);
+    var fin = toAbsoluteIndex(end === undefined ? length : end, length);
+    // inline `ArraySpeciesCreate` for usage native `Array#slice` where it's possible
+    var Constructor, result, n;
+    if (isArray$6(O)) {
+      Constructor = O.constructor;
+      // cross-realm fallback
+      if (isConstructor(Constructor) && (Constructor === $Array || isArray$6(Constructor.prototype))) {
+        Constructor = undefined;
+      } else if (isObject(Constructor)) {
+        Constructor = Constructor[SPECIES];
+        if (Constructor === null) Constructor = undefined;
+      }
+      if (Constructor === $Array || Constructor === undefined) {
+        return nativeSlice(O, k, fin);
+      }
+    }
+    result = new (Constructor === undefined ? $Array : Constructor)(max$1(fin - k, 0));
+    for (n = 0; k < fin; k++, n++) if (k in O) createProperty(result, n, O[k]);
+    result.length = n;
+    return result;
+  }
+});
+
+var getBuiltInPrototypeMethod$1 = function (CONSTRUCTOR, METHOD) {
+  var Namespace = path[CONSTRUCTOR + 'Prototype'];
+  var pureMethod = Namespace && Namespace[METHOD];
+  if (pureMethod) return pureMethod;
+  var NativeConstructor = globalThis$1[CONSTRUCTOR];
+  var NativePrototype = NativeConstructor && NativeConstructor.prototype;
+  return NativePrototype && NativePrototype[METHOD];
+};
+
+var getBuiltInPrototypeMethod = getBuiltInPrototypeMethod$1;
+
+var slice$6 = getBuiltInPrototypeMethod('Array', 'slice');
+
+var method$6 = slice$6;
+
+var ArrayPrototype$6 = Array.prototype;
+
+var slice$5 = function (it) {
+  var own = it.slice;
+  return it === ArrayPrototype$6 || (isPrototypeOf(ArrayPrototype$6, it) && own === ArrayPrototype$6.slice) ? method$6 : own;
+};
+
+var parent$o = slice$5;
+
+var slice$4 = parent$o;
+
+var parent$n = slice$4;
+
+var slice$3 = parent$n;
+
+var defineProperty$5 = parent$C;
+
+var parent$m = defineProperty$5;
+
+var defineProperty$4 = parent$m;
+
+var require$$0$i = defineProperty$4;
+
+var defineProperty$3 = require$$0$i;
+
+var defineProperty$2 = require$$0$r.f;
+
+var METADATA = wellKnownSymbol('metadata');
+var FunctionPrototype = Function.prototype;
+
+// Function.prototype[@@metadata]
+// https://github.com/tc39/proposal-decorator-metadata
+if (FunctionPrototype[METADATA] === undefined) {
+  defineProperty$2(FunctionPrototype, METADATA, {
+    value: null
+  });
+}
+
+// `Symbol.asyncDispose` well-known symbol
+// https://github.com/tc39/proposal-async-explicit-resource-management
+defineWellKnownSymbol('asyncDispose');
+
+// `Symbol.dispose` well-known symbol
+// https://github.com/tc39/proposal-explicit-resource-management
+defineWellKnownSymbol('dispose');
+
+// `Symbol.metadata` well-known symbol
+// https://github.com/tc39/proposal-decorators
+defineWellKnownSymbol('metadata');
+
+var symbol$2 = parent$r;
+
+var Symbol$2 = getBuiltIn('Symbol');
+var keyFor = Symbol$2.keyFor;
+var thisSymbolValue$1 = uncurryThis$1(Symbol$2.prototype.valueOf);
+
+// `Symbol.isRegisteredSymbol` method
+// https://tc39.es/proposal-symbol-predicates/#sec-symbol-isregisteredsymbol
+var symbolIsRegistered = Symbol$2.isRegisteredSymbol || function isRegisteredSymbol(value) {
+  try {
+    return keyFor(thisSymbolValue$1(value)) !== undefined;
+  } catch (error) {
+    return false;
+  }
+};
+
+var isRegisteredSymbol = symbolIsRegistered;
+
+// `Symbol.isRegisteredSymbol` method
+// https://tc39.es/proposal-symbol-predicates/#sec-symbol-isregisteredsymbol
+$({ target: 'Symbol', stat: true }, {
+  isRegisteredSymbol: isRegisteredSymbol
+});
+
+var Symbol$1 = getBuiltIn('Symbol');
+var $isWellKnownSymbol = Symbol$1.isWellKnownSymbol;
+var getOwnPropertyNames = getBuiltIn('Object', 'getOwnPropertyNames');
+var thisSymbolValue = uncurryThis$1(Symbol$1.prototype.valueOf);
+var WellKnownSymbolsStore = shared$1('wks');
+
+for (var i = 0, symbolKeys = getOwnPropertyNames(Symbol$1), symbolKeysLength = symbolKeys.length; i < symbolKeysLength; i++) {
+  // some old engines throws on access to some keys like `arguments` or `caller`
+  try {
+    var symbolKey = symbolKeys[i];
+    if (isSymbol(Symbol$1[symbolKey])) wellKnownSymbol(symbolKey);
+  } catch (error) { /* empty */ }
+}
+
+// `Symbol.isWellKnownSymbol` method
+// https://tc39.es/proposal-symbol-predicates/#sec-symbol-iswellknownsymbol
+// We should patch it for newly added well-known symbols. If it's not required, this module just will not be injected
+var symbolIsWellKnown = function isWellKnownSymbol(value) {
+  if ($isWellKnownSymbol && $isWellKnownSymbol(value)) return true;
+  try {
+    var symbol = thisSymbolValue(value);
+    for (var j = 0, keys = getOwnPropertyNames(WellKnownSymbolsStore), keysLength = keys.length; j < keysLength; j++) {
+      // eslint-disable-next-line eqeqeq -- polyfilled symbols case
+      if (WellKnownSymbolsStore[keys[j]] == symbol) return true;
+    }
+  } catch (error) { /* empty */ }
+  return false;
+};
+
+var isWellKnownSymbol = symbolIsWellKnown;
+
+// `Symbol.isWellKnownSymbol` method
+// https://tc39.es/proposal-symbol-predicates/#sec-symbol-iswellknownsymbol
+// We should patch it for newly added well-known symbols. If it's not required, this module just will not be injected
+$({ target: 'Symbol', stat: true, forced: true }, {
+  isWellKnownSymbol: isWellKnownSymbol
+});
+
+// `Symbol.customMatcher` well-known symbol
+// https://github.com/tc39/proposal-pattern-matching
+defineWellKnownSymbol('customMatcher');
+
+// `Symbol.observable` well-known symbol
+// https://github.com/tc39/proposal-observable
+defineWellKnownSymbol('observable');
+
+// `Symbol.isRegistered` method
+// obsolete version of https://tc39.es/proposal-symbol-predicates/#sec-symbol-isregisteredsymbol
+$({ target: 'Symbol', stat: true, name: 'isRegisteredSymbol' }, {
+  isRegistered: isRegisteredSymbol
+});
+
+// `Symbol.isWellKnown` method
+// obsolete version of https://tc39.es/proposal-symbol-predicates/#sec-symbol-iswellknownsymbol
+// We should patch it for newly added well-known symbols. If it's not required, this module just will not be injected
+$({ target: 'Symbol', stat: true, name: 'isWellKnownSymbol', forced: true }, {
+  isWellKnown: isWellKnownSymbol
+});
+
+// `Symbol.matcher` well-known symbol
+// https://github.com/tc39/proposal-pattern-matching
+defineWellKnownSymbol('matcher');
+
+// TODO: Remove from `core-js@4`
+
+
+// `Symbol.metadataKey` well-known symbol
+// https://github.com/tc39/proposal-decorator-metadata
+defineWellKnownSymbol('metadataKey');
+
+// TODO: remove from `core-js@4`
+
+
+// `Symbol.patternMatch` well-known symbol
+// https://github.com/tc39/proposal-pattern-matching
+defineWellKnownSymbol('patternMatch');
+
+// TODO: remove from `core-js@4`
+
+
+defineWellKnownSymbol('replaceAll');
+
+var parent$l = symbol$2;
+
+// TODO: Remove from `core-js@4`
+
+
+
+
+
+
+
+var symbol$1 = parent$l;
+
+var require$$0$h = symbol$1;
+
+var symbol = require$$0$h;
+
+var iterator$4 = WrappedWellKnownSymbolModule.f('iterator');
+
+var parent$k = iterator$4;
+
+var iterator$3 = parent$k;
+
+var parent$j = iterator$3;
+
+var iterator$2 = parent$j;
+
+var parent$i = iterator$2;
+
+var iterator$1 = parent$i;
+
+var require$$0$g = iterator$1;
+
+var iterator = require$$0$g;
+
+var _Symbol = symbol;
+
+var _Symbol$iterator = iterator;
+
+var _typeof_1 = createCommonjsModule(function (module) {
+function _typeof(o) {
+  "@babel/helpers - typeof";
+
+  return module.exports = _typeof = "function" == typeof _Symbol && "symbol" == typeof _Symbol$iterator ? function (o) {
+    return typeof o;
+  } : function (o) {
+    return o && "function" == typeof _Symbol && o.constructor === _Symbol && o !== _Symbol.prototype ? "symbol" : typeof o;
+  }, module.exports.__esModule = true, module.exports["default"] = module.exports, _typeof(o);
+}
+module.exports = _typeof, module.exports.__esModule = true, module.exports["default"] = module.exports;
+});
+
+var toPrimitive$4 = WrappedWellKnownSymbolModule.f('toPrimitive');
+
+var parent$h = toPrimitive$4;
+
+var toPrimitive$3 = parent$h;
+
+var parent$g = toPrimitive$3;
+
+var toPrimitive$2 = parent$g;
+
+var parent$f = toPrimitive$2;
+
+var toPrimitive$1 = parent$f;
+
+var require$$0$f = toPrimitive$1;
+
+var toPrimitive = require$$0$f;
+
+var _Symbol$toPrimitive = toPrimitive;
+
+var toPrimitive_1 = createCommonjsModule(function (module) {
+var _typeof = _typeof_1["default"];
+function toPrimitive(t, r) {
+  if ("object" != _typeof(t) || !t) return t;
+  var e = t[_Symbol$toPrimitive];
+  if (void 0 !== e) {
+    var i = e.call(t, r || "default");
+    if ("object" != _typeof(i)) return i;
+    throw new TypeError("@@toPrimitive must return a primitive value.");
+  }
+  return ("string" === r ? String : Number)(t);
+}
+module.exports = toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
+});
+
+var toPropertyKey_1 = createCommonjsModule(function (module) {
+var _typeof = _typeof_1["default"];
+
+function toPropertyKey(t) {
+  var i = toPrimitive_1(t, "string");
+  return "symbol" == _typeof(i) ? i : i + "";
+}
+module.exports = toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
+});
+
+var _Object$defineProperty = defineProperty$3;
+
+var defineProperty$1 = createCommonjsModule(function (module) {
+function _defineProperty(e, r, t) {
+  return (r = toPropertyKey_1(r)) in e ? _Object$defineProperty(e, r, {
+    value: t,
+    enumerable: !0,
+    configurable: !0,
+    writable: !0
+  }) : e[r] = t, e;
+}
+module.exports = _defineProperty, module.exports.__esModule = true, module.exports["default"] = module.exports;
+});
+
+// eslint-disable-next-line es/no-object-assign -- safe
+var $assign = Object.assign;
+// eslint-disable-next-line es/no-object-defineproperty -- required for testing
+var defineProperty = Object.defineProperty;
+var concat$4 = uncurryThis$1([].concat);
+
+// `Object.assign` method
+// https://tc39.es/ecma262/#sec-object.assign
+var objectAssign$1 = !$assign || fails(function () {
+  // should have correct order of operations (Edge bug)
+  if (DESCRIPTORS && $assign({ b: 1 }, $assign(defineProperty({}, 'a', {
+    enumerable: true,
+    get: function () {
+      defineProperty(this, 'b', {
+        value: 3,
+        enumerable: false
+      });
+    }
+  }), { b: 2 })).b !== 1) return true;
+  // should work with symbols and should have deterministic property order (V8 bug)
+  var A = {};
+  var B = {};
+  // eslint-disable-next-line es/no-symbol -- safe
+  var symbol = Symbol('assign detection');
+  var alphabet = 'abcdefghijklmnopqrst';
+  A[symbol] = 7;
+  // eslint-disable-next-line es/no-array-prototype-foreach -- safe
+  alphabet.split('').forEach(function (chr) { B[chr] = chr; });
+  return $assign({}, A)[symbol] !== 7 || nativeKeys($assign({}, B)).join('') !== alphabet;
+}) ? function assign(target, source) { // eslint-disable-line no-unused-vars -- required for `.length`
+  var T = toObject$1(target);
+  var argumentsLength = arguments.length;
+  var index = 1;
+  var getOwnPropertySymbols = getOwnPropertySymbolsModule.f;
+  var propertyIsEnumerable = propertyIsEnumerableModule.f;
+  while (argumentsLength > index) {
+    var S = IndexedObject(arguments[index++]);
+    var keys = getOwnPropertySymbols ? concat$4(nativeKeys(S), getOwnPropertySymbols(S)) : nativeKeys(S);
+    var length = keys.length;
+    var j = 0;
+    var key;
+    while (length > j) {
+      key = keys[j++];
+      if (!DESCRIPTORS || call(propertyIsEnumerable, S, key)) T[key] = S[key];
+    }
+  } return T;
+} : $assign;
+
+var assign$3 = objectAssign$1;
+
+// `Object.assign` method
+// https://tc39.es/ecma262/#sec-object.assign
+// eslint-disable-next-line es/no-object-assign -- required for testing
+$({ target: 'Object', stat: true, arity: 2, forced: Object.assign !== assign$3 }, {
+  assign: assign$3
+});
+
+var assign$2 = path.Object.assign;
+
+var parent$e = assign$2;
+
+var assign$1 = parent$e;
+
+var require$$0$e = assign$1;
+
+var assign = require$$0$e;
+
+var FAILS_ON_PRIMITIVES = fails(function () { nativeKeys(1); });
+
+// `Object.keys` method
+// https://tc39.es/ecma262/#sec-object.keys
+$({ target: 'Object', stat: true, forced: FAILS_ON_PRIMITIVES }, {
+  keys: function keys(it) {
+    return nativeKeys(toObject$1(it));
+  }
+});
+
+var keys$6 = path.Object.keys;
+
+var parent$d = keys$6;
+
+var keys$5 = parent$d;
+
+var require$$0$d = keys$5;
+
+var keys$4 = require$$0$d;
+
+var arrayMethodIsStrict$1 = function (METHOD_NAME, argument) {
+  var method = [][METHOD_NAME];
+  return !!method && fails(function () {
+    // eslint-disable-next-line no-useless-call -- required for testing
+    method.call(null, argument || function () { return 1; }, 1);
+  });
+};
+
+var arrayMethodIsStrict = arrayMethodIsStrict$1;
+
+var $forEach = require$$0$o.forEach;
+
+
+var STRICT_METHOD = arrayMethodIsStrict('forEach');
+
+// `Array.prototype.forEach` method implementation
+// https://tc39.es/ecma262/#sec-array.prototype.foreach
+var arrayForEach = !STRICT_METHOD ? function forEach(callbackfn /* , thisArg */) {
+  return $forEach(this, callbackfn, arguments.length > 1 ? arguments[1] : undefined);
+// eslint-disable-next-line es/no-array-prototype-foreach -- safe
+} : [].forEach;
+
+var forEach$4 = arrayForEach;
+
+// `Array.prototype.forEach` method
+// https://tc39.es/ecma262/#sec-array.prototype.foreach
+// eslint-disable-next-line es/no-array-prototype-foreach -- safe
+$({ target: 'Array', proto: true, forced: [].forEach !== forEach$4 }, {
+  forEach: forEach$4
+});
+
+var forEach$3 = getBuiltInPrototypeMethod('Array', 'forEach');
+
+var parent$c = forEach$3;
+
+var forEach$2 = parent$c;
+
+var method$5 = forEach$2;
+
+var ArrayPrototype$5 = Array.prototype;
+
+var DOMIterables$2 = {
+  DOMTokenList: true,
+  NodeList: true
+};
+
+var forEach$1 = function (it) {
+  var own = it.forEach;
+  return it === ArrayPrototype$5 || (isPrototypeOf(ArrayPrototype$5, it) && own === ArrayPrototype$5.forEach)
+    || hasOwn(DOMIterables$2, classof(it)) ? method$5 : own;
+};
+
+var require$$0$c = forEach$1;
+
+var forEach = require$$0$c;
+
+var commandRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var commandRole = {
+  abstract: true,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'menuitem'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'widget']]
+};
+var _default = commandRole;
+exports.default = _default;
+});
+
+var compositeRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var compositeRole = {
+  abstract: true,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-activedescendant': null,
+    'aria-disabled': null
+  },
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'widget']]
+};
+var _default = compositeRole;
+exports.default = _default;
+});
+
+var inputRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var inputRole = {
+  abstract: true,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'input'
+    },
+    module: 'XForms'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'widget']]
+};
+var _default = inputRole;
+exports.default = _default;
+});
+
+var landmarkRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var landmarkRole = {
+  abstract: true,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = landmarkRole;
+exports.default = _default;
+});
+
+var rangeRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var rangeRole = {
+  abstract: true,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-valuemax': null,
+    'aria-valuemin': null,
+    'aria-valuenow': null,
+    'aria-valuetext': null
+  },
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure']]
+};
+var _default = rangeRole;
+exports.default = _default;
+});
+
+var roletypeRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var roletypeRole = {
+  abstract: true,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: [],
+  prohibitedProps: [],
+  props: {
+    'aria-atomic': null,
+    'aria-busy': null,
+    'aria-controls': null,
+    'aria-current': null,
+    'aria-describedby': null,
+    'aria-details': null,
+    'aria-dropeffect': null,
+    'aria-flowto': null,
+    'aria-grabbed': null,
+    'aria-hidden': null,
+    'aria-keyshortcuts': null,
+    'aria-label': null,
+    'aria-labelledby': null,
+    'aria-live': null,
+    'aria-owns': null,
+    'aria-relevant': null,
+    'aria-roledescription': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'rel'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'role'
+    },
+    module: 'XHTML'
+  }, {
+    concept: {
+      name: 'type'
+    },
+    module: 'Dublin Core'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: []
+};
+var _default = roletypeRole;
+exports.default = _default;
+});
+
+var sectionRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var sectionRole = {
+  abstract: true,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: [],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'frontmatter'
+    },
+    module: 'DTB'
+  }, {
+    concept: {
+      name: 'level'
+    },
+    module: 'DTB'
+  }, {
+    concept: {
+      name: 'level'
+    },
+    module: 'SMIL'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure']]
+};
+var _default = sectionRole;
+exports.default = _default;
+});
+
+var sectionheadRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var sectionheadRole = {
+  abstract: true,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure']]
+};
+var _default = sectionheadRole;
+exports.default = _default;
+});
+
+var selectRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var selectRole = {
+  abstract: true,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-orientation': null
+  },
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'composite'], ['roletype', 'structure', 'section', 'group']]
+};
+var _default = selectRole;
+exports.default = _default;
+});
+
+var structureRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var structureRole = {
+  abstract: true,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: [],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype']]
+};
+var _default = structureRole;
+exports.default = _default;
+});
+
+var widgetRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var widgetRole = {
+  abstract: true,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: [],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype']]
+};
+var _default = widgetRole;
+exports.default = _default;
+});
+
+var windowRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var windowRole = {
+  abstract: true,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-modal': null
+  },
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype']]
+};
+var _default = windowRole;
+exports.default = _default;
+});
+
+var ariaAbstractRoles_1 = createCommonjsModule(function (module, exports) {
+
+
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+
+var _map = interopRequireDefault(map);
+
+var _commandRole = interopRequireDefault(commandRole_1);
+
+var _compositeRole = interopRequireDefault(compositeRole_1);
+
+var _inputRole = interopRequireDefault(inputRole_1);
+
+var _landmarkRole = interopRequireDefault(landmarkRole_1);
+
+var _rangeRole = interopRequireDefault(rangeRole_1);
+
+var _roletypeRole = interopRequireDefault(roletypeRole_1);
+
+var _sectionRole = interopRequireDefault(sectionRole_1);
+
+var _sectionheadRole = interopRequireDefault(sectionheadRole_1);
+
+var _selectRole = interopRequireDefault(selectRole_1);
+
+var _structureRole = interopRequireDefault(structureRole_1);
+
+var _widgetRole = interopRequireDefault(widgetRole_1);
+
+var _windowRole = interopRequireDefault(windowRole_1);
+
+var ariaAbstractRoles = new _map.default([['command', _commandRole.default], ['composite', _compositeRole.default], ['input', _inputRole.default], ['landmark', _landmarkRole.default], ['range', _rangeRole.default], ['roletype', _roletypeRole.default], ['section', _sectionRole.default], ['sectionhead', _sectionheadRole.default], ['select', _selectRole.default], ['structure', _structureRole.default], ['widget', _widgetRole.default], ['window', _windowRole.default]]);
+var _default = ariaAbstractRoles;
+exports.default = _default;
+});
+
+var alertRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var alertRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-atomic': 'true',
+    'aria-live': 'assertive'
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'alert'
+    },
+    module: 'XForms'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = alertRole;
+exports.default = _default;
+});
+
+var alertdialogRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var alertdialogRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'alert'
+    },
+    module: 'XForms'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'alert'], ['roletype', 'window', 'dialog']]
+};
+var _default = alertdialogRole;
+exports.default = _default;
+});
+
+var applicationRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var applicationRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-activedescendant': null,
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'Device Independence Delivery Unit'
+    }
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure']]
+};
+var _default = applicationRole;
+exports.default = _default;
+});
+
+var articleRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var articleRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-posinset': null,
+    'aria-setsize': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'article'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'document']]
+};
+var _default = articleRole;
+exports.default = _default;
+});
+
+var bannerRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var bannerRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      constraints: ['direct descendant of document'],
+      name: 'header'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = bannerRole;
+exports.default = _default;
+});
+
+var blockquoteRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var blockquoteRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = blockquoteRole;
+exports.default = _default;
+});
+
+var buttonRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var buttonRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: true,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-pressed': null
+  },
+  relatedConcepts: [{
+    concept: {
+      attributes: [{
+        constraints: ['set'],
+        name: 'aria-pressed'
+      }, {
+        name: 'type',
+        value: 'checkbox'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        name: 'aria-expanded',
+        value: 'false'
+      }],
+      name: 'summary'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        name: 'aria-expanded',
+        value: 'true'
+      }],
+      constraints: ['direct descendant of details element with the open attribute defined'],
+      name: 'summary'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        name: 'type',
+        value: 'button'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        name: 'type',
+        value: 'image'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        name: 'type',
+        value: 'reset'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        name: 'type',
+        value: 'submit'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'button'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'trigger'
+    },
+    module: 'XForms'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'command']]
+};
+var _default = buttonRole;
+exports.default = _default;
+});
+
+var captionRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var captionRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['prohibited'],
+  prohibitedProps: ['aria-label', 'aria-labelledby'],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: ['figure', 'grid', 'table'],
+  requiredContextRole: ['figure', 'grid', 'table'],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = captionRole;
+exports.default = _default;
+});
+
+var cellRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var cellRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {
+    'aria-colindex': null,
+    'aria-colspan': null,
+    'aria-rowindex': null,
+    'aria-rowspan': null
+  },
+  relatedConcepts: [{
+    concept: {
+      constraints: ['descendant of table'],
+      name: 'td'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: ['row'],
+  requiredContextRole: ['row'],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = cellRole;
+exports.default = _default;
+});
+
+var checkboxRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var checkboxRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: true,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {
+    'aria-checked': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-invalid': null,
+    'aria-readonly': null,
+    'aria-required': null
+  },
+  relatedConcepts: [{
+    concept: {
+      attributes: [{
+        name: 'type',
+        value: 'checkbox'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'option'
+    },
+    module: 'ARIA'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {
+    'aria-checked': null
+  },
+  superClass: [['roletype', 'widget', 'input']]
+};
+var _default = checkboxRole;
+exports.default = _default;
+});
+
+var codeRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var codeRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['prohibited'],
+  prohibitedProps: ['aria-label', 'aria-labelledby'],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = codeRole;
+exports.default = _default;
+});
+
+var columnheaderRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var columnheaderRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {
+    'aria-sort': null
+  },
+  relatedConcepts: [{
+    attributes: [{
+      name: 'scope',
+      value: 'col'
+    }],
+    concept: {
+      name: 'th'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: ['row'],
+  requiredContextRole: ['row'],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'cell'], ['roletype', 'structure', 'section', 'cell', 'gridcell'], ['roletype', 'widget', 'gridcell'], ['roletype', 'structure', 'sectionhead']]
+};
+var _default = columnheaderRole;
+exports.default = _default;
+});
+
+var comboboxRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var comboboxRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-activedescendant': null,
+    'aria-autocomplete': null,
+    'aria-errormessage': null,
+    'aria-invalid': null,
+    'aria-readonly': null,
+    'aria-required': null,
+    'aria-expanded': 'false',
+    'aria-haspopup': 'listbox'
+  },
+  relatedConcepts: [{
+    concept: {
+      attributes: [{
+        constraints: ['set'],
+        name: 'list'
+      }, {
+        name: 'type',
+        value: 'email'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        constraints: ['set'],
+        name: 'list'
+      }, {
+        name: 'type',
+        value: 'search'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        constraints: ['set'],
+        name: 'list'
+      }, {
+        name: 'type',
+        value: 'tel'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        constraints: ['set'],
+        name: 'list'
+      }, {
+        name: 'type',
+        value: 'text'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        constraints: ['set'],
+        name: 'list'
+      }, {
+        name: 'type',
+        value: 'url'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        constraints: ['set'],
+        name: 'list'
+      }, {
+        name: 'type',
+        value: 'url'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        constraints: ['undefined'],
+        name: 'multiple'
+      }, {
+        constraints: ['undefined'],
+        name: 'size'
+      }],
+      name: 'select'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        constraints: ['undefined'],
+        name: 'multiple'
+      }, {
+        name: 'size',
+        value: 1
+      }],
+      name: 'select'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'select'
+    },
+    module: 'XForms'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {
+    'aria-controls': null,
+    'aria-expanded': 'false'
+  },
+  superClass: [['roletype', 'widget', 'input']]
+};
+var _default = comboboxRole;
+exports.default = _default;
+});
+
+var complementaryRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var complementaryRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'aside'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = complementaryRole;
+exports.default = _default;
+});
+
+var contentinfoRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var contentinfoRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      constraints: ['direct descendant of document'],
+      name: 'footer'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = contentinfoRole;
+exports.default = _default;
+});
+
+var definitionRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var definitionRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'dd'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = definitionRole;
+exports.default = _default;
+});
+
+var deletionRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var deletionRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['prohibited'],
+  prohibitedProps: ['aria-label', 'aria-labelledby'],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = deletionRole;
+exports.default = _default;
+});
+
+var dialogRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var dialogRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'dialog'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'window']]
+};
+var _default = dialogRole;
+exports.default = _default;
+});
+
+var directoryRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var directoryRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    module: 'DAISY Guide'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'list']]
+};
+var _default = directoryRole;
+exports.default = _default;
+});
+
+var documentRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var documentRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'Device Independence Delivery Unit'
+    }
+  }, {
+    concept: {
+      name: 'body'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure']]
+};
+var _default = documentRole;
+exports.default = _default;
+});
+
+var emphasisRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var emphasisRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['prohibited'],
+  prohibitedProps: ['aria-label', 'aria-labelledby'],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = emphasisRole;
+exports.default = _default;
+});
+
+var feedRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var feedRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [['article']],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'list']]
+};
+var _default = feedRole;
+exports.default = _default;
+});
+
+var figureRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var figureRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'figure'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = figureRole;
+exports.default = _default;
+});
+
+var formRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var formRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      attributes: [{
+        constraints: ['set'],
+        name: 'aria-label'
+      }],
+      name: 'form'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        constraints: ['set'],
+        name: 'aria-labelledby'
+      }],
+      name: 'form'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        constraints: ['set'],
+        name: 'name'
+      }],
+      name: 'form'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = formRole;
+exports.default = _default;
+});
+
+var genericRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var genericRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['prohibited'],
+  prohibitedProps: ['aria-label', 'aria-labelledby'],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'span'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'div'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure']]
+};
+var _default = genericRole;
+exports.default = _default;
+});
+
+var gridRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var gridRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-multiselectable': null,
+    'aria-readonly': null
+  },
+  relatedConcepts: [{
+    concept: {
+      attributes: [{
+        name: 'role',
+        value: 'grid'
+      }],
+      name: 'table'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [['row'], ['row', 'rowgroup']],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'composite'], ['roletype', 'structure', 'section', 'table']]
+};
+var _default = gridRole;
+exports.default = _default;
+});
+
+var gridcellRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var gridcellRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null,
+    'aria-readonly': null,
+    'aria-required': null,
+    'aria-selected': null
+  },
+  relatedConcepts: [{
+    concept: {
+      attributes: [{
+        name: 'role',
+        value: 'gridcell'
+      }],
+      name: 'td'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: ['row'],
+  requiredContextRole: ['row'],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'cell'], ['roletype', 'widget']]
+};
+var _default = gridcellRole;
+exports.default = _default;
+});
+
+var groupRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var groupRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-activedescendant': null,
+    'aria-disabled': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'details'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'fieldset'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'optgroup'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = groupRole;
+exports.default = _default;
+});
+
+var headingRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var headingRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {
+    'aria-level': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'h1'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'h2'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'h3'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'h4'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'h5'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'h6'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {
+    'aria-level': 2
+  },
+  superClass: [['roletype', 'structure', 'sectionhead']]
+};
+var _default = headingRole;
+exports.default = _default;
+});
+
+var imgRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var imgRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: true,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      attributes: [{
+        constraints: ['set'],
+        name: 'alt'
+      }],
+      name: 'img'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        constraints: ['undefined'],
+        name: 'alt'
+      }],
+      name: 'img'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'imggroup'
+    },
+    module: 'DTB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = imgRole;
+exports.default = _default;
+});
+
+var insertionRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var insertionRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['prohibited'],
+  prohibitedProps: ['aria-label', 'aria-labelledby'],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = insertionRole;
+exports.default = _default;
+});
+
+var linkRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var linkRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-expanded': null
+  },
+  relatedConcepts: [{
+    concept: {
+      attributes: [{
+        name: 'href'
+      }],
+      name: 'a'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        name: 'href'
+      }],
+      name: 'area'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        name: 'href'
+      }],
+      name: 'link'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'command']]
+};
+var _default = linkRole;
+exports.default = _default;
+});
+
+var listRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var listRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'menu'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'ol'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'ul'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [['listitem']],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = listRole;
+exports.default = _default;
+});
+
+var listboxRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var listboxRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-invalid': null,
+    'aria-multiselectable': null,
+    'aria-readonly': null,
+    'aria-required': null,
+    'aria-orientation': 'vertical'
+  },
+  relatedConcepts: [{
+    concept: {
+      attributes: [{
+        constraints: ['>1'],
+        name: 'size'
+      }, {
+        name: 'multiple'
+      }],
+      name: 'select'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        constraints: ['>1'],
+        name: 'size'
+      }],
+      name: 'select'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        name: 'multiple'
+      }],
+      name: 'select'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'datalist'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'list'
+    },
+    module: 'ARIA'
+  }, {
+    concept: {
+      name: 'select'
+    },
+    module: 'XForms'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [['option', 'group'], ['option']],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'composite', 'select'], ['roletype', 'structure', 'section', 'group', 'select']]
+};
+var _default = listboxRole;
+exports.default = _default;
+});
+
+var listitemRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var listitemRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-level': null,
+    'aria-posinset': null,
+    'aria-setsize': null
+  },
+  relatedConcepts: [{
+    concept: {
+      constraints: ['direct descendant of ol, ul or menu'],
+      name: 'li'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'item'
+    },
+    module: 'XForms'
+  }],
+  requireContextRole: ['directory', 'list'],
+  requiredContextRole: ['directory', 'list'],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = listitemRole;
+exports.default = _default;
+});
+
+var logRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var logRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-live': 'polite'
+  },
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = logRole;
+exports.default = _default;
+});
+
+var mainRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var mainRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'main'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = mainRole;
+exports.default = _default;
+});
+
+var marqueeRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var marqueeRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = marqueeRole;
+exports.default = _default;
+});
+
+var mathRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var mathRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'math'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = mathRole;
+exports.default = _default;
+});
+
+var menuRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var menuRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-orientation': 'vertical'
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'MENU'
+    },
+    module: 'JAPI'
+  }, {
+    concept: {
+      name: 'list'
+    },
+    module: 'ARIA'
+  }, {
+    concept: {
+      name: 'select'
+    },
+    module: 'XForms'
+  }, {
+    concept: {
+      name: 'sidebar'
+    },
+    module: 'DTB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [['menuitem', 'group'], ['menuitemradio', 'group'], ['menuitemcheckbox', 'group'], ['menuitem'], ['menuitemcheckbox'], ['menuitemradio']],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'composite', 'select'], ['roletype', 'structure', 'section', 'group', 'select']]
+};
+var _default = menuRole;
+exports.default = _default;
+});
+
+var menubarRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var menubarRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-orientation': 'horizontal'
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'toolbar'
+    },
+    module: 'ARIA'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [['menuitem', 'group'], ['menuitemradio', 'group'], ['menuitemcheckbox', 'group'], ['menuitem'], ['menuitemcheckbox'], ['menuitemradio']],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'composite', 'select', 'menu'], ['roletype', 'structure', 'section', 'group', 'select', 'menu']]
+};
+var _default = menubarRole;
+exports.default = _default;
+});
+
+var menuitemRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var menuitemRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-posinset': null,
+    'aria-setsize': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'MENU_ITEM'
+    },
+    module: 'JAPI'
+  }, {
+    concept: {
+      name: 'listitem'
+    },
+    module: 'ARIA'
+  }, {
+    concept: {
+      name: 'menuitem'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'option'
+    },
+    module: 'ARIA'
+  }],
+  requireContextRole: ['group', 'menu', 'menubar'],
+  requiredContextRole: ['group', 'menu', 'menubar'],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'command']]
+};
+var _default = menuitemRole;
+exports.default = _default;
+});
+
+var menuitemcheckboxRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var menuitemcheckboxRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: true,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'menuitem'
+    },
+    module: 'ARIA'
+  }],
+  requireContextRole: ['group', 'menu', 'menubar'],
+  requiredContextRole: ['group', 'menu', 'menubar'],
+  requiredOwnedElements: [],
+  requiredProps: {
+    'aria-checked': null
+  },
+  superClass: [['roletype', 'widget', 'input', 'checkbox'], ['roletype', 'widget', 'command', 'menuitem']]
+};
+var _default = menuitemcheckboxRole;
+exports.default = _default;
+});
+
+var menuitemradioRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var menuitemradioRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: true,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'menuitem'
+    },
+    module: 'ARIA'
+  }],
+  requireContextRole: ['group', 'menu', 'menubar'],
+  requiredContextRole: ['group', 'menu', 'menubar'],
+  requiredOwnedElements: [],
+  requiredProps: {
+    'aria-checked': null
+  },
+  superClass: [['roletype', 'widget', 'input', 'checkbox', 'menuitemcheckbox'], ['roletype', 'widget', 'command', 'menuitem', 'menuitemcheckbox'], ['roletype', 'widget', 'input', 'radio']]
+};
+var _default = menuitemradioRole;
+exports.default = _default;
+});
+
+var meterRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var meterRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: true,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {
+    'aria-valuemax': null,
+    'aria-valuemin': null,
+    'aria-valuenow': null
+  },
+  superClass: [['roletype', 'structure', 'range']]
+};
+var _default = meterRole;
+exports.default = _default;
+});
+
+var navigationRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var navigationRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'nav'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = navigationRole;
+exports.default = _default;
+});
+
+var noneRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var noneRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: [],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: []
+};
+var _default = noneRole;
+exports.default = _default;
+});
+
+var noteRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var noteRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = noteRole;
+exports.default = _default;
+});
+
+var optionRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var optionRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: true,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {
+    'aria-checked': null,
+    'aria-posinset': null,
+    'aria-setsize': null,
+    'aria-selected': 'false'
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'item'
+    },
+    module: 'XForms'
+  }, {
+    concept: {
+      name: 'listitem'
+    },
+    module: 'ARIA'
+  }, {
+    concept: {
+      name: 'option'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {
+    'aria-selected': 'false'
+  },
+  superClass: [['roletype', 'widget', 'input']]
+};
+var _default = optionRole;
+exports.default = _default;
+});
+
+var paragraphRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var paragraphRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['prohibited'],
+  prohibitedProps: ['aria-label', 'aria-labelledby'],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = paragraphRole;
+exports.default = _default;
+});
+
+var presentationRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var presentationRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['prohibited'],
+  prohibitedProps: ['aria-label', 'aria-labelledby'],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure']]
+};
+var _default = presentationRole;
+exports.default = _default;
+});
+
+var progressbarRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var progressbarRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: true,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'progress'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'status'
+    },
+    module: 'ARIA'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'range'], ['roletype', 'widget']]
+};
+var _default = progressbarRole;
+exports.default = _default;
+});
+
+var radioRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var radioRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: true,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {
+    'aria-checked': null,
+    'aria-posinset': null,
+    'aria-setsize': null
+  },
+  relatedConcepts: [{
+    concept: {
+      attributes: [{
+        name: 'type',
+        value: 'radio'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {
+    'aria-checked': null
+  },
+  superClass: [['roletype', 'widget', 'input']]
+};
+var _default = radioRole;
+exports.default = _default;
+});
+
+var radiogroupRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var radiogroupRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-errormessage': null,
+    'aria-invalid': null,
+    'aria-readonly': null,
+    'aria-required': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'list'
+    },
+    module: 'ARIA'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [['radio']],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'composite', 'select'], ['roletype', 'structure', 'section', 'group', 'select']]
+};
+var _default = radiogroupRole;
+exports.default = _default;
+});
+
+var regionRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var regionRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      attributes: [{
+        constraints: ['set'],
+        name: 'aria-label'
+      }],
+      name: 'section'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        constraints: ['set'],
+        name: 'aria-labelledby'
+      }],
+      name: 'section'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'Device Independence Glossart perceivable unit'
+    }
+  }, {
+    concept: {
+      name: 'frame'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = regionRole;
+exports.default = _default;
+});
+
+var rowRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var rowRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {
+    'aria-colindex': null,
+    'aria-expanded': null,
+    'aria-level': null,
+    'aria-posinset': null,
+    'aria-rowindex': null,
+    'aria-selected': null,
+    'aria-setsize': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'tr'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: ['grid', 'rowgroup', 'table', 'treegrid'],
+  requiredContextRole: ['grid', 'rowgroup', 'table', 'treegrid'],
+  requiredOwnedElements: [['cell'], ['columnheader'], ['gridcell'], ['rowheader']],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'group'], ['roletype', 'widget']]
+};
+var _default = rowRole;
+exports.default = _default;
+});
+
+var rowgroupRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var rowgroupRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'tbody'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'tfoot'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'thead'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: ['grid', 'table', 'treegrid'],
+  requiredContextRole: ['grid', 'table', 'treegrid'],
+  requiredOwnedElements: [['row']],
+  requiredProps: {},
+  superClass: [['roletype', 'structure']]
+};
+var _default = rowgroupRole;
+exports.default = _default;
+});
+
+var rowheaderRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var rowheaderRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {
+    'aria-sort': null
+  },
+  relatedConcepts: [{
+    concept: {
+      attributes: [{
+        name: 'scope',
+        value: 'row'
+      }],
+      name: 'th'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: ['row'],
+  requiredContextRole: ['row'],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'cell'], ['roletype', 'structure', 'section', 'cell', 'gridcell'], ['roletype', 'widget', 'gridcell'], ['roletype', 'structure', 'sectionhead']]
+};
+var _default = rowheaderRole;
+exports.default = _default;
+});
+
+var scrollbarRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var scrollbarRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: true,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-orientation': 'vertical',
+    'aria-valuemax': '100',
+    'aria-valuemin': '0'
+  },
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {
+    'aria-controls': null,
+    'aria-valuenow': null
+  },
+  superClass: [['roletype', 'structure', 'range'], ['roletype', 'widget']]
+};
+var _default = scrollbarRole;
+exports.default = _default;
+});
+
+var searchRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var searchRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = searchRole;
+exports.default = _default;
+});
+
+var searchboxRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var searchboxRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      attributes: [{
+        constraints: ['undefined'],
+        name: 'list'
+      }, {
+        name: 'type',
+        value: 'search'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'input', 'textbox']]
+};
+var _default = searchboxRole;
+exports.default = _default;
+});
+
+var separatorRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var separatorRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: true,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-valuetext': null,
+    'aria-orientation': 'horizontal',
+    'aria-valuemax': '100',
+    'aria-valuemin': '0'
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'hr'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure']]
+};
+var _default = separatorRole;
+exports.default = _default;
+});
+
+var sliderRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var sliderRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: true,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-errormessage': null,
+    'aria-haspopup': null,
+    'aria-invalid': null,
+    'aria-readonly': null,
+    'aria-orientation': 'horizontal',
+    'aria-valuemax': '100',
+    'aria-valuemin': '0'
+  },
+  relatedConcepts: [{
+    concept: {
+      attributes: [{
+        name: 'type',
+        value: 'range'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {
+    'aria-valuenow': null
+  },
+  superClass: [['roletype', 'widget', 'input'], ['roletype', 'structure', 'range']]
+};
+var _default = sliderRole;
+exports.default = _default;
+});
+
+var spinbuttonRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var spinbuttonRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-errormessage': null,
+    'aria-invalid': null,
+    'aria-readonly': null,
+    'aria-required': null,
+    'aria-valuenow': '0'
+  },
+  relatedConcepts: [{
+    concept: {
+      attributes: [{
+        name: 'type',
+        value: 'number'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'composite'], ['roletype', 'widget', 'input'], ['roletype', 'structure', 'range']]
+};
+var _default = spinbuttonRole;
+exports.default = _default;
+});
+
+var statusRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var statusRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-atomic': 'true',
+    'aria-live': 'polite'
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'output'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = statusRole;
+exports.default = _default;
+});
+
+var strongRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var strongRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['prohibited'],
+  prohibitedProps: ['aria-label', 'aria-labelledby'],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = strongRole;
+exports.default = _default;
+});
+
+var subscriptRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var subscriptRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['prohibited'],
+  prohibitedProps: ['aria-label', 'aria-labelledby'],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = subscriptRole;
+exports.default = _default;
+});
+
+var superscriptRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var superscriptRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['prohibited'],
+  prohibitedProps: ['aria-label', 'aria-labelledby'],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = superscriptRole;
+exports.default = _default;
+});
+
+var switchRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var switchRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: true,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'button'
+    },
+    module: 'ARIA'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {
+    'aria-checked': null
+  },
+  superClass: [['roletype', 'widget', 'input', 'checkbox']]
+};
+var _default = switchRole;
+exports.default = _default;
+});
+
+var tabRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var tabRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: true,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-posinset': null,
+    'aria-setsize': null,
+    'aria-selected': 'false'
+  },
+  relatedConcepts: [],
+  requireContextRole: ['tablist'],
+  requiredContextRole: ['tablist'],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'sectionhead'], ['roletype', 'widget']]
+};
+var _default = tabRole;
+exports.default = _default;
+});
+
+var tableRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var tableRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-colcount': null,
+    'aria-rowcount': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'table'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [['row'], ['row', 'rowgroup']],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = tableRole;
+exports.default = _default;
+});
+
+var tablistRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var tablistRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-level': null,
+    'aria-multiselectable': null,
+    'aria-orientation': 'horizontal'
+  },
+  relatedConcepts: [{
+    module: 'DAISY',
+    concept: {
+      name: 'guide'
+    }
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [['tab']],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'composite']]
+};
+var _default = tablistRole;
+exports.default = _default;
+});
+
+var tabpanelRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var tabpanelRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = tabpanelRole;
+exports.default = _default;
+});
+
+var termRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var termRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'dfn'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = termRole;
+exports.default = _default;
+});
+
+var textboxRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var textboxRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-activedescendant': null,
+    'aria-autocomplete': null,
+    'aria-errormessage': null,
+    'aria-haspopup': null,
+    'aria-invalid': null,
+    'aria-multiline': null,
+    'aria-placeholder': null,
+    'aria-readonly': null,
+    'aria-required': null
+  },
+  relatedConcepts: [{
+    concept: {
+      attributes: [{
+        constraints: ['undefined'],
+        name: 'type'
+      }, {
+        constraints: ['undefined'],
+        name: 'list'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        constraints: ['undefined'],
+        name: 'list'
+      }, {
+        name: 'type',
+        value: 'email'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        constraints: ['undefined'],
+        name: 'list'
+      }, {
+        name: 'type',
+        value: 'tel'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        constraints: ['undefined'],
+        name: 'list'
+      }, {
+        name: 'type',
+        value: 'text'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      attributes: [{
+        constraints: ['undefined'],
+        name: 'list'
+      }, {
+        name: 'type',
+        value: 'url'
+      }],
+      name: 'input'
+    },
+    module: 'HTML'
+  }, {
+    concept: {
+      name: 'input'
+    },
+    module: 'XForms'
+  }, {
+    concept: {
+      name: 'textarea'
+    },
+    module: 'HTML'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'input']]
+};
+var _default = textboxRole;
+exports.default = _default;
+});
+
+var timeRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var timeRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = timeRole;
+exports.default = _default;
+});
+
+var timerRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var timerRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'status']]
+};
+var _default = timerRole;
+exports.default = _default;
+});
+
+var toolbarRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var toolbarRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-orientation': 'horizontal'
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'menubar'
+    },
+    module: 'ARIA'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'group']]
+};
+var _default = toolbarRole;
+exports.default = _default;
+});
+
+var tooltipRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var tooltipRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = tooltipRole;
+exports.default = _default;
+});
+
+var treeRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var treeRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-errormessage': null,
+    'aria-invalid': null,
+    'aria-multiselectable': null,
+    'aria-required': null,
+    'aria-orientation': 'vertical'
+  },
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [['treeitem', 'group'], ['treeitem']],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'composite', 'select'], ['roletype', 'structure', 'section', 'group', 'select']]
+};
+var _default = treeRole;
+exports.default = _default;
+});
+
+var treegridRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var treegridRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [['row'], ['row', 'rowgroup']],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'composite', 'grid'], ['roletype', 'structure', 'section', 'table', 'grid'], ['roletype', 'widget', 'composite', 'select', 'tree'], ['roletype', 'structure', 'section', 'group', 'select', 'tree']]
+};
+var _default = treegridRole;
+exports.default = _default;
+});
+
+var treeitemRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var treeitemRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {
+    'aria-expanded': null,
+    'aria-haspopup': null
+  },
+  relatedConcepts: [],
+  requireContextRole: ['group', 'tree'],
+  requiredContextRole: ['group', 'tree'],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'listitem'], ['roletype', 'widget', 'input', 'option']]
+};
+var _default = treeitemRole;
+exports.default = _default;
+});
+
+var ariaLiteralRoles_1 = createCommonjsModule(function (module, exports) {
+
+
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+
+var _map = interopRequireDefault(map);
+
+var _alertRole = interopRequireDefault(alertRole_1);
+
+var _alertdialogRole = interopRequireDefault(alertdialogRole_1);
+
+var _applicationRole = interopRequireDefault(applicationRole_1);
+
+var _articleRole = interopRequireDefault(articleRole_1);
+
+var _bannerRole = interopRequireDefault(bannerRole_1);
+
+var _blockquoteRole = interopRequireDefault(blockquoteRole_1);
+
+var _buttonRole = interopRequireDefault(buttonRole_1);
+
+var _captionRole = interopRequireDefault(captionRole_1);
+
+var _cellRole = interopRequireDefault(cellRole_1);
+
+var _checkboxRole = interopRequireDefault(checkboxRole_1);
+
+var _codeRole = interopRequireDefault(codeRole_1);
+
+var _columnheaderRole = interopRequireDefault(columnheaderRole_1);
+
+var _comboboxRole = interopRequireDefault(comboboxRole_1);
+
+var _complementaryRole = interopRequireDefault(complementaryRole_1);
+
+var _contentinfoRole = interopRequireDefault(contentinfoRole_1);
+
+var _definitionRole = interopRequireDefault(definitionRole_1);
+
+var _deletionRole = interopRequireDefault(deletionRole_1);
+
+var _dialogRole = interopRequireDefault(dialogRole_1);
+
+var _directoryRole = interopRequireDefault(directoryRole_1);
+
+var _documentRole = interopRequireDefault(documentRole_1);
+
+var _emphasisRole = interopRequireDefault(emphasisRole_1);
+
+var _feedRole = interopRequireDefault(feedRole_1);
+
+var _figureRole = interopRequireDefault(figureRole_1);
+
+var _formRole = interopRequireDefault(formRole_1);
+
+var _genericRole = interopRequireDefault(genericRole_1);
+
+var _gridRole = interopRequireDefault(gridRole_1);
+
+var _gridcellRole = interopRequireDefault(gridcellRole_1);
+
+var _groupRole = interopRequireDefault(groupRole_1);
+
+var _headingRole = interopRequireDefault(headingRole_1);
+
+var _imgRole = interopRequireDefault(imgRole_1);
+
+var _insertionRole = interopRequireDefault(insertionRole_1);
+
+var _linkRole = interopRequireDefault(linkRole_1);
+
+var _listRole = interopRequireDefault(listRole_1);
+
+var _listboxRole = interopRequireDefault(listboxRole_1);
+
+var _listitemRole = interopRequireDefault(listitemRole_1);
+
+var _logRole = interopRequireDefault(logRole_1);
+
+var _mainRole = interopRequireDefault(mainRole_1);
+
+var _marqueeRole = interopRequireDefault(marqueeRole_1);
+
+var _mathRole = interopRequireDefault(mathRole_1);
+
+var _menuRole = interopRequireDefault(menuRole_1);
+
+var _menubarRole = interopRequireDefault(menubarRole_1);
+
+var _menuitemRole = interopRequireDefault(menuitemRole_1);
+
+var _menuitemcheckboxRole = interopRequireDefault(menuitemcheckboxRole_1);
+
+var _menuitemradioRole = interopRequireDefault(menuitemradioRole_1);
+
+var _meterRole = interopRequireDefault(meterRole_1);
+
+var _navigationRole = interopRequireDefault(navigationRole_1);
+
+var _noneRole = interopRequireDefault(noneRole_1);
+
+var _noteRole = interopRequireDefault(noteRole_1);
+
+var _optionRole = interopRequireDefault(optionRole_1);
+
+var _paragraphRole = interopRequireDefault(paragraphRole_1);
+
+var _presentationRole = interopRequireDefault(presentationRole_1);
+
+var _progressbarRole = interopRequireDefault(progressbarRole_1);
+
+var _radioRole = interopRequireDefault(radioRole_1);
+
+var _radiogroupRole = interopRequireDefault(radiogroupRole_1);
+
+var _regionRole = interopRequireDefault(regionRole_1);
+
+var _rowRole = interopRequireDefault(rowRole_1);
+
+var _rowgroupRole = interopRequireDefault(rowgroupRole_1);
+
+var _rowheaderRole = interopRequireDefault(rowheaderRole_1);
+
+var _scrollbarRole = interopRequireDefault(scrollbarRole_1);
+
+var _searchRole = interopRequireDefault(searchRole_1);
+
+var _searchboxRole = interopRequireDefault(searchboxRole_1);
+
+var _separatorRole = interopRequireDefault(separatorRole_1);
+
+var _sliderRole = interopRequireDefault(sliderRole_1);
+
+var _spinbuttonRole = interopRequireDefault(spinbuttonRole_1);
+
+var _statusRole = interopRequireDefault(statusRole_1);
+
+var _strongRole = interopRequireDefault(strongRole_1);
+
+var _subscriptRole = interopRequireDefault(subscriptRole_1);
+
+var _superscriptRole = interopRequireDefault(superscriptRole_1);
+
+var _switchRole = interopRequireDefault(switchRole_1);
+
+var _tabRole = interopRequireDefault(tabRole_1);
+
+var _tableRole = interopRequireDefault(tableRole_1);
+
+var _tablistRole = interopRequireDefault(tablistRole_1);
+
+var _tabpanelRole = interopRequireDefault(tabpanelRole_1);
+
+var _termRole = interopRequireDefault(termRole_1);
+
+var _textboxRole = interopRequireDefault(textboxRole_1);
+
+var _timeRole = interopRequireDefault(timeRole_1);
+
+var _timerRole = interopRequireDefault(timerRole_1);
+
+var _toolbarRole = interopRequireDefault(toolbarRole_1);
+
+var _tooltipRole = interopRequireDefault(tooltipRole_1);
+
+var _treeRole = interopRequireDefault(treeRole_1);
+
+var _treegridRole = interopRequireDefault(treegridRole_1);
+
+var _treeitemRole = interopRequireDefault(treeitemRole_1);
+
+var ariaLiteralRoles = new _map.default([['alert', _alertRole.default], ['alertdialog', _alertdialogRole.default], ['application', _applicationRole.default], ['article', _articleRole.default], ['banner', _bannerRole.default], ['blockquote', _blockquoteRole.default], ['button', _buttonRole.default], ['caption', _captionRole.default], ['cell', _cellRole.default], ['checkbox', _checkboxRole.default], ['code', _codeRole.default], ['columnheader', _columnheaderRole.default], ['combobox', _comboboxRole.default], ['complementary', _complementaryRole.default], ['contentinfo', _contentinfoRole.default], ['definition', _definitionRole.default], ['deletion', _deletionRole.default], ['dialog', _dialogRole.default], ['directory', _directoryRole.default], ['document', _documentRole.default], ['emphasis', _emphasisRole.default], ['feed', _feedRole.default], ['figure', _figureRole.default], ['form', _formRole.default], ['generic', _genericRole.default], ['grid', _gridRole.default], ['gridcell', _gridcellRole.default], ['group', _groupRole.default], ['heading', _headingRole.default], ['img', _imgRole.default], ['insertion', _insertionRole.default], ['link', _linkRole.default], ['list', _listRole.default], ['listbox', _listboxRole.default], ['listitem', _listitemRole.default], ['log', _logRole.default], ['main', _mainRole.default], ['marquee', _marqueeRole.default], ['math', _mathRole.default], ['menu', _menuRole.default], ['menubar', _menubarRole.default], ['menuitem', _menuitemRole.default], ['menuitemcheckbox', _menuitemcheckboxRole.default], ['menuitemradio', _menuitemradioRole.default], ['meter', _meterRole.default], ['navigation', _navigationRole.default], ['none', _noneRole.default], ['note', _noteRole.default], ['option', _optionRole.default], ['paragraph', _paragraphRole.default], ['presentation', _presentationRole.default], ['progressbar', _progressbarRole.default], ['radio', _radioRole.default], ['radiogroup', _radiogroupRole.default], ['region', _regionRole.default], ['row', _rowRole.default], ['rowgroup', _rowgroupRole.default], ['rowheader', _rowheaderRole.default], ['scrollbar', _scrollbarRole.default], ['search', _searchRole.default], ['searchbox', _searchboxRole.default], ['separator', _separatorRole.default], ['slider', _sliderRole.default], ['spinbutton', _spinbuttonRole.default], ['status', _statusRole.default], ['strong', _strongRole.default], ['subscript', _subscriptRole.default], ['superscript', _superscriptRole.default], ['switch', _switchRole.default], ['tab', _tabRole.default], ['table', _tableRole.default], ['tablist', _tablistRole.default], ['tabpanel', _tabpanelRole.default], ['term', _termRole.default], ['textbox', _textboxRole.default], ['time', _timeRole.default], ['timer', _timerRole.default], ['toolbar', _toolbarRole.default], ['tooltip', _tooltipRole.default], ['tree', _treeRole.default], ['treegrid', _treegridRole.default], ['treeitem', _treeitemRole.default]]);
+var _default = ariaLiteralRoles;
+exports.default = _default;
+});
+
+var docAbstractRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docAbstractRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'abstract [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = docAbstractRole;
+exports.default = _default;
+});
+
+var docAcknowledgmentsRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docAcknowledgmentsRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'acknowledgments [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = docAcknowledgmentsRole;
+exports.default = _default;
+});
+
+var docAfterwordRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docAfterwordRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'afterword [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = docAfterwordRole;
+exports.default = _default;
+});
+
+var docAppendixRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docAppendixRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'appendix [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = docAppendixRole;
+exports.default = _default;
+});
+
+var docBacklinkRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docBacklinkRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author', 'content'],
+  prohibitedProps: [],
+  props: {
+    'aria-errormessage': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'referrer [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'command', 'link']]
+};
+var _default = docBacklinkRole;
+exports.default = _default;
+});
+
+var docBiblioentryRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docBiblioentryRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'EPUB biblioentry [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: ['doc-bibliography'],
+  requiredContextRole: ['doc-bibliography'],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'listitem']]
+};
+var _default = docBiblioentryRole;
+exports.default = _default;
+});
+
+var docBibliographyRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docBibliographyRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'bibliography [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [['doc-biblioentry']],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = docBibliographyRole;
+exports.default = _default;
+});
+
+var docBibliorefRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docBibliorefRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {
+    'aria-errormessage': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'biblioref [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'command', 'link']]
+};
+var _default = docBibliorefRole;
+exports.default = _default;
+});
+
+var docChapterRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docChapterRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'chapter [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = docChapterRole;
+exports.default = _default;
+});
+
+var docColophonRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docColophonRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'colophon [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = docColophonRole;
+exports.default = _default;
+});
+
+var docConclusionRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docConclusionRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'conclusion [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = docConclusionRole;
+exports.default = _default;
+});
+
+var docCoverRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docCoverRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'cover [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'img']]
+};
+var _default = docCoverRole;
+exports.default = _default;
+});
+
+var docCreditRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docCreditRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'credit [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = docCreditRole;
+exports.default = _default;
+});
+
+var docCreditsRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docCreditsRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'credits [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = docCreditsRole;
+exports.default = _default;
+});
+
+var docDedicationRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docDedicationRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'dedication [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = docDedicationRole;
+exports.default = _default;
+});
+
+var docEndnoteRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docEndnoteRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'rearnote [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: ['doc-endnotes'],
+  requiredContextRole: ['doc-endnotes'],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'listitem']]
+};
+var _default = docEndnoteRole;
+exports.default = _default;
+});
+
+var docEndnotesRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docEndnotesRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'rearnotes [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [['doc-endnote']],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = docEndnotesRole;
+exports.default = _default;
+});
+
+var docEpigraphRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docEpigraphRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'epigraph [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = docEpigraphRole;
+exports.default = _default;
+});
+
+var docEpilogueRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docEpilogueRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'epilogue [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = docEpilogueRole;
+exports.default = _default;
+});
+
+var docErrataRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docErrataRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'errata [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = docErrataRole;
+exports.default = _default;
+});
+
+var docExampleRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docExampleRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = docExampleRole;
+exports.default = _default;
+});
+
+var docFootnoteRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docFootnoteRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'footnote [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = docFootnoteRole;
+exports.default = _default;
+});
+
+var docForewordRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docForewordRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'foreword [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = docForewordRole;
+exports.default = _default;
+});
+
+var docGlossaryRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docGlossaryRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'glossary [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [['definition'], ['term']],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = docGlossaryRole;
+exports.default = _default;
+});
+
+var docGlossrefRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docGlossrefRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {
+    'aria-errormessage': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'glossref [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'command', 'link']]
+};
+var _default = docGlossrefRole;
+exports.default = _default;
+});
+
+var docIndexRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docIndexRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'index [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark', 'navigation']]
+};
+var _default = docIndexRole;
+exports.default = _default;
+});
+
+var docIntroductionRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docIntroductionRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'introduction [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = docIntroductionRole;
+exports.default = _default;
+});
+
+var docNoterefRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docNoterefRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author', 'contents'],
+  prohibitedProps: [],
+  props: {
+    'aria-errormessage': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'noteref [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'widget', 'command', 'link']]
+};
+var _default = docNoterefRole;
+exports.default = _default;
+});
+
+var docNoticeRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docNoticeRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'notice [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'note']]
+};
+var _default = docNoticeRole;
+exports.default = _default;
+});
+
+var docPagebreakRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docPagebreakRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: true,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'pagebreak [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'separator']]
+};
+var _default = docPagebreakRole;
+exports.default = _default;
+});
+
+var docPagelistRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docPagelistRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'page-list [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark', 'navigation']]
+};
+var _default = docPagelistRole;
+exports.default = _default;
+});
+
+var docPartRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docPartRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'part [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = docPartRole;
+exports.default = _default;
+});
+
+var docPrefaceRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docPrefaceRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'preface [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = docPrefaceRole;
+exports.default = _default;
+});
+
+var docPrologueRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docPrologueRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'prologue [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark']]
+};
+var _default = docPrologueRole;
+exports.default = _default;
+});
+
+var docPullquoteRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docPullquoteRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [{
+    concept: {
+      name: 'pullquote [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['none']]
+};
+var _default = docPullquoteRole;
+exports.default = _default;
+});
+
+var docQnaRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docQnaRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'qna [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = docQnaRole;
+exports.default = _default;
+});
+
+var docSubtitleRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docSubtitleRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'subtitle [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'sectionhead']]
+};
+var _default = docSubtitleRole;
+exports.default = _default;
+});
+
+var docTipRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docTipRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'help [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'note']]
+};
+var _default = docTipRole;
+exports.default = _default;
+});
+
+var docTocRole_1 = createCommonjsModule(function (module, exports) {
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var docTocRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {
+    'aria-disabled': null,
+    'aria-errormessage': null,
+    'aria-expanded': null,
+    'aria-haspopup': null,
+    'aria-invalid': null
+  },
+  relatedConcepts: [{
+    concept: {
+      name: 'toc [EPUB-SSV]'
+    },
+    module: 'EPUB'
+  }],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'landmark', 'navigation']]
+};
+var _default = docTocRole;
+exports.default = _default;
+});
+
+var ariaDpubRoles_1 = createCommonjsModule(function (module, exports) {
+
+
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+
+var _map = interopRequireDefault(map);
+
+var _docAbstractRole = interopRequireDefault(docAbstractRole_1);
+
+var _docAcknowledgmentsRole = interopRequireDefault(docAcknowledgmentsRole_1);
+
+var _docAfterwordRole = interopRequireDefault(docAfterwordRole_1);
+
+var _docAppendixRole = interopRequireDefault(docAppendixRole_1);
+
+var _docBacklinkRole = interopRequireDefault(docBacklinkRole_1);
+
+var _docBiblioentryRole = interopRequireDefault(docBiblioentryRole_1);
+
+var _docBibliographyRole = interopRequireDefault(docBibliographyRole_1);
+
+var _docBibliorefRole = interopRequireDefault(docBibliorefRole_1);
+
+var _docChapterRole = interopRequireDefault(docChapterRole_1);
+
+var _docColophonRole = interopRequireDefault(docColophonRole_1);
+
+var _docConclusionRole = interopRequireDefault(docConclusionRole_1);
+
+var _docCoverRole = interopRequireDefault(docCoverRole_1);
+
+var _docCreditRole = interopRequireDefault(docCreditRole_1);
+
+var _docCreditsRole = interopRequireDefault(docCreditsRole_1);
+
+var _docDedicationRole = interopRequireDefault(docDedicationRole_1);
+
+var _docEndnoteRole = interopRequireDefault(docEndnoteRole_1);
+
+var _docEndnotesRole = interopRequireDefault(docEndnotesRole_1);
+
+var _docEpigraphRole = interopRequireDefault(docEpigraphRole_1);
+
+var _docEpilogueRole = interopRequireDefault(docEpilogueRole_1);
+
+var _docErrataRole = interopRequireDefault(docErrataRole_1);
+
+var _docExampleRole = interopRequireDefault(docExampleRole_1);
+
+var _docFootnoteRole = interopRequireDefault(docFootnoteRole_1);
+
+var _docForewordRole = interopRequireDefault(docForewordRole_1);
+
+var _docGlossaryRole = interopRequireDefault(docGlossaryRole_1);
+
+var _docGlossrefRole = interopRequireDefault(docGlossrefRole_1);
+
+var _docIndexRole = interopRequireDefault(docIndexRole_1);
+
+var _docIntroductionRole = interopRequireDefault(docIntroductionRole_1);
+
+var _docNoterefRole = interopRequireDefault(docNoterefRole_1);
+
+var _docNoticeRole = interopRequireDefault(docNoticeRole_1);
+
+var _docPagebreakRole = interopRequireDefault(docPagebreakRole_1);
+
+var _docPagelistRole = interopRequireDefault(docPagelistRole_1);
+
+var _docPartRole = interopRequireDefault(docPartRole_1);
+
+var _docPrefaceRole = interopRequireDefault(docPrefaceRole_1);
+
+var _docPrologueRole = interopRequireDefault(docPrologueRole_1);
+
+var _docPullquoteRole = interopRequireDefault(docPullquoteRole_1);
+
+var _docQnaRole = interopRequireDefault(docQnaRole_1);
+
+var _docSubtitleRole = interopRequireDefault(docSubtitleRole_1);
+
+var _docTipRole = interopRequireDefault(docTipRole_1);
+
+var _docTocRole = interopRequireDefault(docTocRole_1);
+
+var ariaDpubRoles = new _map.default([['doc-abstract', _docAbstractRole.default], ['doc-acknowledgments', _docAcknowledgmentsRole.default], ['doc-afterword', _docAfterwordRole.default], ['doc-appendix', _docAppendixRole.default], ['doc-backlink', _docBacklinkRole.default], ['doc-biblioentry', _docBiblioentryRole.default], ['doc-bibliography', _docBibliographyRole.default], ['doc-biblioref', _docBibliorefRole.default], ['doc-chapter', _docChapterRole.default], ['doc-colophon', _docColophonRole.default], ['doc-conclusion', _docConclusionRole.default], ['doc-cover', _docCoverRole.default], ['doc-credit', _docCreditRole.default], ['doc-credits', _docCreditsRole.default], ['doc-dedication', _docDedicationRole.default], ['doc-endnote', _docEndnoteRole.default], ['doc-endnotes', _docEndnotesRole.default], ['doc-epigraph', _docEpigraphRole.default], ['doc-epilogue', _docEpilogueRole.default], ['doc-errata', _docErrataRole.default], ['doc-example', _docExampleRole.default], ['doc-footnote', _docFootnoteRole.default], ['doc-foreword', _docForewordRole.default], ['doc-glossary', _docGlossaryRole.default], ['doc-glossref', _docGlossrefRole.default], ['doc-index', _docIndexRole.default], ['doc-introduction', _docIntroductionRole.default], ['doc-noteref', _docNoterefRole.default], ['doc-notice', _docNoticeRole.default], ['doc-pagebreak', _docPagebreakRole.default], ['doc-pagelist', _docPagelistRole.default], ['doc-part', _docPartRole.default], ['doc-preface', _docPrefaceRole.default], ['doc-prologue', _docPrologueRole.default], ['doc-pullquote', _docPullquoteRole.default], ['doc-qna', _docQnaRole.default], ['doc-subtitle', _docSubtitleRole.default], ['doc-tip', _docTipRole.default], ['doc-toc', _docTocRole.default]]);
+var _default = ariaDpubRoles;
+exports.default = _default;
+});
+
+var rolesMap_1 = createCommonjsModule(function (module, exports) {
+
+
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+
+var _getIterator2 = interopRequireDefault(getIterator);
+
+var _isArray = interopRequireDefault(isArray$3);
+
+var _getIteratorMethod2 = interopRequireDefault(getIteratorMethod);
+
+var _symbol = interopRequireDefault(symbol$3);
+
+var _from = interopRequireDefault(from$3);
+
+var _slice = interopRequireDefault(slice$3);
+
+var _defineProperty2 = interopRequireDefault(defineProperty$1);
+
+var _assign = interopRequireDefault(assign);
+
+var _keys = interopRequireDefault(keys$4);
+
+var _forEach = interopRequireDefault(forEach);
+
+var _map = interopRequireDefault(map);
+
+var _ariaAbstractRoles = interopRequireDefault(ariaAbstractRoles_1);
+
+var _ariaLiteralRoles = interopRequireDefault(ariaLiteralRoles_1);
+
+var _ariaDpubRoles = interopRequireDefault(ariaDpubRoles_1);
+
+var _context;
+
+function _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof _symbol.default === "undefined" || (0, _getIteratorMethod2.default)(o) == null) { if ((0, _isArray.default)(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = (0, _getIterator2.default)(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
+
+function _unsupportedIterableToArray(o, minLen) { var _context2; if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = (0, _slice.default)(_context2 = Object.prototype.toString.call(o)).call(_context2, 8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return (0, _from.default)(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+var rolesMap = new _map.default([]);
+(0, _forEach.default)(_context = [_ariaAbstractRoles.default, _ariaLiteralRoles.default, _ariaDpubRoles.default]).call(_context, function (roleSet) {
+  (0, _forEach.default)(roleSet).call(roleSet, function (roleDefinition, name) {
+    return rolesMap.set(name, roleDefinition);
+  });
+});
+(0, _forEach.default)(rolesMap).call(rolesMap, function (roleDefinition, name) {
+  // Conglomerate the properties
+  var _iterator = _createForOfIteratorHelper(roleDefinition.superClass),
+      _step;
+
+  try {
+    for (_iterator.s(); !(_step = _iterator.n()).done;) {
+      var superClassIter = _step.value;
+
+      var _iterator2 = _createForOfIteratorHelper(superClassIter),
+          _step2;
+
+      try {
+        for (_iterator2.s(); !(_step2 = _iterator2.n()).done;) {
+          var superClassName = _step2.value;
+          var superClassDefinition = rolesMap.get(superClassName);
+
+          if (superClassDefinition) {
+            for (var _i = 0, _Object$keys = (0, _keys.default)(superClassDefinition.props); _i < _Object$keys.length; _i++) {
+              var prop = _Object$keys[_i];
+
+              if (!Object.prototype.hasOwnProperty.call(roleDefinition.props, prop)) {
+                (0, _assign.default)(roleDefinition.props, (0, _defineProperty2.default)({}, prop, superClassDefinition.props[prop]));
+              }
+            }
+          }
+        }
+      } catch (err) {
+        _iterator2.e(err);
+      } finally {
+        _iterator2.f();
+      }
+    }
+  } catch (err) {
+    _iterator.e(err);
+  } finally {
+    _iterator.f();
+  }
+});
+var _default = rolesMap;
+exports.default = _default;
+});
+
+// `Set` constructor
+// https://tc39.es/ecma262/#sec-set-objects
+collection('Set', function (init) {
+  return function Set() { return init(this, arguments.length ? arguments[0] : undefined); };
+}, collectionStrong);
+
+var $TypeError$2 = TypeError;
+
+// Perform ? RequireInternalSlot(M, [[SetData]])
+var aSet$1 = function (it) {
+  if (typeof it == 'object' && 'size' in it && 'has' in it && 'add' in it && 'delete' in it && 'keys' in it) return it;
+  throw new $TypeError$2(tryToString(it) + ' is not a set');
+};
+
+var Set$3 = getBuiltIn('Set');
+var SetPrototype = Set$3.prototype;
+
+var setHelpers = {
+  Set: Set$3,
+  add: caller('add', 1),
+  has: caller('has', 1),
+  remove: caller('delete', 1),
+  proto: SetPrototype
+};
+
+var iterateSimple$1 = function (record, fn, ITERATOR_INSTEAD_OF_RECORD) {
+  var iterator = ITERATOR_INSTEAD_OF_RECORD ? record : record.iterator;
+  var next = record.next;
+  var step, result;
+  while (!(step = call(next, iterator)).done) {
+    result = fn(step.value);
+    if (result !== undefined) return result;
+  }
+};
+
+var iterateSimple = iterateSimple$1;
+
+var setIterate = function (set, fn, interruptible) {
+  return interruptible ? iterateSimple(set.keys(), fn, true) : set.forEach(fn);
+};
+
+var require$$0$b = setHelpers;
+
+var iterate = setIterate;
+
+var Set$2 = require$$0$b.Set;
+var add$3 = require$$0$b.add;
+
+var setClone = function (set) {
+  var result = new Set$2();
+  iterate(set, function (it) {
+    add$3(result, it);
+  });
+  return result;
+};
+
+var setSize = function (set) {
+  return set.size;
+};
+
+// `GetIteratorDirect(obj)` abstract operation
+// https://tc39.es/proposal-iterator-helpers/#sec-getiteratordirect
+var getIteratorDirect$1 = function (obj) {
+  return {
+    iterator: obj,
+    next: obj.next,
+    done: false
+  };
+};
+
+var getIteratorDirect = getIteratorDirect$1;
+
+var INVALID_SIZE = 'Invalid size';
+var $RangeError$2 = RangeError;
+var $TypeError$1 = TypeError;
+var max = Math.max;
+
+var SetRecord = function (set, intSize) {
+  this.set = set;
+  this.size = max(intSize, 0);
+  this.has = aCallable(set.has);
+  this.keys = aCallable(set.keys);
+};
+
+SetRecord.prototype = {
+  getIterator: function () {
+    return getIteratorDirect(anObject(call(this.keys, this.set)));
+  },
+  includes: function (it) {
+    return call(this.has, this.set, it);
+  }
+};
+
+// `GetSetRecord` abstract operation
+// https://tc39.es/proposal-set-methods/#sec-getsetrecord
+var getSetRecord$1 = function (obj) {
+  anObject(obj);
+  var numSize = +obj.size;
+  // NOTE: If size is undefined, then numSize will be NaN
+  // eslint-disable-next-line no-self-compare -- NaN check
+  if (numSize !== numSize) throw new $TypeError$1(INVALID_SIZE);
+  var intSize = toIntegerOrInfinity(numSize);
+  if (intSize < 0) throw new $RangeError$2(INVALID_SIZE);
+  return new SetRecord(obj, intSize);
+};
+
+var aSet = aSet$1;
+
+var clone = setClone;
+
+var size = setSize;
+
+var getSetRecord = getSetRecord$1;
+
+var has$4 = require$$0$b.has;
+var remove$1 = require$$0$b.remove;
+
+// `Set.prototype.difference` method
+// https://github.com/tc39/proposal-set-methods
+var setDifference = function difference(other) {
+  var O = aSet(this);
+  var otherRec = getSetRecord(other);
+  var result = clone(O);
+  if (size(O) <= otherRec.size) iterate(O, function (e) {
+    if (otherRec.includes(e)) remove$1(result, e);
+  });
+  else iterateSimple(otherRec.getIterator(), function (e) {
+    if (has$4(O, e)) remove$1(result, e);
+  });
+  return result;
+};
+
+var setMethodAcceptSetLike$1 = function () {
+  return false;
+};
+
+var difference = setDifference;
+
+var setMethodAcceptSetLike = setMethodAcceptSetLike$1;
+
+var INCORRECT$4 = !setMethodAcceptSetLike();
+
+// `Set.prototype.difference` method
+// https://tc39.es/ecma262/#sec-set.prototype.difference
+$({ target: 'Set', proto: true, real: true, forced: INCORRECT$4 }, {
+  difference: difference
+});
+
+var Set$1 = require$$0$b.Set;
+var add$2 = require$$0$b.add;
+var has$3 = require$$0$b.has;
+
+// `Set.prototype.intersection` method
+// https://github.com/tc39/proposal-set-methods
+var setIntersection = function intersection(other) {
+  var O = aSet(this);
+  var otherRec = getSetRecord(other);
+  var result = new Set$1();
+
+  if (size(O) > otherRec.size) {
+    iterateSimple(otherRec.getIterator(), function (e) {
+      if (has$3(O, e)) add$2(result, e);
+    });
+  } else {
+    iterate(O, function (e) {
+      if (otherRec.includes(e)) add$2(result, e);
+    });
+  }
+
+  return result;
+};
+
+var intersection = setIntersection;
+
+var INCORRECT$3 = !setMethodAcceptSetLike() || fails(function () {
+  // eslint-disable-next-line es/no-array-from, es/no-set, es/no-set-prototype-intersection -- testing
+  return String(Array.from(new Set([1, 2, 3]).intersection(new Set([3, 2])))) !== '3,2';
+});
+
+// `Set.prototype.intersection` method
+// https://tc39.es/ecma262/#sec-set.prototype.intersection
+$({ target: 'Set', proto: true, real: true, forced: INCORRECT$3 }, {
+  intersection: intersection
+});
+
+var has$2 = require$$0$b.has;
+
+
+
+
+
+
+// `Set.prototype.isDisjointFrom` method
+// https://tc39.github.io/proposal-set-methods/#Set.prototype.isDisjointFrom
+var setIsDisjointFrom = function isDisjointFrom(other) {
+  var O = aSet(this);
+  var otherRec = getSetRecord(other);
+  if (size(O) <= otherRec.size) return iterate(O, function (e) {
+    if (otherRec.includes(e)) return false;
+  }, true) !== false;
+  var iterator = otherRec.getIterator();
+  return iterateSimple(iterator, function (e) {
+    if (has$2(O, e)) return iteratorClose(iterator, 'normal', false);
+  }) !== false;
+};
+
+var isDisjointFrom = setIsDisjointFrom;
+
+var INCORRECT$2 = !setMethodAcceptSetLike();
+
+// `Set.prototype.isDisjointFrom` method
+// https://tc39.es/ecma262/#sec-set.prototype.isdisjointfrom
+$({ target: 'Set', proto: true, real: true, forced: INCORRECT$2 }, {
+  isDisjointFrom: isDisjointFrom
+});
+
+// `Set.prototype.isSubsetOf` method
+// https://tc39.github.io/proposal-set-methods/#Set.prototype.isSubsetOf
+var setIsSubsetOf = function isSubsetOf(other) {
+  var O = aSet(this);
+  var otherRec = getSetRecord(other);
+  if (size(O) > otherRec.size) return false;
+  return iterate(O, function (e) {
+    if (!otherRec.includes(e)) return false;
+  }, true) !== false;
+};
+
+var isSubsetOf = setIsSubsetOf;
+
+var INCORRECT$1 = !setMethodAcceptSetLike();
+
+// `Set.prototype.isSubsetOf` method
+// https://tc39.es/ecma262/#sec-set.prototype.issubsetof
+$({ target: 'Set', proto: true, real: true, forced: INCORRECT$1 }, {
+  isSubsetOf: isSubsetOf
+});
+
+var has$1 = require$$0$b.has;
+
+
+
+
+
+// `Set.prototype.isSupersetOf` method
+// https://tc39.github.io/proposal-set-methods/#Set.prototype.isSupersetOf
+var setIsSupersetOf = function isSupersetOf(other) {
+  var O = aSet(this);
+  var otherRec = getSetRecord(other);
+  if (size(O) < otherRec.size) return false;
+  var iterator = otherRec.getIterator();
+  return iterateSimple(iterator, function (e) {
+    if (!has$1(O, e)) return iteratorClose(iterator, 'normal', false);
+  }) !== false;
+};
+
+var isSupersetOf = setIsSupersetOf;
+
+var INCORRECT = !setMethodAcceptSetLike();
+
+// `Set.prototype.isSupersetOf` method
+// https://tc39.es/ecma262/#sec-set.prototype.issupersetof
+$({ target: 'Set', proto: true, real: true, forced: INCORRECT }, {
+  isSupersetOf: isSupersetOf
+});
+
+var add$1 = require$$0$b.add;
+var has = require$$0$b.has;
+var remove = require$$0$b.remove;
+
+// `Set.prototype.symmetricDifference` method
+// https://github.com/tc39/proposal-set-methods
+var setSymmetricDifference = function symmetricDifference(other) {
+  var O = aSet(this);
+  var keysIter = getSetRecord(other).getIterator();
+  var result = clone(O);
+  iterateSimple(keysIter, function (e) {
+    if (has(O, e)) remove(result, e);
+    else add$1(result, e);
+  });
+  return result;
+};
+
+var symmetricDifference = setSymmetricDifference;
+
+// `Set.prototype.symmetricDifference` method
+// https://tc39.es/ecma262/#sec-set.prototype.symmetricdifference
+$({ target: 'Set', proto: true, real: true, forced: !setMethodAcceptSetLike() }, {
+  symmetricDifference: symmetricDifference
+});
+
+var add = require$$0$b.add;
+
+
+
+
+// `Set.prototype.union` method
+// https://github.com/tc39/proposal-set-methods
+var setUnion = function union(other) {
+  var O = aSet(this);
+  var keysIter = getSetRecord(other).getIterator();
+  var result = clone(O);
+  iterateSimple(keysIter, function (it) {
+    add(result, it);
+  });
+  return result;
+};
+
+var union = setUnion;
+
+// `Set.prototype.union` method
+// https://tc39.es/ecma262/#sec-set.prototype.union
+$({ target: 'Set', proto: true, real: true, forced: !setMethodAcceptSetLike() }, {
+  union: union
+});
+
+var set$2 = path.Set;
+
+var parent$b = set$2;
+
+var set$1 = parent$b;
+
+var require$$0$a = set$1;
+
+var set = require$$0$a;
+
+var isArray$2 = parent$w;
+
+var parent$a = isArray$2;
+
+var isArray$1 = parent$a;
+
+var require$$0$9 = isArray$1;
+
+var isArray = require$$0$9;
+
+var _Array$isArray = isArray;
+
+var arrayWithHoles = createCommonjsModule(function (module) {
+function _arrayWithHoles(r) {
+  if (_Array$isArray(r)) return r;
+}
+module.exports = _arrayWithHoles, module.exports.__esModule = true, module.exports["default"] = module.exports;
+});
+
+var $TypeError = TypeError;
+// eslint-disable-next-line es/no-object-getownpropertydescriptor -- safe
+var getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+
+// Safari < 13 does not throw an error in this case
+var SILENT_ON_NON_WRITABLE_LENGTH_SET = DESCRIPTORS && !function () {
+  // makes no sense without proper strict mode support
+  if (this !== undefined) return true;
+  try {
+    // eslint-disable-next-line es/no-object-defineproperty -- safe
+    Object.defineProperty([], 'length', { writable: false }).length = 1;
+  } catch (error) {
+    return error instanceof TypeError;
+  }
+}();
+
+var arraySetLength = SILENT_ON_NON_WRITABLE_LENGTH_SET ? function (O, length) {
+  if (isArray$6(O) && !getOwnPropertyDescriptor(O, 'length').writable) {
+    throw new $TypeError('Cannot set read only .length');
+  } return O.length = length;
+} : function (O, length) {
+  return O.length = length;
+};
+
+var setArrayLength = arraySetLength;
+
+var INCORRECT_TO_LENGTH = fails(function () {
+  return [].push.call({ length: 0x100000000 }, 1) !== 4294967297;
+});
+
+// V8 <= 121 and Safari <= 15.4; FF < 23 throws InternalError
+// https://bugs.chromium.org/p/v8/issues/detail?id=12681
+var properErrorOnNonWritableLength = function () {
+  try {
+    // eslint-disable-next-line es/no-object-defineproperty -- safe
+    Object.defineProperty([], 'length', { writable: false }).push();
+  } catch (error) {
+    return error instanceof TypeError;
+  }
+};
+
+var FORCED$1 = INCORRECT_TO_LENGTH || !properErrorOnNonWritableLength();
+
+// `Array.prototype.push` method
+// https://tc39.es/ecma262/#sec-array.prototype.push
+$({ target: 'Array', proto: true, arity: 1, forced: FORCED$1 }, {
+  // eslint-disable-next-line no-unused-vars -- required for `.length`
+  push: function push(item) {
+    var O = toObject$1(this);
+    var len = lengthOfArrayLike(O);
+    var argCount = arguments.length;
+    doesNotExceedSafeInteger(len + argCount);
+    for (var i = 0; i < argCount; i++) {
+      O[len] = arguments[i];
+      len++;
+    }
+    setArrayLength(O, len);
+    return len;
+  }
+});
+
+var push$5 = getBuiltInPrototypeMethod('Array', 'push');
+
+var method$4 = push$5;
+
+var ArrayPrototype$4 = Array.prototype;
+
+var push$4 = function (it) {
+  var own = it.push;
+  return it === ArrayPrototype$4 || (isPrototypeOf(ArrayPrototype$4, it) && own === ArrayPrototype$4.push) ? method$4 : own;
+};
+
+var parent$9 = push$4;
+
+var push$3 = parent$9;
+
+var parent$8 = push$3;
+
+var push$2 = parent$8;
+
+var parent$7 = push$2;
+
+var push$1 = parent$7;
+
+var require$$0$8 = push$1;
+
+var push = require$$0$8;
+
+var _pushInstanceProperty = push;
+
+var iterableToArrayLimit = createCommonjsModule(function (module) {
+function _iterableToArrayLimit(r, l) {
+  var t = null == r ? null : "undefined" != typeof _Symbol && _getIteratorMethod(r) || r["@@iterator"];
+  if (null != t) {
+    var e,
+      n,
+      i,
+      u,
+      a = [],
+      f = !0,
+      o = !1;
+    try {
+      if (i = (t = t.call(r)).next, 0 === l) {
+        if (Object(t) !== t) return;
+        f = !1;
+      } else for (; !(f = (e = i.call(t)).done) && (_pushInstanceProperty(a).call(a, e.value), a.length !== l); f = !0);
+    } catch (r) {
+      o = !0, n = r;
+    } finally {
+      try {
+        if (!f && null != t["return"] && (u = t["return"](), Object(u) !== u)) return;
+      } finally {
+        if (o) throw n;
+      }
+    }
+    return a;
+  }
+}
+module.exports = _iterableToArrayLimit, module.exports.__esModule = true, module.exports["default"] = module.exports;
+});
+
+var slice$2 = parent$n;
+
+var parent$6 = slice$2;
+
+var slice$1 = parent$6;
+
+var require$$0$7 = slice$1;
+
+var slice = require$$0$7;
+
+var from$2 = parent$p;
+
+var parent$5 = from$2;
+
+var from$1 = parent$5;
+
+var require$$0$6 = from$1;
+
+var from = require$$0$6;
+
+var arrayLikeToArray = createCommonjsModule(function (module) {
+function _arrayLikeToArray(r, a) {
+  (null == a || a > r.length) && (a = r.length);
+  for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e];
+  return n;
+}
+module.exports = _arrayLikeToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
+});
+
+var _sliceInstanceProperty = slice;
+
+var _Array$from = from;
+
+var unsupportedIterableToArray = createCommonjsModule(function (module) {
+function _unsupportedIterableToArray(r, a) {
+  if (r) {
+    var _context;
+    if ("string" == typeof r) return arrayLikeToArray(r, a);
+    var t = _sliceInstanceProperty(_context = {}.toString.call(r)).call(_context, 8, -1);
+    return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? _Array$from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? arrayLikeToArray(r, a) : void 0;
+  }
+}
+module.exports = _unsupportedIterableToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
+});
+
+var nonIterableRest = createCommonjsModule(function (module) {
+function _nonIterableRest() {
+  throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+}
+module.exports = _nonIterableRest, module.exports.__esModule = true, module.exports["default"] = module.exports;
+});
+
+var slicedToArray = createCommonjsModule(function (module) {
+function _slicedToArray(r, e) {
+  return arrayWithHoles(r) || iterableToArrayLimit(r, e) || unsupportedIterableToArray(r, e) || nonIterableRest();
+}
+module.exports = _slicedToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
+});
+
+var entries$3 = getBuiltInPrototypeMethod('Array', 'entries');
+
+var parent$4 = entries$3;
+
+var entries$2 = parent$4;
+
+var method$3 = entries$2;
+
+var ArrayPrototype$3 = Array.prototype;
+
+var DOMIterables$1 = {
+  DOMTokenList: true,
+  NodeList: true
+};
+
+var entries$1 = function (it) {
+  var own = it.entries;
+  return it === ArrayPrototype$3 || (isPrototypeOf(ArrayPrototype$3, it) && own === ArrayPrototype$3.entries)
+    || hasOwn(DOMIterables$1, classof(it)) ? method$3 : own;
+};
+
+var require$$0$5 = entries$1;
+
+var entries = require$$0$5;
+
+var $find = require$$0$o.find;
+
+
+var FIND = 'find';
+var SKIPS_HOLES = true;
+
+// Shouldn't skip holes
+// eslint-disable-next-line es/no-array-prototype-find -- testing
+if (FIND in []) Array(1)[FIND](function () { SKIPS_HOLES = false; });
+
+// `Array.prototype.find` method
+// https://tc39.es/ecma262/#sec-array.prototype.find
+$({ target: 'Array', proto: true, forced: SKIPS_HOLES }, {
+  find: function find(callbackfn /* , that = undefined */) {
+    return $find(this, callbackfn, arguments.length > 1 ? arguments[1] : undefined);
+  }
+});
+
+// https://tc39.es/ecma262/#sec-array.prototype-@@unscopables
+addToUnscopables();
+
+var find$3 = getBuiltInPrototypeMethod('Array', 'find');
+
+var method$2 = find$3;
+
+var ArrayPrototype$2 = Array.prototype;
+
+var find$2 = function (it) {
+  var own = it.find;
+  return it === ArrayPrototype$2 || (isPrototypeOf(ArrayPrototype$2, it) && own === ArrayPrototype$2.find) ? method$2 : own;
+};
+
+var parent$3 = find$2;
+
+var find$1 = parent$3;
+
+var require$$0$4 = find$1;
+
+var find = require$$0$4;
+
+var $RangeError$1 = RangeError;
+
+// `String.prototype.repeat` method implementation
+// https://tc39.es/ecma262/#sec-string.prototype.repeat
+var stringRepeat = function repeat(count) {
+  var str = toString(requireObjectCoercible(this));
+  var result = '';
+  var n = toIntegerOrInfinity(count);
+  if (n < 0 || n === Infinity) throw new $RangeError$1('Wrong number of repetitions');
+  for (;n > 0; (n >>>= 1) && (str += str)) if (n & 1) result += str;
+  return result;
+};
+
+var $repeat = stringRepeat;
+
+// https://github.com/tc39/proposal-string-pad-start-end
+
+
+
+
+
+
+var repeat = uncurryThis$1($repeat);
+var stringSlice = uncurryThis$1(''.slice);
+var ceil = Math.ceil;
+
+// `String.prototype.{ padStart, padEnd }` methods implementation
+var createMethod = function (IS_END) {
+  return function ($this, maxLength, fillString) {
+    var S = toString(requireObjectCoercible($this));
+    var intMaxLength = toLength(maxLength);
+    var stringLength = S.length;
+    var fillStr = fillString === undefined ? ' ' : toString(fillString);
+    var fillLen, stringFiller;
+    if (intMaxLength <= stringLength || fillStr === '') return S;
+    fillLen = intMaxLength - stringLength;
+    stringFiller = repeat(fillStr, ceil(fillLen / fillStr.length));
+    if (stringFiller.length > fillLen) stringFiller = stringSlice(stringFiller, 0, fillLen);
+    return IS_END ? S + stringFiller : stringFiller + S;
+  };
+};
+
+var stringPad = {
+  // `String.prototype.padStart` method
+  // https://tc39.es/ecma262/#sec-string.prototype.padstart
+  start: createMethod(false),
+  // `String.prototype.padEnd` method
+  // https://tc39.es/ecma262/#sec-string.prototype.padend
+  end: createMethod(true)
+};
+
+var require$$0$3 = stringPad;
+
+var padStart = require$$0$3.start;
+
+var $RangeError = RangeError;
+var $isFinite = isFinite;
+var abs = Math.abs;
+var DatePrototype = Date.prototype;
+var nativeDateToISOString = DatePrototype.toISOString;
+var thisTimeValue = uncurryThis$1(DatePrototype.getTime);
+var getUTCDate = uncurryThis$1(DatePrototype.getUTCDate);
+var getUTCFullYear = uncurryThis$1(DatePrototype.getUTCFullYear);
+var getUTCHours = uncurryThis$1(DatePrototype.getUTCHours);
+var getUTCMilliseconds = uncurryThis$1(DatePrototype.getUTCMilliseconds);
+var getUTCMinutes = uncurryThis$1(DatePrototype.getUTCMinutes);
+var getUTCMonth = uncurryThis$1(DatePrototype.getUTCMonth);
+var getUTCSeconds = uncurryThis$1(DatePrototype.getUTCSeconds);
+
+// `Date.prototype.toISOString` method implementation
+// https://tc39.es/ecma262/#sec-date.prototype.toisostring
+// PhantomJS / old WebKit fails here:
+var dateToIsoString = (fails(function () {
+  return nativeDateToISOString.call(new Date(-5e13 - 1)) !== '0385-07-25T07:06:39.999Z';
+}) || !fails(function () {
+  nativeDateToISOString.call(new Date(NaN));
+})) ? function toISOString() {
+  if (!$isFinite(thisTimeValue(this))) throw new $RangeError('Invalid time value');
+  var date = this;
+  var year = getUTCFullYear(date);
+  var milliseconds = getUTCMilliseconds(date);
+  var sign = year < 0 ? '-' : year > 9999 ? '+' : '';
+  return sign + padStart(abs(year), sign ? 6 : 4, 0) +
+    '-' + padStart(getUTCMonth(date) + 1, 2, 0) +
+    '-' + padStart(getUTCDate(date), 2, 0) +
+    'T' + padStart(getUTCHours(date), 2, 0) +
+    ':' + padStart(getUTCMinutes(date), 2, 0) +
+    ':' + padStart(getUTCSeconds(date), 2, 0) +
+    '.' + padStart(milliseconds, 3, 0) +
+    'Z';
+} : nativeDateToISOString;
+
+var toISOString = dateToIsoString;
+
+var FORCED = fails(function () {
+  return new Date(NaN).toJSON() !== null
+    || call(Date.prototype.toJSON, { toISOString: function () { return 1; } }) !== 1;
+});
+
+// `Date.prototype.toJSON` method
+// https://tc39.es/ecma262/#sec-date.prototype.tojson
+$({ target: 'Date', proto: true, forced: FORCED }, {
+  // eslint-disable-next-line no-unused-vars -- required for `.length`
+  toJSON: function toJSON(key) {
+    var O = toObject$1(this);
+    var pv = toPrimitive$5(O, 'number');
+    return typeof pv == 'number' && !isFinite(pv) ? null :
+      (!('toISOString' in O) && classof$2(O) === 'Date') ? call(toISOString, O) : O.toISOString();
+  }
+});
+
+// eslint-disable-next-line es/no-json -- safe
+if (!path.JSON) path.JSON = { stringify: JSON.stringify };
+
+// eslint-disable-next-line no-unused-vars -- required for `.length`
+var stringify$2 = function stringify(it, replacer, space) {
+  return apply(path.JSON.stringify, null, arguments);
+};
+
+var parent$2 = stringify$2;
+
+var stringify$1 = parent$2;
+
+var require$$0$2 = stringify$1;
+
+var stringify = require$$0$2;
+
+var concat$3 = getBuiltInPrototypeMethod('Array', 'concat');
+
+var method$1 = concat$3;
+
+var ArrayPrototype$1 = Array.prototype;
+
+var concat$2 = function (it) {
+  var own = it.concat;
+  return it === ArrayPrototype$1 || (isPrototypeOf(ArrayPrototype$1, it) && own === ArrayPrototype$1.concat) ? method$1 : own;
+};
+
+var parent$1 = concat$2;
+
+var concat$1 = parent$1;
+
+var require$$0$1 = concat$1;
+
+var concat = require$$0$1;
+
+var keys$3 = getBuiltInPrototypeMethod('Array', 'keys');
+
+var parent = keys$3;
+
+var keys$2 = parent;
+
+var method = keys$2;
+
+var ArrayPrototype = Array.prototype;
+
+var DOMIterables = {
+  DOMTokenList: true,
+  NodeList: true
+};
+
+var keys$1 = function (it) {
+  var own = it.keys;
+  return it === ArrayPrototype || (isPrototypeOf(ArrayPrototype, it) && own === ArrayPrototype.keys)
+    || hasOwn(DOMIterables, classof(it)) ? method : own;
+};
+
+var require$$0 = keys$1;
+
+var keys = require$$0;
+
+var arrayWithoutHoles = createCommonjsModule(function (module) {
+function _arrayWithoutHoles(r) {
+  if (_Array$isArray(r)) return arrayLikeToArray(r);
+}
+module.exports = _arrayWithoutHoles, module.exports.__esModule = true, module.exports["default"] = module.exports;
+});
+
+var iterableToArray = createCommonjsModule(function (module) {
+function _iterableToArray(r) {
+  if ("undefined" != typeof _Symbol && null != _getIteratorMethod(r) || null != r["@@iterator"]) return _Array$from(r);
+}
+module.exports = _iterableToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
+});
+
+var nonIterableSpread = createCommonjsModule(function (module) {
+function _nonIterableSpread() {
+  throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+}
+module.exports = _nonIterableSpread, module.exports.__esModule = true, module.exports["default"] = module.exports;
+});
+
+var toConsumableArray = createCommonjsModule(function (module) {
+function _toConsumableArray(r) {
+  return arrayWithoutHoles(r) || iterableToArray(r) || unsupportedIterableToArray(r) || nonIterableSpread();
+}
+module.exports = _toConsumableArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
+});
+
+var elementRoleMap_1 = createCommonjsModule(function (module, exports) {
+
+
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+
+var _set = interopRequireDefault(set);
+
+var _slicedToArray2 = interopRequireDefault(slicedToArray);
+
+var _entries = interopRequireDefault(entries);
+
+var _find = interopRequireDefault(find);
+
+var _stringify = interopRequireDefault(stringify);
+
+var _concat = interopRequireDefault(concat);
+
+var _keys = interopRequireDefault(keys);
+
+var _toConsumableArray2 = interopRequireDefault(toConsumableArray);
+
+var _forEach = interopRequireDefault(forEach);
+
+var _map = interopRequireDefault(map);
+
+var _rolesMap = interopRequireDefault(rolesMap_1);
+
+var _context;
+
+var elementRoleMap = new _map.default([]);
+(0, _forEach.default)(_context = (0, _toConsumableArray2.default)((0, _keys.default)(_rolesMap.default).call(_rolesMap.default))).call(_context, function (key) {
+  var role = _rolesMap.default.get(key);
+
+  if (role) {
+    var _context2, _context3;
+
+    (0, _forEach.default)(_context2 = (0, _concat.default)(_context3 = []).call(_context3, (0, _toConsumableArray2.default)(role.baseConcepts), (0, _toConsumableArray2.default)(role.relatedConcepts))).call(_context2, function (relation) {
+      if (relation.module === 'HTML') {
+        var concept = relation.concept;
+
+        if (concept) {
+          var _context4;
+
+          var conceptStr = (0, _stringify.default)(concept);
+          var roles = ((0, _find.default)(_context4 = (0, _toConsumableArray2.default)((0, _entries.default)(elementRoleMap).call(elementRoleMap))).call(_context4, function (_ref) {
+            var _ref2 = (0, _slicedToArray2.default)(_ref, 2),
+                key = _ref2[0];
+                _ref2[1];
+
+            return (0, _stringify.default)(key) === conceptStr;
+          }) || [])[1];
+
+          if (!roles) {
+            roles = new _set.default([]);
+          }
+
+          roles.add(key);
+          elementRoleMap.set(concept, roles);
+        }
+      }
+    });
+  }
+});
+var _default = elementRoleMap;
+exports.default = _default;
+});
+
+var roleElementMap_1 = createCommonjsModule(function (module, exports) {
+
+
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+
+var _set = interopRequireDefault(set);
+
+var _concat = interopRequireDefault(concat);
+
+var _keys = interopRequireDefault(keys);
+
+var _toConsumableArray2 = interopRequireDefault(toConsumableArray);
+
+var _forEach = interopRequireDefault(forEach);
+
+var _map = interopRequireDefault(map);
+
+var _rolesMap = interopRequireDefault(rolesMap_1);
+
+var _context;
+
+var roleElementMap = new _map.default([]);
+(0, _forEach.default)(_context = (0, _toConsumableArray2.default)((0, _keys.default)(_rolesMap.default).call(_rolesMap.default))).call(_context, function (key) {
+  var role = _rolesMap.default.get(key);
+
+  if (role) {
+    var _context2, _context3;
+
+    (0, _forEach.default)(_context2 = (0, _concat.default)(_context3 = []).call(_context3, (0, _toConsumableArray2.default)(role.baseConcepts), (0, _toConsumableArray2.default)(role.relatedConcepts))).call(_context2, function (relation) {
+      if (relation.module === 'HTML') {
+        var concept = relation.concept;
+
+        if (concept) {
+          var relationConcepts = roleElementMap.get(key) || new _set.default([]);
+          relationConcepts.add(concept);
+          roleElementMap.set(key, relationConcepts);
+        }
+      }
+    });
+  }
+});
+var _default = roleElementMap;
+exports.default = _default;
+});
+
+var lib = createCommonjsModule(function (module, exports) {
+
+
+
+
+
+defineProperty$a(exports, "__esModule", {
+  value: true
+});
+
+exports.roleElements = exports.elementRoles = exports.roles = exports.dom = exports.aria = void 0;
+
+var _ariaPropsMap = interopRequireDefault(ariaPropsMap_1);
+
+var _domMap = interopRequireDefault(domMap_1);
+
+var _rolesMap = interopRequireDefault(rolesMap_1);
+
+var _elementRoleMap = interopRequireDefault(elementRoleMap_1);
+
+var _roleElementMap = interopRequireDefault(roleElementMap_1);
+
+var aria = _ariaPropsMap.default;
+exports.aria = aria;
+var dom = _domMap.default;
+exports.dom = dom;
+var roles = _rolesMap.default;
+exports.roles = roles;
+var elementRoles = _elementRoleMap.default;
+exports.elementRoles = elementRoles;
+var roleElements = _roleElementMap.default;
+exports.roleElements = roleElements;
+});
+
+function _objectWithoutPropertiesLoose(r, e) {
+  if (null == r) return {};
+  var t = {};
+  for (var n in r) if ({}.hasOwnProperty.call(r, n)) {
+    if (-1 !== e.indexOf(n)) continue;
+    t[n] = r[n];
+  }
+  return t;
+}
+
+var lzString = createCommonjsModule(function (module) {
+// Copyright (c) 2013 Pieroxy <pieroxy@pieroxy.net>
+// This work is free. You can redistribute it and/or modify it
+// under the terms of the WTFPL, Version 2
+// For more information see LICENSE.txt or http://www.wtfpl.net/
+//
+// For more information, the home page:
+// http://pieroxy.net/blog/pages/lz-string/testing.html
+//
+// LZ-based compression algorithm, version 1.4.5
+var LZString = (function() {
+
+// private property
+var f = String.fromCharCode;
+var keyStrBase64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+var keyStrUriSafe = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-$";
+var baseReverseDic = {};
+
+function getBaseValue(alphabet, character) {
+  if (!baseReverseDic[alphabet]) {
+    baseReverseDic[alphabet] = {};
+    for (var i=0 ; i<alphabet.length ; i++) {
+      baseReverseDic[alphabet][alphabet.charAt(i)] = i;
+    }
+  }
+  return baseReverseDic[alphabet][character];
+}
+
+var LZString = {
+  compressToBase64 : function (input) {
+    if (input == null) return "";
+    var res = LZString._compress(input, 6, function(a){return keyStrBase64.charAt(a);});
+    switch (res.length % 4) { // To produce valid Base64
+    default: // When could this happen ?
+    case 0 : return res;
+    case 1 : return res+"===";
+    case 2 : return res+"==";
+    case 3 : return res+"=";
+    }
+  },
+
+  decompressFromBase64 : function (input) {
+    if (input == null) return "";
+    if (input == "") return null;
+    return LZString._decompress(input.length, 32, function(index) { return getBaseValue(keyStrBase64, input.charAt(index)); });
+  },
+
+  compressToUTF16 : function (input) {
+    if (input == null) return "";
+    return LZString._compress(input, 15, function(a){return f(a+32);}) + " ";
+  },
+
+  decompressFromUTF16: function (compressed) {
+    if (compressed == null) return "";
+    if (compressed == "") return null;
+    return LZString._decompress(compressed.length, 16384, function(index) { return compressed.charCodeAt(index) - 32; });
+  },
+
+  //compress into uint8array (UCS-2 big endian format)
+  compressToUint8Array: function (uncompressed) {
+    var compressed = LZString.compress(uncompressed);
+    var buf=new Uint8Array(compressed.length*2); // 2 bytes per character
+
+    for (var i=0, TotalLen=compressed.length; i<TotalLen; i++) {
+      var current_value = compressed.charCodeAt(i);
+      buf[i*2] = current_value >>> 8;
+      buf[i*2+1] = current_value % 256;
+    }
+    return buf;
+  },
+
+  //decompress from uint8array (UCS-2 big endian format)
+  decompressFromUint8Array:function (compressed) {
+    if (compressed===null || compressed===undefined){
+        return LZString.decompress(compressed);
+    } else {
+        var buf=new Array(compressed.length/2); // 2 bytes per character
+        for (var i=0, TotalLen=buf.length; i<TotalLen; i++) {
+          buf[i]=compressed[i*2]*256+compressed[i*2+1];
+        }
+
+        var result = [];
+        buf.forEach(function (c) {
+          result.push(f(c));
+        });
+        return LZString.decompress(result.join(''));
+
+    }
+
+  },
+
+
+  //compress into a string that is already URI encoded
+  compressToEncodedURIComponent: function (input) {
+    if (input == null) return "";
+    return LZString._compress(input, 6, function(a){return keyStrUriSafe.charAt(a);});
+  },
+
+  //decompress from an output of compressToEncodedURIComponent
+  decompressFromEncodedURIComponent:function (input) {
+    if (input == null) return "";
+    if (input == "") return null;
+    input = input.replace(/ /g, "+");
+    return LZString._decompress(input.length, 32, function(index) { return getBaseValue(keyStrUriSafe, input.charAt(index)); });
+  },
+
+  compress: function (uncompressed) {
+    return LZString._compress(uncompressed, 16, function(a){return f(a);});
+  },
+  _compress: function (uncompressed, bitsPerChar, getCharFromInt) {
+    if (uncompressed == null) return "";
+    var i, value,
+        context_dictionary= {},
+        context_dictionaryToCreate= {},
+        context_c="",
+        context_wc="",
+        context_w="",
+        context_enlargeIn= 2, // Compensate for the first entry which should not count
+        context_dictSize= 3,
+        context_numBits= 2,
+        context_data=[],
+        context_data_val=0,
+        context_data_position=0,
+        ii;
+
+    for (ii = 0; ii < uncompressed.length; ii += 1) {
+      context_c = uncompressed.charAt(ii);
+      if (!Object.prototype.hasOwnProperty.call(context_dictionary,context_c)) {
+        context_dictionary[context_c] = context_dictSize++;
+        context_dictionaryToCreate[context_c] = true;
+      }
+
+      context_wc = context_w + context_c;
+      if (Object.prototype.hasOwnProperty.call(context_dictionary,context_wc)) {
+        context_w = context_wc;
+      } else {
+        if (Object.prototype.hasOwnProperty.call(context_dictionaryToCreate,context_w)) {
+          if (context_w.charCodeAt(0)<256) {
+            for (i=0 ; i<context_numBits ; i++) {
+              context_data_val = (context_data_val << 1);
+              if (context_data_position == bitsPerChar-1) {
+                context_data_position = 0;
+                context_data.push(getCharFromInt(context_data_val));
+                context_data_val = 0;
+              } else {
+                context_data_position++;
+              }
+            }
+            value = context_w.charCodeAt(0);
+            for (i=0 ; i<8 ; i++) {
+              context_data_val = (context_data_val << 1) | (value&1);
+              if (context_data_position == bitsPerChar-1) {
+                context_data_position = 0;
+                context_data.push(getCharFromInt(context_data_val));
+                context_data_val = 0;
+              } else {
+                context_data_position++;
+              }
+              value = value >> 1;
+            }
+          } else {
+            value = 1;
+            for (i=0 ; i<context_numBits ; i++) {
+              context_data_val = (context_data_val << 1) | value;
+              if (context_data_position ==bitsPerChar-1) {
+                context_data_position = 0;
+                context_data.push(getCharFromInt(context_data_val));
+                context_data_val = 0;
+              } else {
+                context_data_position++;
+              }
+              value = 0;
+            }
+            value = context_w.charCodeAt(0);
+            for (i=0 ; i<16 ; i++) {
+              context_data_val = (context_data_val << 1) | (value&1);
+              if (context_data_position == bitsPerChar-1) {
+                context_data_position = 0;
+                context_data.push(getCharFromInt(context_data_val));
+                context_data_val = 0;
+              } else {
+                context_data_position++;
+              }
+              value = value >> 1;
+            }
+          }
+          context_enlargeIn--;
+          if (context_enlargeIn == 0) {
+            context_enlargeIn = Math.pow(2, context_numBits);
+            context_numBits++;
+          }
+          delete context_dictionaryToCreate[context_w];
+        } else {
+          value = context_dictionary[context_w];
+          for (i=0 ; i<context_numBits ; i++) {
+            context_data_val = (context_data_val << 1) | (value&1);
+            if (context_data_position == bitsPerChar-1) {
+              context_data_position = 0;
+              context_data.push(getCharFromInt(context_data_val));
+              context_data_val = 0;
+            } else {
+              context_data_position++;
+            }
+            value = value >> 1;
+          }
+
+
+        }
+        context_enlargeIn--;
+        if (context_enlargeIn == 0) {
+          context_enlargeIn = Math.pow(2, context_numBits);
+          context_numBits++;
+        }
+        // Add wc to the dictionary.
+        context_dictionary[context_wc] = context_dictSize++;
+        context_w = String(context_c);
+      }
+    }
+
+    // Output the code for w.
+    if (context_w !== "") {
+      if (Object.prototype.hasOwnProperty.call(context_dictionaryToCreate,context_w)) {
+        if (context_w.charCodeAt(0)<256) {
+          for (i=0 ; i<context_numBits ; i++) {
+            context_data_val = (context_data_val << 1);
+            if (context_data_position == bitsPerChar-1) {
+              context_data_position = 0;
+              context_data.push(getCharFromInt(context_data_val));
+              context_data_val = 0;
+            } else {
+              context_data_position++;
+            }
+          }
+          value = context_w.charCodeAt(0);
+          for (i=0 ; i<8 ; i++) {
+            context_data_val = (context_data_val << 1) | (value&1);
+            if (context_data_position == bitsPerChar-1) {
+              context_data_position = 0;
+              context_data.push(getCharFromInt(context_data_val));
+              context_data_val = 0;
+            } else {
+              context_data_position++;
+            }
+            value = value >> 1;
+          }
+        } else {
+          value = 1;
+          for (i=0 ; i<context_numBits ; i++) {
+            context_data_val = (context_data_val << 1) | value;
+            if (context_data_position == bitsPerChar-1) {
+              context_data_position = 0;
+              context_data.push(getCharFromInt(context_data_val));
+              context_data_val = 0;
+            } else {
+              context_data_position++;
+            }
+            value = 0;
+          }
+          value = context_w.charCodeAt(0);
+          for (i=0 ; i<16 ; i++) {
+            context_data_val = (context_data_val << 1) | (value&1);
+            if (context_data_position == bitsPerChar-1) {
+              context_data_position = 0;
+              context_data.push(getCharFromInt(context_data_val));
+              context_data_val = 0;
+            } else {
+              context_data_position++;
+            }
+            value = value >> 1;
+          }
+        }
+        context_enlargeIn--;
+        if (context_enlargeIn == 0) {
+          context_enlargeIn = Math.pow(2, context_numBits);
+          context_numBits++;
+        }
+        delete context_dictionaryToCreate[context_w];
+      } else {
+        value = context_dictionary[context_w];
+        for (i=0 ; i<context_numBits ; i++) {
+          context_data_val = (context_data_val << 1) | (value&1);
+          if (context_data_position == bitsPerChar-1) {
+            context_data_position = 0;
+            context_data.push(getCharFromInt(context_data_val));
+            context_data_val = 0;
+          } else {
+            context_data_position++;
+          }
+          value = value >> 1;
+        }
+
+
+      }
+      context_enlargeIn--;
+      if (context_enlargeIn == 0) {
+        context_enlargeIn = Math.pow(2, context_numBits);
+        context_numBits++;
+      }
+    }
+
+    // Mark the end of the stream
+    value = 2;
+    for (i=0 ; i<context_numBits ; i++) {
+      context_data_val = (context_data_val << 1) | (value&1);
+      if (context_data_position == bitsPerChar-1) {
+        context_data_position = 0;
+        context_data.push(getCharFromInt(context_data_val));
+        context_data_val = 0;
+      } else {
+        context_data_position++;
+      }
+      value = value >> 1;
+    }
+
+    // Flush the last char
+    while (true) {
+      context_data_val = (context_data_val << 1);
+      if (context_data_position == bitsPerChar-1) {
+        context_data.push(getCharFromInt(context_data_val));
+        break;
+      }
+      else context_data_position++;
+    }
+    return context_data.join('');
+  },
+
+  decompress: function (compressed) {
+    if (compressed == null) return "";
+    if (compressed == "") return null;
+    return LZString._decompress(compressed.length, 32768, function(index) { return compressed.charCodeAt(index); });
+  },
+
+  _decompress: function (length, resetValue, getNextValue) {
+    var dictionary = [],
+        enlargeIn = 4,
+        dictSize = 4,
+        numBits = 3,
+        entry = "",
+        result = [],
+        i,
+        w,
+        bits, resb, maxpower, power,
+        c,
+        data = {val:getNextValue(0), position:resetValue, index:1};
+
+    for (i = 0; i < 3; i += 1) {
+      dictionary[i] = i;
+    }
+
+    bits = 0;
+    maxpower = Math.pow(2,2);
+    power=1;
+    while (power!=maxpower) {
+      resb = data.val & data.position;
+      data.position >>= 1;
+      if (data.position == 0) {
+        data.position = resetValue;
+        data.val = getNextValue(data.index++);
+      }
+      bits |= (resb>0 ? 1 : 0) * power;
+      power <<= 1;
+    }
+
+    switch (bits) {
+      case 0:
+          bits = 0;
+          maxpower = Math.pow(2,8);
+          power=1;
+          while (power!=maxpower) {
+            resb = data.val & data.position;
+            data.position >>= 1;
+            if (data.position == 0) {
+              data.position = resetValue;
+              data.val = getNextValue(data.index++);
+            }
+            bits |= (resb>0 ? 1 : 0) * power;
+            power <<= 1;
+          }
+        c = f(bits);
+        break;
+      case 1:
+          bits = 0;
+          maxpower = Math.pow(2,16);
+          power=1;
+          while (power!=maxpower) {
+            resb = data.val & data.position;
+            data.position >>= 1;
+            if (data.position == 0) {
+              data.position = resetValue;
+              data.val = getNextValue(data.index++);
+            }
+            bits |= (resb>0 ? 1 : 0) * power;
+            power <<= 1;
+          }
+        c = f(bits);
+        break;
+      case 2:
+        return "";
+    }
+    dictionary[3] = c;
+    w = c;
+    result.push(c);
+    while (true) {
+      if (data.index > length) {
+        return "";
+      }
+
+      bits = 0;
+      maxpower = Math.pow(2,numBits);
+      power=1;
+      while (power!=maxpower) {
+        resb = data.val & data.position;
+        data.position >>= 1;
+        if (data.position == 0) {
+          data.position = resetValue;
+          data.val = getNextValue(data.index++);
+        }
+        bits |= (resb>0 ? 1 : 0) * power;
+        power <<= 1;
+      }
+
+      switch (c = bits) {
+        case 0:
+          bits = 0;
+          maxpower = Math.pow(2,8);
+          power=1;
+          while (power!=maxpower) {
+            resb = data.val & data.position;
+            data.position >>= 1;
+            if (data.position == 0) {
+              data.position = resetValue;
+              data.val = getNextValue(data.index++);
+            }
+            bits |= (resb>0 ? 1 : 0) * power;
+            power <<= 1;
+          }
+
+          dictionary[dictSize++] = f(bits);
+          c = dictSize-1;
+          enlargeIn--;
+          break;
+        case 1:
+          bits = 0;
+          maxpower = Math.pow(2,16);
+          power=1;
+          while (power!=maxpower) {
+            resb = data.val & data.position;
+            data.position >>= 1;
+            if (data.position == 0) {
+              data.position = resetValue;
+              data.val = getNextValue(data.index++);
+            }
+            bits |= (resb>0 ? 1 : 0) * power;
+            power <<= 1;
+          }
+          dictionary[dictSize++] = f(bits);
+          c = dictSize-1;
+          enlargeIn--;
+          break;
+        case 2:
+          return result.join('');
+      }
+
+      if (enlargeIn == 0) {
+        enlargeIn = Math.pow(2, numBits);
+        numBits++;
+      }
+
+      if (dictionary[c]) {
+        entry = dictionary[c];
+      } else {
+        if (c === dictSize) {
+          entry = w + w.charAt(0);
+        } else {
+          return null;
+        }
+      }
+      result.push(entry);
+
+      // Add w+entry[0] to the dictionary.
+      dictionary[dictSize++] = w + entry.charAt(0);
+      enlargeIn--;
+
+      w = entry;
+
+      if (enlargeIn == 0) {
+        enlargeIn = Math.pow(2, numBits);
+        numBits++;
+      }
+
+    }
+  }
+};
+  return LZString;
+})();
+
+if( module != null ) {
+  module.exports = LZString;
+} else if( typeof angular !== 'undefined' && angular != null ) {
+  angular.module('LZString', [])
+  .factory('LZString', function () {
+    return LZString;
+  });
+}
+});
+
+// We try to load node dependencies
+var chalk = null;
+var readFileSync = null;
+var codeFrameColumns = null;
+
+try {
+  var nodeRequire = module && module.require;
+  readFileSync = nodeRequire.call(module, 'fs').readFileSync;
+  codeFrameColumns = nodeRequire.call(module, '@babel/code-frame').codeFrameColumns;
+  chalk = nodeRequire.call(module, 'chalk');
+} catch (_unused) {// We're in a browser environment
+} // frame has the form "at myMethod (location/to/my/file.js:10:2)"
+
+
+function getCodeFrame(frame) {
+  var locationStart = frame.indexOf('(') + 1;
+  var locationEnd = frame.indexOf(')');
+  var frameLocation = frame.slice(locationStart, locationEnd);
+  var frameLocationElements = frameLocation.split(':');
+  var _ref = [frameLocationElements[0], parseInt(frameLocationElements[1], 10), parseInt(frameLocationElements[2], 10)],
+      filename = _ref[0],
+      line = _ref[1],
+      column = _ref[2];
+  var rawFileContents = '';
+
+  try {
+    rawFileContents = readFileSync(filename, 'utf-8');
+  } catch (_unused2) {
+    return '';
+  }
+
+  var codeFrame = codeFrameColumns(rawFileContents, {
+    start: {
+      line: line,
+      column: column
+    }
+  }, {
+    highlightCode: true,
+    linesBelow: 0
+  });
+  return chalk.dim(frameLocation) + "\n" + codeFrame + "\n";
+}
+
+function getUserCodeFrame() {
+  // If we couldn't load dependencies, we can't generate the user trace
+
+  /* istanbul ignore next */
+  if (!readFileSync || !codeFrameColumns) {
+    return '';
+  }
+
+  var err = new Error();
+  var firstClientCodeFrame = err.stack.split('\n').slice(1) // Remove first line which has the form "Error: TypeError"
+  .find(function (frame) {
+    return !frame.includes('node_modules/');
+  }); // Ignore frames from 3rd party libraries
+
+  return getCodeFrame(firstClientCodeFrame);
+}
+
+var globalObj = typeof window === 'undefined' ? global$1 : window; // Constant node.nodeType for text nodes, see:
+// https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#Node_type_constants
+
+var TEXT_NODE = 3; // Currently this fn only supports jest timers, but it could support other test runners in the future.
+
+function runWithRealTimers(callback) {
+  return hasJestTimers() ? runWithJestRealTimers(callback).callbackReturnValue : // istanbul ignore next
+  callback();
+}
+
+function hasJestTimers() {
+  return typeof jest !== 'undefined' && jest !== null && typeof jest.useRealTimers === 'function';
+}
+
+function runWithJestRealTimers(callback) {
+  var timerAPI = {
+    clearInterval: clearInterval,
+    clearTimeout: clearTimeout,
+    setInterval: setInterval,
+    setTimeout: setTimeout
+  }; // For more on why we have the check here,
+  // checkout https://github.com/testing-library/dom-testing-library/issues/914
+
+  if (typeof setImmediate === 'function') {
+    timerAPI.setImmediate = setImmediate;
+  }
+
+  if (typeof clearImmediate === 'function') {
+    timerAPI.clearImmediate = clearImmediate;
+  }
+
+  jest.useRealTimers();
+  var callbackReturnValue = callback();
+  var usedFakeTimers = Object.entries(timerAPI).some(function (_ref) {
+    var name = _ref[0],
+        func = _ref[1];
+    return func !== globalObj[name];
+  });
+
+  if (usedFakeTimers) {
+    var _timerAPI$setTimeout;
+
+    jest.useFakeTimers((_timerAPI$setTimeout = timerAPI.setTimeout) != null && _timerAPI$setTimeout.clock ? 'modern' : 'legacy');
+  }
+
+  return {
+    callbackReturnValue: callbackReturnValue,
+    usedFakeTimers: usedFakeTimers
+  };
+}
+
+function jestFakeTimersAreEnabled() {
+  return hasJestTimers() ? runWithJestRealTimers(function () {}).usedFakeTimers : // istanbul ignore next
+  false;
+} // we only run our tests in node, and setImmediate is supported in node.
+// istanbul ignore next
+
+
+function setImmediatePolyfill(fn) {
+  return globalObj.setTimeout(fn, 0);
+}
+
+function getTimeFunctions() {
+  // istanbul ignore next
+  return {
+    clearTimeoutFn: globalObj.clearTimeout,
+    setImmediateFn: globalObj.setImmediate || setImmediatePolyfill,
+    setTimeoutFn: globalObj.setTimeout
+  };
+}
+
+var _runWithRealTimers = runWithRealTimers(getTimeFunctions),
+    clearTimeoutFn = _runWithRealTimers.clearTimeoutFn,
+    setImmediateFn = _runWithRealTimers.setImmediateFn,
+    setTimeoutFn = _runWithRealTimers.setTimeoutFn;
+
+function getDocument() {
+  /* istanbul ignore if */
+  if (typeof window === 'undefined') {
+    throw new Error('Could not find default container');
+  }
+
+  return window.document;
+}
+
+function getWindowFromNode(node) {
+  if (node.defaultView) {
+    // node is document
+    return node.defaultView;
+  } else if (node.ownerDocument && node.ownerDocument.defaultView) {
+    // node is a DOM node
+    return node.ownerDocument.defaultView;
+  } else if (node.window) {
+    // node is window
+    return node.window;
+  } else if (node.then instanceof Function) {
+    throw new Error("It looks like you passed a Promise object instead of a DOM node. Did you do something like `fireEvent.click(screen.findBy...` when you meant to use a `getBy` query `fireEvent.click(screen.getBy...`, or await the findBy query `fireEvent.click(await screen.findBy...`?");
+  } else if (Array.isArray(node)) {
+    throw new Error("It looks like you passed an Array instead of a DOM node. Did you do something like `fireEvent.click(screen.getAllBy...` when you meant to use a `getBy` query `fireEvent.click(screen.getBy...`?");
+  } else if (typeof node.debug === 'function' && typeof node.logTestingPlaygroundURL === 'function') {
+    throw new Error("It looks like you passed a `screen` object. Did you do something like `fireEvent.click(screen, ...` when you meant to use a query, e.g. `fireEvent.click(screen.getBy..., `?");
+  } else {
+    // The user passed something unusual to a calling function
+    throw new Error("Unable to find the \"window\" object for the given node. Please file an issue with the code that's causing you to see this error: https://github.com/testing-library/dom-testing-library/issues/new");
+  }
+}
+
+function checkContainerType(container) {
+  if (!container || !(typeof container.querySelector === 'function') || !(typeof container.querySelectorAll === 'function')) {
+    throw new TypeError("Expected container to be an Element, a Document or a DocumentFragment but got " + getTypeName(container) + ".");
+  }
+
+  function getTypeName(object) {
+    if (typeof object === 'object') {
+      return object === null ? 'null' : object.constructor.name;
+    }
+
+    return typeof object;
+  }
+}
+
+function inCypress(dom) {
+  var window = dom.ownerDocument && dom.ownerDocument.defaultView || undefined;
+  return typeof global$1 !== 'undefined' && global$1.Cypress || typeof window !== 'undefined' && window.Cypress;
+}
+
+var inNode = function inNode() {
+  return typeof process$1 !== 'undefined' && process$1.versions !== undefined && process$1.versions.node !== undefined;
+};
+
+var getMaxLength = function getMaxLength(dom) {
+  return inCypress(dom) ? 0 : typeof process$1 !== 'undefined' && process$1.env.DEBUG_PRINT_LIMIT || 7000;
+};
+
+var _prettyFormat$plugins = build$1.plugins,
+    DOMElement = _prettyFormat$plugins.DOMElement,
+    DOMCollection = _prettyFormat$plugins.DOMCollection;
+
+function prettyDOM(dom, maxLength, options) {
+  if (!dom) {
+    dom = getDocument().body;
+  }
+
+  if (typeof maxLength !== 'number') {
+    maxLength = getMaxLength(dom);
+  }
+
+  if (maxLength === 0) {
+    return '';
+  }
+
+  if (dom.documentElement) {
+    dom = dom.documentElement;
+  }
+
+  var domTypeName = typeof dom;
+
+  if (domTypeName === 'object') {
+    domTypeName = dom.constructor.name;
+  } else {
+    // To don't fall with `in` operator
+    dom = {};
+  }
+
+  if (!('outerHTML' in dom)) {
+    throw new TypeError("Expected an element or document but got " + domTypeName);
+  }
+
+  var debugContent = build$1(dom, _extends({
+    plugins: [DOMElement, DOMCollection],
+    printFunctionName: false,
+    highlight: inNode()
+  }, options));
+  return maxLength !== undefined && dom.outerHTML.length > maxLength ? debugContent.slice(0, maxLength) + "..." : debugContent;
+}
+
+var logDOM = function logDOM() {
+  var userCodeFrame = getUserCodeFrame();
+
+  if (userCodeFrame) {
+    console.log(prettyDOM.apply(void 0, arguments) + "\n\n" + userCodeFrame);
+  } else {
+    console.log(prettyDOM.apply(void 0, arguments));
+  }
+};
+
+// It would be cleaner for this to live inside './queries', but
+// other parts of the code assume that all exports from
+// './queries' are query functions.
+var config = {
+  testIdAttribute: 'data-testid',
+  asyncUtilTimeout: 1000,
+  // this is to support React's async `act` function.
+  // forcing react-testing-library to wrap all async functions would've been
+  // a total nightmare (consider wrapping every findBy* query and then also
+  // updating `within` so those would be wrapped too. Total nightmare).
+  // so we have this config option that's really only intended for
+  // react-testing-library to use. For that reason, this feature will remain
+  // undocumented.
+  asyncWrapper: function asyncWrapper(cb) {
+    return cb();
+  },
+  eventWrapper: function eventWrapper(cb) {
+    return cb();
+  },
+  // default value for the `hidden` option in `ByRole` queries
+  defaultHidden: false,
+  // showOriginalStackTrace flag to show the full error stack traces for async errors
+  showOriginalStackTrace: false,
+  // throw errors w/ suggestions for better queries. Opt in so off by default.
+  throwSuggestions: false,
+  // called when getBy* queries fail. (message, container) => Error
+  getElementError: function getElementError(message, container) {
+    var error = new Error([message, prettyDOM(container)].filter(Boolean).join('\n\n'));
+    error.name = 'TestingLibraryElementError';
+    return error;
+  },
+  _disableExpensiveErrorDiagnostics: false,
+  computedStyleSupportsPseudoElements: false
+};
+var DEFAULT_IGNORE_TAGS = 'script, style';
+function runWithExpensiveErrorDiagnosticsDisabled(callback) {
+  try {
+    config._disableExpensiveErrorDiagnostics = true;
+    return callback();
+  } finally {
+    config._disableExpensiveErrorDiagnostics = false;
+  }
+}
+function configure(newConfig) {
+  if (typeof newConfig === 'function') {
+    // Pass the existing config out to the provided function
+    // and accept a delta in return
+    newConfig = newConfig(config);
+  } // Merge the incoming config delta
+
+
+  config = _extends({}, config, newConfig);
+}
+function getConfig() {
+  return config;
+}
+
+var labelledNodeNames = ['button', 'meter', 'output', 'progress', 'select', 'textarea', 'input'];
+
+function getTextContent(node) {
+  if (labelledNodeNames.includes(node.nodeName.toLowerCase())) {
+    return '';
+  }
+
+  if (node.nodeType === TEXT_NODE) return node.textContent;
+  return Array.from(node.childNodes).map(function (childNode) {
+    return getTextContent(childNode);
+  }).join('');
+}
+
+function getLabelContent(element) {
+  var textContent;
+
+  if (element.tagName.toLowerCase() === 'label') {
+    textContent = getTextContent(element);
+  } else {
+    textContent = element.value || element.textContent;
+  }
+
+  return textContent;
+} // Based on https://github.com/eps1lon/dom-accessibility-api/pull/352
+
+
+function getRealLabels(element) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- types are not aware of older browsers that don't implement `labels`
+  if (element.labels !== undefined) {
+    var _labels;
+
+    return (_labels = element.labels) != null ? _labels : [];
+  }
+
+  if (!isLabelable(element)) return [];
+  var labels = element.ownerDocument.querySelectorAll('label');
+  return Array.from(labels).filter(function (label) {
+    return label.control === element;
+  });
+}
+
+function isLabelable(element) {
+  return /BUTTON|METER|OUTPUT|PROGRESS|SELECT|TEXTAREA/.test(element.tagName) || element.tagName === 'INPUT' && element.getAttribute('type') !== 'hidden';
+}
+
+function getLabels(container, element, _temp) {
+  var _ref = _temp === void 0 ? {} : _temp,
+      _ref$selector = _ref.selector,
+      selector = _ref$selector === void 0 ? '*' : _ref$selector;
+
+  var ariaLabelledBy = element.getAttribute('aria-labelledby');
+  var labelsId = ariaLabelledBy ? ariaLabelledBy.split(' ') : [];
+  return labelsId.length ? labelsId.map(function (labelId) {
+    var labellingElement = container.querySelector("[id=\"" + labelId + "\"]");
+    return labellingElement ? {
+      content: getLabelContent(labellingElement),
+      formControl: null
+    } : {
+      content: '',
+      formControl: null
+    };
+  }) : Array.from(getRealLabels(element)).map(function (label) {
+    var textToMatch = getLabelContent(label);
+    var formControlSelector = 'button, input, meter, output, progress, select, textarea';
+    var labelledFormControl = Array.from(label.querySelectorAll(formControlSelector)).filter(function (formControlElement) {
+      return formControlElement.matches(selector);
+    })[0];
+    return {
+      content: textToMatch,
+      formControl: labelledFormControl
+    };
+  });
+}
+
+function assertNotNullOrUndefined(matcher) {
+  if (matcher === null || matcher === undefined) {
+    throw new Error( // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- implicitly converting `T` to `string`
+    "It looks like " + matcher + " was passed instead of a matcher. Did you do something like getByText(" + matcher + ")?");
+  }
+}
+
+function fuzzyMatches(textToMatch, node, matcher, normalizer) {
+  if (typeof textToMatch !== 'string') {
+    return false;
+  }
+
+  assertNotNullOrUndefined(matcher);
+  var normalizedText = normalizer(textToMatch);
+
+  if (typeof matcher === 'string' || typeof matcher === 'number') {
+    return normalizedText.toLowerCase().includes(matcher.toString().toLowerCase());
+  } else if (typeof matcher === 'function') {
+    return matcher(normalizedText, node);
+  } else {
+    return matcher.test(normalizedText);
+  }
+}
+
+function matches(textToMatch, node, matcher, normalizer) {
+  if (typeof textToMatch !== 'string') {
+    return false;
+  }
+
+  assertNotNullOrUndefined(matcher);
+  var normalizedText = normalizer(textToMatch);
+
+  if (matcher instanceof Function) {
+    return matcher(normalizedText, node);
+  } else if (matcher instanceof RegExp) {
+    return matcher.test(normalizedText);
+  } else {
+    return normalizedText === String(matcher);
+  }
+}
+
+function getDefaultNormalizer(_temp) {
+  var _ref = _temp === void 0 ? {} : _temp,
+      _ref$trim = _ref.trim,
+      trim = _ref$trim === void 0 ? true : _ref$trim,
+      _ref$collapseWhitespa = _ref.collapseWhitespace,
+      collapseWhitespace = _ref$collapseWhitespa === void 0 ? true : _ref$collapseWhitespa;
+
+  return function (text) {
+    var normalizedText = text;
+    normalizedText = trim ? normalizedText.trim() : normalizedText;
+    normalizedText = collapseWhitespace ? normalizedText.replace(/\s+/g, ' ') : normalizedText;
+    return normalizedText;
+  };
+}
+/**
+ * Constructs a normalizer to pass to functions in matches.js
+ * @param {boolean|undefined} trim The user-specified value for `trim`, without
+ * any defaulting having been applied
+ * @param {boolean|undefined} collapseWhitespace The user-specified value for
+ * `collapseWhitespace`, without any defaulting having been applied
+ * @param {Function|undefined} normalizer The user-specified normalizer
+ * @returns {Function} A normalizer
+ */
+
+
+function makeNormalizer(_ref2) {
+  var trim = _ref2.trim,
+      collapseWhitespace = _ref2.collapseWhitespace,
+      normalizer = _ref2.normalizer;
+
+  if (normalizer) {
+    // User has specified a custom normalizer
+    if (typeof trim !== 'undefined' || typeof collapseWhitespace !== 'undefined') {
+      // They've also specified a value for trim or collapseWhitespace
+      throw new Error('trim and collapseWhitespace are not supported with a normalizer. ' + 'If you want to use the default trim and collapseWhitespace logic in your normalizer, ' + 'use "getDefaultNormalizer({trim, collapseWhitespace})" and compose that into your normalizer');
+    }
+
+    return normalizer;
+  } else {
+    // No custom normalizer specified. Just use default.
+    return getDefaultNormalizer({
+      trim: trim,
+      collapseWhitespace: collapseWhitespace
+    });
+  }
+}
+
+function getNodeText(node) {
+  if (node.matches('input[type=submit], input[type=button]')) {
+    return node.value;
+  }
+
+  return Array.from(node.childNodes).filter(function (child) {
+    return child.nodeType === TEXT_NODE && Boolean(child.textContent);
+  }).map(function (c) {
+    return c.textContent;
+  }).join('');
+}
+
+function _createForOfIteratorHelperLoose(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (it) return (it = it.call(o)).next.bind(it); if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; return function () { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+var elementRoleList = buildElementRoleList(lib.elementRoles);
+/**
+ * @param {Element} element -
+ * @returns {boolean} - `true` if `element` and its subtree are inaccessible
+ */
+
+function isSubtreeInaccessible(element) {
+  if (element.hidden === true) {
+    return true;
+  }
+
+  if (element.getAttribute('aria-hidden') === 'true') {
+    return true;
+  }
+
+  var window = element.ownerDocument.defaultView;
+
+  if (window.getComputedStyle(element).display === 'none') {
+    return true;
+  }
+
+  return false;
+}
+/**
+ * Partial implementation https://www.w3.org/TR/wai-aria-1.2/#tree_exclusion
+ * which should only be used for elements with a non-presentational role i.e.
+ * `role="none"` and `role="presentation"` will not be excluded.
+ *
+ * Implements aria-hidden semantics (i.e. parent overrides child)
+ * Ignores "Child Presentational: True" characteristics
+ *
+ * @param {Element} element -
+ * @param {object} [options] -
+ * @param {function (element: Element): boolean} options.isSubtreeInaccessible -
+ * can be used to return cached results from previous isSubtreeInaccessible calls
+ * @returns {boolean} true if excluded, otherwise false
+ */
+
+
+function isInaccessible(element, options) {
+  if (options === void 0) {
+    options = {};
+  }
+
+  var _options = options,
+      _options$isSubtreeIna = _options.isSubtreeInaccessible,
+      isSubtreeInaccessibleImpl = _options$isSubtreeIna === void 0 ? isSubtreeInaccessible : _options$isSubtreeIna;
+  var window = element.ownerDocument.defaultView; // since visibility is inherited we can exit early
+
+  if (window.getComputedStyle(element).visibility === 'hidden') {
+    return true;
+  }
+
+  var currentElement = element;
+
+  while (currentElement) {
+    if (isSubtreeInaccessibleImpl(currentElement)) {
+      return true;
+    }
+
+    currentElement = currentElement.parentElement;
+  }
+
+  return false;
+}
+
+function getImplicitAriaRoles(currentNode) {
+  // eslint bug here:
+  // eslint-disable-next-line no-unused-vars
+  for (var _iterator = _createForOfIteratorHelperLoose(elementRoleList), _step; !(_step = _iterator()).done;) {
+    var _step$value = _step.value,
+        match = _step$value.match,
+        roles = _step$value.roles;
+
+    if (match(currentNode)) {
+      return [].concat(roles);
+    }
+  }
+
+  return [];
+}
+
+function buildElementRoleList(elementRolesMap) {
+  function makeElementSelector(_ref) {
+    var name = _ref.name,
+        attributes = _ref.attributes;
+    return "" + name + attributes.map(function (_ref2) {
+      var attributeName = _ref2.name,
+          value = _ref2.value,
+          _ref2$constraints = _ref2.constraints,
+          constraints = _ref2$constraints === void 0 ? [] : _ref2$constraints;
+      var shouldNotExist = constraints.indexOf('undefined') !== -1;
+
+      if (shouldNotExist) {
+        return ":not([" + attributeName + "])";
+      } else if (value) {
+        return "[" + attributeName + "=\"" + value + "\"]";
+      } else {
+        return "[" + attributeName + "]";
+      }
+    }).join('');
+  }
+
+  function getSelectorSpecificity(_ref3) {
+    var _ref3$attributes = _ref3.attributes,
+        attributes = _ref3$attributes === void 0 ? [] : _ref3$attributes;
+    return attributes.length;
+  }
+
+  function bySelectorSpecificity(_ref4, _ref5) {
+    var leftSpecificity = _ref4.specificity;
+    var rightSpecificity = _ref5.specificity;
+    return rightSpecificity - leftSpecificity;
+  }
+
+  function match(element) {
+    return function (node) {
+      var _element$attributes = element.attributes,
+          attributes = _element$attributes === void 0 ? [] : _element$attributes; // https://github.com/testing-library/dom-testing-library/issues/814
+
+      var typeTextIndex = attributes.findIndex(function (attribute) {
+        return attribute.value && attribute.name === 'type' && attribute.value === 'text';
+      });
+
+      if (typeTextIndex >= 0) {
+        // not using splice to not mutate the attributes array
+        attributes = [].concat(attributes.slice(0, typeTextIndex), attributes.slice(typeTextIndex + 1));
+
+        if (node.type !== 'text') {
+          return false;
+        }
+      }
+
+      return node.matches(makeElementSelector(_extends({}, element, {
+        attributes: attributes
+      })));
+    };
+  }
+
+  var result = []; // eslint bug here:
+  // eslint-disable-next-line no-unused-vars
+
+  for (var _iterator2 = _createForOfIteratorHelperLoose(elementRolesMap.entries()), _step2; !(_step2 = _iterator2()).done;) {
+    var _step2$value = _step2.value,
+        element = _step2$value[0],
+        roles = _step2$value[1];
+    result = [].concat(result, [{
+      match: match(element),
+      roles: Array.from(roles),
+      specificity: getSelectorSpecificity(element)
+    }]);
+  }
+
+  return result.sort(bySelectorSpecificity);
+}
+
+function getRoles(container, _temp) {
+  var _ref6 = _temp === void 0 ? {} : _temp,
+      _ref6$hidden = _ref6.hidden,
+      hidden = _ref6$hidden === void 0 ? false : _ref6$hidden;
+
+  function flattenDOM(node) {
+    return [node].concat(Array.from(node.children).reduce(function (acc, child) {
+      return [].concat(acc, flattenDOM(child));
+    }, []));
+  }
+
+  return flattenDOM(container).filter(function (element) {
+    return hidden === false ? isInaccessible(element) === false : true;
+  }).reduce(function (acc, node) {
+    var roles = []; // TODO: This violates html-aria which does not allow any role on every element
+
+    if (node.hasAttribute('role')) {
+      roles = node.getAttribute('role').split(' ').slice(0, 1);
+    } else {
+      roles = getImplicitAriaRoles(node);
+    }
+
+    return roles.reduce(function (rolesAcc, role) {
+      var _extends2, _extends3;
+
+      return Array.isArray(rolesAcc[role]) ? _extends({}, rolesAcc, (_extends2 = {}, _extends2[role] = [].concat(rolesAcc[role], [node]), _extends2)) : _extends({}, rolesAcc, (_extends3 = {}, _extends3[role] = [node], _extends3));
+    }, acc);
+  }, {});
+}
+
+function prettyRoles(dom, _ref7) {
+  var hidden = _ref7.hidden;
+  var roles = getRoles(dom, {
+    hidden: hidden
+  }); // We prefer to skip generic role, we don't recommend it
+
+  return Object.entries(roles).filter(function (_ref8) {
+    var role = _ref8[0];
+    return role !== 'generic';
+  }).map(function (_ref9) {
+    var role = _ref9[0],
+        elements = _ref9[1];
+    var delimiterBar = '-'.repeat(50);
+    var elementsString = elements.map(function (el) {
+      var nameString = "Name \"" + computeAccessibleName(el, {
+        computedStyleSupportsPseudoElements: getConfig().computedStyleSupportsPseudoElements
+      }) + "\":\n";
+      var domString = prettyDOM(el.cloneNode(false));
+      return "" + nameString + domString;
+    }).join('\n\n');
+    return role + ":\n\n" + elementsString + "\n\n" + delimiterBar;
+  }).join('\n');
+}
+
+var logRoles = function logRoles(dom, _temp2) {
+  var _ref10 = _temp2 === void 0 ? {} : _temp2,
+      _ref10$hidden = _ref10.hidden,
+      hidden = _ref10$hidden === void 0 ? false : _ref10$hidden;
+
+  return console.log(prettyRoles(dom, {
+    hidden: hidden
+  }));
+};
+/**
+ * @param {Element} element -
+ * @returns {boolean | undefined} - false/true if (not)selected, undefined if not selectable
+ */
+
+
+function computeAriaSelected(element) {
+  // implicit value from html-aam mappings: https://www.w3.org/TR/html-aam-1.0/#html-attribute-state-and-property-mappings
+  // https://www.w3.org/TR/html-aam-1.0/#details-id-97
+  if (element.tagName === 'OPTION') {
+    return element.selected;
+  } // explicit value
+
+
+  return checkBooleanAttribute(element, 'aria-selected');
+}
+/**
+ * @param {Element} element -
+ * @returns {boolean | undefined} - false/true if (not)checked, undefined if not checked-able
+ */
+
+
+function computeAriaChecked(element) {
+  // implicit value from html-aam mappings: https://www.w3.org/TR/html-aam-1.0/#html-attribute-state-and-property-mappings
+  // https://www.w3.org/TR/html-aam-1.0/#details-id-56
+  // https://www.w3.org/TR/html-aam-1.0/#details-id-67
+  if ('indeterminate' in element && element.indeterminate) {
+    return undefined;
+  }
+
+  if ('checked' in element) {
+    return element.checked;
+  } // explicit value
+
+
+  return checkBooleanAttribute(element, 'aria-checked');
+}
+/**
+ * @param {Element} element -
+ * @returns {boolean | undefined} - false/true if (not)pressed, undefined if not press-able
+ */
+
+
+function computeAriaPressed(element) {
+  // https://www.w3.org/TR/wai-aria-1.1/#aria-pressed
+  return checkBooleanAttribute(element, 'aria-pressed');
+}
+/**
+ * @param {Element} element -
+ * @returns {boolean | undefined} - false/true if (not)expanded, undefined if not expand-able
+ */
+
+
+function computeAriaExpanded(element) {
+  // https://www.w3.org/TR/wai-aria-1.1/#aria-expanded
+  return checkBooleanAttribute(element, 'aria-expanded');
+}
+
+function checkBooleanAttribute(element, attribute) {
+  var attributeValue = element.getAttribute(attribute);
+
+  if (attributeValue === 'true') {
+    return true;
+  }
+
+  if (attributeValue === 'false') {
+    return false;
+  }
+
+  return undefined;
+}
+/**
+ * @param {Element} element -
+ * @returns {number | undefined} - number if implicit heading or aria-level present, otherwise undefined
+ */
+
+
+function computeHeadingLevel(element) {
+  // https://w3c.github.io/html-aam/#el-h1-h6
+  // https://w3c.github.io/html-aam/#el-h1-h6
+  var implicitHeadingLevels = {
+    H1: 1,
+    H2: 2,
+    H3: 3,
+    H4: 4,
+    H5: 5,
+    H6: 6
+  }; // explicit aria-level value
+  // https://www.w3.org/TR/wai-aria-1.2/#aria-level
+
+  var ariaLevelAttribute = element.getAttribute('aria-level') && Number(element.getAttribute('aria-level'));
+  return ariaLevelAttribute || implicitHeadingLevels[element.tagName];
+}
+
+var normalize = getDefaultNormalizer();
+
+function escapeRegExp(string) {
+  return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
+
+function getRegExpMatcher(string) {
+  return new RegExp(escapeRegExp(string.toLowerCase()), 'i');
+}
+
+function makeSuggestion(queryName, element, content, _ref) {
+  var variant = _ref.variant,
+      name = _ref.name;
+  var warning = '';
+  var queryOptions = {};
+  var queryArgs = [['Role', 'TestId'].includes(queryName) ? content : getRegExpMatcher(content)];
+
+  if (name) {
+    queryOptions.name = getRegExpMatcher(name);
+  }
+
+  if (queryName === 'Role' && isInaccessible(element)) {
+    queryOptions.hidden = true;
+    warning = "Element is inaccessible. This means that the element and all its children are invisible to screen readers.\n    If you are using the aria-hidden prop, make sure this is the right choice for your case.\n    ";
+  }
+
+  if (Object.keys(queryOptions).length > 0) {
+    queryArgs.push(queryOptions);
+  }
+
+  var queryMethod = variant + "By" + queryName;
+  return {
+    queryName: queryName,
+    queryMethod: queryMethod,
+    queryArgs: queryArgs,
+    variant: variant,
+    warning: warning,
+    toString: function toString() {
+      if (warning) {
+        console.warn(warning);
+      }
+
+      var text = queryArgs[0],
+          options = queryArgs[1];
+      text = typeof text === 'string' ? "'" + text + "'" : text;
+      options = options ? ", { " + Object.entries(options).map(function (_ref2) {
+        var k = _ref2[0],
+            v = _ref2[1];
+        return k + ": " + v;
+      }).join(', ') + " }" : '';
+      return queryMethod + "(" + text + options + ")";
+    }
+  };
+}
+
+function canSuggest(currentMethod, requestedMethod, data) {
+  return data && (!requestedMethod || requestedMethod.toLowerCase() === currentMethod.toLowerCase());
+}
+
+function getSuggestedQuery(element, variant, method) {
+  var _element$getAttribute, _getImplicitAriaRoles;
+
+  if (variant === void 0) {
+    variant = 'get';
+  }
+
+  // don't create suggestions for script and style elements
+  if (element.matches(DEFAULT_IGNORE_TAGS)) {
+    return undefined;
+  } //We prefer to suggest something else if the role is generic
+
+
+  var role = (_element$getAttribute = element.getAttribute('role')) != null ? _element$getAttribute : (_getImplicitAriaRoles = getImplicitAriaRoles(element)) == null ? void 0 : _getImplicitAriaRoles[0];
+
+  if (role !== 'generic' && canSuggest('Role', method, role)) {
+    return makeSuggestion('Role', element, role, {
+      variant: variant,
+      name: computeAccessibleName(element, {
+        computedStyleSupportsPseudoElements: getConfig().computedStyleSupportsPseudoElements
+      })
+    });
+  }
+
+  var labelText = getLabels(document, element).map(function (label) {
+    return label.content;
+  }).join(' ');
+
+  if (canSuggest('LabelText', method, labelText)) {
+    return makeSuggestion('LabelText', element, labelText, {
+      variant: variant
+    });
+  }
+
+  var placeholderText = element.getAttribute('placeholder');
+
+  if (canSuggest('PlaceholderText', method, placeholderText)) {
+    return makeSuggestion('PlaceholderText', element, placeholderText, {
+      variant: variant
+    });
+  }
+
+  var textContent = normalize(getNodeText(element));
+
+  if (canSuggest('Text', method, textContent)) {
+    return makeSuggestion('Text', element, textContent, {
+      variant: variant
+    });
+  }
+
+  if (canSuggest('DisplayValue', method, element.value)) {
+    return makeSuggestion('DisplayValue', element, normalize(element.value), {
+      variant: variant
+    });
+  }
+
+  var alt = element.getAttribute('alt');
+
+  if (canSuggest('AltText', method, alt)) {
+    return makeSuggestion('AltText', element, alt, {
+      variant: variant
+    });
+  }
+
+  var title = element.getAttribute('title');
+
+  if (canSuggest('Title', method, title)) {
+    return makeSuggestion('Title', element, title, {
+      variant: variant
+    });
+  }
+
+  var testId = element.getAttribute(getConfig().testIdAttribute);
+
+  if (canSuggest('TestId', method, testId)) {
+    return makeSuggestion('TestId', element, testId, {
+      variant: variant
+    });
+  }
+
+  return undefined;
+}
+
+// closer to their code (because async stack traces are hard to follow).
+
+function copyStackTrace(target, source) {
+  target.stack = source.stack.replace(source.message, target.message);
+}
+
+function waitFor(callback, _ref) {
+  var _ref$container = _ref.container,
+      container = _ref$container === void 0 ? getDocument() : _ref$container,
+      _ref$timeout = _ref.timeout,
+      timeout = _ref$timeout === void 0 ? getConfig().asyncUtilTimeout : _ref$timeout,
+      _ref$showOriginalStac = _ref.showOriginalStackTrace,
+      showOriginalStackTrace = _ref$showOriginalStac === void 0 ? getConfig().showOriginalStackTrace : _ref$showOriginalStac,
+      stackTraceError = _ref.stackTraceError,
+      _ref$interval = _ref.interval,
+      interval = _ref$interval === void 0 ? 50 : _ref$interval,
+      _ref$onTimeout = _ref.onTimeout,
+      onTimeout = _ref$onTimeout === void 0 ? function (error) {
+    error.message = getConfig().getElementError(error.message, container).message;
+    return error;
+  } : _ref$onTimeout,
+      _ref$mutationObserver = _ref.mutationObserverOptions,
+      mutationObserverOptions = _ref$mutationObserver === void 0 ? {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    characterData: true
+  } : _ref$mutationObserver;
+
+  if (typeof callback !== 'function') {
+    throw new TypeError('Received `callback` arg must be a function');
+  }
+
+  return new Promise( /*#__PURE__*/function () {
+    var _ref2 = _asyncToGenerator( /*#__PURE__*/regenerator.mark(function _callee(resolve, reject) {
+      var lastError, intervalId, observer, finished, promiseStatus, overallTimeoutTimer, usingJestFakeTimers, error, _getWindowFromNode, MutationObserver, onDone, checkRealTimersCallback, checkCallback, handleTimeout;
+
+      return regenerator.wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              handleTimeout = function _handleTimeout() {
+                var error;
+
+                if (lastError) {
+                  error = lastError;
+
+                  if (!showOriginalStackTrace && error.name === 'TestingLibraryElementError') {
+                    copyStackTrace(error, stackTraceError);
+                  }
+                } else {
+                  error = new Error('Timed out in waitFor.');
+
+                  if (!showOriginalStackTrace) {
+                    copyStackTrace(error, stackTraceError);
+                  }
+                }
+
+                onDone(onTimeout(error), null);
+              };
+
+              checkCallback = function _checkCallback() {
+                if (promiseStatus === 'pending') return;
+
+                try {
+                  var result = runWithExpensiveErrorDiagnosticsDisabled(callback);
+
+                  if (typeof (result == null ? void 0 : result.then) === 'function') {
+                    promiseStatus = 'pending';
+                    result.then(function (resolvedValue) {
+                      promiseStatus = 'resolved';
+                      onDone(null, resolvedValue);
+                    }, function (rejectedValue) {
+                      promiseStatus = 'rejected';
+                      lastError = rejectedValue;
+                    });
+                  } else {
+                    onDone(null, result);
+                  } // If `callback` throws, wait for the next mutation, interval, or timeout.
+
+                } catch (error) {
+                  // Save the most recent callback error to reject the promise with it in the event of a timeout
+                  lastError = error;
+                }
+              };
+
+              checkRealTimersCallback = function _checkRealTimersCallb() {
+                if (jestFakeTimersAreEnabled()) {
+                  var _error = new Error("Changed from using real timers to fake timers while using waitFor. This is not allowed and will result in very strange behavior. Please ensure you're awaiting all async things your test is doing before changing to fake timers. For more info, please go to https://github.com/testing-library/dom-testing-library/issues/830");
+
+                  if (!showOriginalStackTrace) copyStackTrace(_error, stackTraceError);
+                  return reject(_error);
+                } else {
+                  return checkCallback();
+                }
+              };
+
+              onDone = function _onDone(error, result) {
+                finished = true;
+                clearTimeoutFn(overallTimeoutTimer);
+
+                if (!usingJestFakeTimers) {
+                  clearInterval(intervalId);
+                  observer.disconnect();
+                }
+
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(result);
+                }
+              };
+
+              finished = false;
+              promiseStatus = 'idle';
+              overallTimeoutTimer = setTimeoutFn(handleTimeout, timeout);
+              usingJestFakeTimers = jestFakeTimersAreEnabled();
+
+              if (!usingJestFakeTimers) {
+                _context.next = 24;
+                break;
+              }
+
+              checkCallback(); // this is a dangerous rule to disable because it could lead to an
+              // infinite loop. However, eslint isn't smart enough to know that we're
+              // setting finished inside `onDone` which will be called when we're done
+              // waiting or when we've timed out.
+              // eslint-disable-next-line no-unmodified-loop-condition
+
+            case 10:
+              if (finished) {
+                _context.next = 22;
+                break;
+              }
+
+              if (jestFakeTimersAreEnabled()) {
+                _context.next = 16;
+                break;
+              }
+
+              error = new Error("Changed from using fake timers to real timers while using waitFor. This is not allowed and will result in very strange behavior. Please ensure you're awaiting all async things your test is doing before changing to real timers. For more info, please go to https://github.com/testing-library/dom-testing-library/issues/830");
+              if (!showOriginalStackTrace) copyStackTrace(error, stackTraceError);
+              reject(error);
+              return _context.abrupt("return");
+
+            case 16:
+              // we *could* (maybe should?) use `advanceTimersToNextTimer` but it's
+              // possible that could make this loop go on forever if someone is using
+              // third party code that's setting up recursive timers so rapidly that
+              // the user's timer's don't get a chance to resolve. So we'll advance
+              // by an interval instead. (We have a test for this case).
+              jest.advanceTimersByTime(interval); // It's really important that checkCallback is run *before* we flush
+              // in-flight promises. To be honest, I'm not sure why, and I can't quite
+              // think of a way to reproduce the problem in a test, but I spent
+              // an entire day banging my head against a wall on this.
+
+              checkCallback(); // In this rare case, we *need* to wait for in-flight promises
+              // to resolve before continuing. We don't need to take advantage
+              // of parallelization so we're fine.
+              // https://stackoverflow.com/a/59243586/971592
+              // eslint-disable-next-line no-await-in-loop
+
+              _context.next = 20;
+              return new Promise(function (r) {
+                return setImmediateFn(r);
+              });
+
+            case 20:
+              _context.next = 10;
+              break;
+
+            case 22:
+              _context.next = 37;
+              break;
+
+            case 24:
+              _context.prev = 24;
+              checkContainerType(container);
+              _context.next = 32;
+              break;
+
+            case 28:
+              _context.prev = 28;
+              _context.t0 = _context["catch"](24);
+              reject(_context.t0);
+              return _context.abrupt("return");
+
+            case 32:
+              intervalId = setInterval(checkRealTimersCallback, interval);
+              _getWindowFromNode = getWindowFromNode(container), MutationObserver = _getWindowFromNode.MutationObserver;
+              observer = new MutationObserver(checkRealTimersCallback);
+              observer.observe(container, mutationObserverOptions);
+              checkCallback();
+
+            case 37:
+            case "end":
+              return _context.stop();
+          }
+        }
+      }, _callee, null, [[24, 28]]);
+    }));
+
+    return function (_x, _x2) {
+      return _ref2.apply(this, arguments);
+    };
+  }());
+}
+
+function waitForWrapper(callback, options) {
+  // create the error here so its stack trace is as close to the
+  // calling code as possible
+  var stackTraceError = new Error('STACK_TRACE_MESSAGE');
+  return getConfig().asyncWrapper(function () {
+    return waitFor(callback, _extends({
+      stackTraceError: stackTraceError
+    }, options));
+  });
+}
+
+var hasWarned$2 = false; // deprecated... TODO: remove this method. We renamed this to `waitFor` so the
+// code people write reads more clearly.
+
+function wait$1() {
+  for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+    args[_key] = arguments[_key];
+  }
+
+  // istanbul ignore next
+  var _args$ = args[0],
+      first = _args$ === void 0 ? function () {} : _args$,
+      rest = args.slice(1);
+
+  if (!hasWarned$2) {
+    hasWarned$2 = true;
+    console.warn("`wait` has been deprecated and replaced by `waitFor` instead. In most cases you should be able to find/replace `wait` with `waitFor`. Learn more: https://testing-library.com/docs/dom-testing-library/api-async#waitfor.");
+  }
+
+  return waitForWrapper.apply(void 0, [first].concat(rest));
+}
+/*
+eslint
+  max-lines-per-function: ["error", {"max": 200}],
+*/
+
+function getElementError(message, container) {
+  return getConfig().getElementError(message, container);
+}
+
+function getMultipleElementsFoundError(message, container) {
+  return getElementError(message + "\n\n(If this is intentional, then use the `*AllBy*` variant of the query (like `queryAllByText`, `getAllByText`, or `findAllByText`)).", container);
+}
+
+function queryAllByAttribute(attribute, container, text, _temp) {
+  var _ref = _temp === void 0 ? {} : _temp,
+      _ref$exact = _ref.exact,
+      exact = _ref$exact === void 0 ? true : _ref$exact,
+      collapseWhitespace = _ref.collapseWhitespace,
+      trim = _ref.trim,
+      normalizer = _ref.normalizer;
+
+  var matcher = exact ? matches : fuzzyMatches;
+  var matchNormalizer = makeNormalizer({
+    collapseWhitespace: collapseWhitespace,
+    trim: trim,
+    normalizer: normalizer
+  });
+  return Array.from(container.querySelectorAll("[" + attribute + "]")).filter(function (node) {
+    return matcher(node.getAttribute(attribute), node, text, matchNormalizer);
+  });
+}
+
+function queryByAttribute(attribute, container, text) {
+  for (var _len = arguments.length, args = new Array(_len > 3 ? _len - 3 : 0), _key = 3; _key < _len; _key++) {
+    args[_key - 3] = arguments[_key];
+  }
+
+  var els = queryAllByAttribute.apply(void 0, [attribute, container, text].concat(args));
+
+  if (els.length > 1) {
+    throw getMultipleElementsFoundError("Found multiple elements by [" + attribute + "=" + text + "]", container);
+  }
+
+  return els[0] || null;
+} // this accepts a query function and returns a function which throws an error
+// if more than one elements is returned, otherwise it returns the first
+// element or null
+
+
+function makeSingleQuery(allQuery, getMultipleError) {
+  return function (container) {
+    for (var _len2 = arguments.length, args = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
+      args[_key2 - 1] = arguments[_key2];
+    }
+
+    var els = allQuery.apply(void 0, [container].concat(args));
+
+    if (els.length > 1) {
+      var elementStrings = els.map(function (element) {
+        return getElementError(null, element).message;
+      }).join('\n\n');
+      throw getMultipleElementsFoundError(getMultipleError.apply(void 0, [container].concat(args)) + "\n\nHere are the matching elements:\n\n" + elementStrings, container);
+    }
+
+    return els[0] || null;
+  };
+}
+
+function getSuggestionError(suggestion, container) {
+  return getConfig().getElementError("A better query is available, try this:\n" + suggestion.toString() + "\n", container);
+} // this accepts a query function and returns a function which throws an error
+// if an empty list of elements is returned
+
+
+function makeGetAllQuery(allQuery, getMissingError) {
+  return function (container) {
+    for (var _len3 = arguments.length, args = new Array(_len3 > 1 ? _len3 - 1 : 0), _key3 = 1; _key3 < _len3; _key3++) {
+      args[_key3 - 1] = arguments[_key3];
+    }
+
+    var els = allQuery.apply(void 0, [container].concat(args));
+
+    if (!els.length) {
+      throw getConfig().getElementError(getMissingError.apply(void 0, [container].concat(args)), container);
+    }
+
+    return els;
+  };
+} // this accepts a getter query function and returns a function which calls
+// waitFor and passing a function which invokes the getter.
+
+
+function makeFindQuery(getter) {
+  return function (container, text, options, waitForOptions) {
+    return waitForWrapper(function () {
+      return getter(container, text, options);
+    }, _extends({
+      container: container
+    }, waitForOptions));
+  };
+}
+
+var wrapSingleQueryWithSuggestion = function wrapSingleQueryWithSuggestion(query, queryAllByName, variant) {
+  return function (container) {
+    for (var _len4 = arguments.length, args = new Array(_len4 > 1 ? _len4 - 1 : 0), _key4 = 1; _key4 < _len4; _key4++) {
+      args[_key4 - 1] = arguments[_key4];
+    }
+
+    var element = query.apply(void 0, [container].concat(args));
+
+    var _args$slice = args.slice(-1),
+        _args$slice$ = _args$slice[0];
+
+    _args$slice$ = _args$slice$ === void 0 ? {} : _args$slice$;
+    var _args$slice$$suggest = _args$slice$.suggest,
+        suggest = _args$slice$$suggest === void 0 ? getConfig().throwSuggestions : _args$slice$$suggest;
+
+    if (element && suggest) {
+      var suggestion = getSuggestedQuery(element, variant);
+
+      if (suggestion && !queryAllByName.endsWith(suggestion.queryName)) {
+        throw getSuggestionError(suggestion.toString(), container);
+      }
+    }
+
+    return element;
+  };
+};
+
+var wrapAllByQueryWithSuggestion = function wrapAllByQueryWithSuggestion(query, queryAllByName, variant) {
+  return function (container) {
+    for (var _len5 = arguments.length, args = new Array(_len5 > 1 ? _len5 - 1 : 0), _key5 = 1; _key5 < _len5; _key5++) {
+      args[_key5 - 1] = arguments[_key5];
+    }
+
+    var els = query.apply(void 0, [container].concat(args));
+
+    var _args$slice2 = args.slice(-1),
+        _args$slice2$ = _args$slice2[0];
+
+    _args$slice2$ = _args$slice2$ === void 0 ? {} : _args$slice2$;
+    var _args$slice2$$suggest = _args$slice2$.suggest,
+        suggest = _args$slice2$$suggest === void 0 ? getConfig().throwSuggestions : _args$slice2$$suggest;
+
+    if (els.length && suggest) {
+      // get a unique list of all suggestion messages.  We are only going to make a suggestion if
+      // all the suggestions are the same
+      var uniqueSuggestionMessages = [].concat(new Set(els.map(function (element) {
+        var _getSuggestedQuery;
+
+        return (_getSuggestedQuery = getSuggestedQuery(element, variant)) == null ? void 0 : _getSuggestedQuery.toString();
+      })));
+
+      if ( // only want to suggest if all the els have the same suggestion.
+      uniqueSuggestionMessages.length === 1 && !queryAllByName.endsWith(getSuggestedQuery(els[0], variant).queryName)) {
+        throw getSuggestionError(uniqueSuggestionMessages[0], container);
+      }
+    }
+
+    return els;
+  };
+};
+
+function buildQueries(queryAllBy, getMultipleError, getMissingError) {
+  var queryBy = wrapSingleQueryWithSuggestion(makeSingleQuery(queryAllBy, getMultipleError), queryAllBy.name, 'query');
+  var getAllBy = makeGetAllQuery(queryAllBy, getMissingError);
+  var getBy = makeSingleQuery(getAllBy, getMultipleError);
+  var getByWithSuggestions = wrapSingleQueryWithSuggestion(getBy, queryAllBy.name, 'get');
+  var getAllWithSuggestions = wrapAllByQueryWithSuggestion(getAllBy, queryAllBy.name.replace('query', 'get'), 'getAll');
+  var findAllBy = makeFindQuery(wrapAllByQueryWithSuggestion(getAllBy, queryAllBy.name, 'findAll'));
+  var findBy = makeFindQuery(wrapSingleQueryWithSuggestion(getBy, queryAllBy.name, 'find'));
+  return [queryBy, getAllWithSuggestions, getByWithSuggestions, findAllBy, findBy];
+}
+
+var queryHelpers = /*#__PURE__*/Object.freeze({
+  __proto__: null,
+  getElementError: getElementError,
+  wrapAllByQueryWithSuggestion: wrapAllByQueryWithSuggestion,
+  wrapSingleQueryWithSuggestion: wrapSingleQueryWithSuggestion,
+  getMultipleElementsFoundError: getMultipleElementsFoundError,
+  queryAllByAttribute: queryAllByAttribute,
+  queryByAttribute: queryByAttribute,
+  makeSingleQuery: makeSingleQuery,
+  makeGetAllQuery: makeGetAllQuery,
+  makeFindQuery: makeFindQuery,
+  buildQueries: buildQueries
+});
+
+function queryAllLabels(container) {
+  return Array.from(container.querySelectorAll('label,input')).map(function (node) {
+    return {
+      node: node,
+      textToMatch: getLabelContent(node)
+    };
+  }).filter(function (_ref) {
+    var textToMatch = _ref.textToMatch;
+    return textToMatch !== null;
+  });
+}
+
+var queryAllLabelsByText = function queryAllLabelsByText(container, text, _temp) {
+  var _ref2 = _temp === void 0 ? {} : _temp,
+      _ref2$exact = _ref2.exact,
+      exact = _ref2$exact === void 0 ? true : _ref2$exact,
+      trim = _ref2.trim,
+      collapseWhitespace = _ref2.collapseWhitespace,
+      normalizer = _ref2.normalizer;
+
+  var matcher = exact ? matches : fuzzyMatches;
+  var matchNormalizer = makeNormalizer({
+    collapseWhitespace: collapseWhitespace,
+    trim: trim,
+    normalizer: normalizer
+  });
+  var textToMatchByLabels = queryAllLabels(container);
+  return textToMatchByLabels.filter(function (_ref3) {
+    var node = _ref3.node,
+        textToMatch = _ref3.textToMatch;
+    return matcher(textToMatch, node, text, matchNormalizer);
+  }).map(function (_ref4) {
+    var node = _ref4.node;
+    return node;
+  });
+};
+
+var queryAllByLabelText = function queryAllByLabelText(container, text, _temp2) {
+  var _ref5 = _temp2 === void 0 ? {} : _temp2,
+      _ref5$selector = _ref5.selector,
+      selector = _ref5$selector === void 0 ? '*' : _ref5$selector,
+      _ref5$exact = _ref5.exact,
+      exact = _ref5$exact === void 0 ? true : _ref5$exact,
+      collapseWhitespace = _ref5.collapseWhitespace,
+      trim = _ref5.trim,
+      normalizer = _ref5.normalizer;
+
+  checkContainerType(container);
+  var matcher = exact ? matches : fuzzyMatches;
+  var matchNormalizer = makeNormalizer({
+    collapseWhitespace: collapseWhitespace,
+    trim: trim,
+    normalizer: normalizer
+  });
+  var matchingLabelledElements = Array.from(container.querySelectorAll('*')).filter(function (element) {
+    return getRealLabels(element).length || element.hasAttribute('aria-labelledby');
+  }).reduce(function (labelledElements, labelledElement) {
+    var labelList = getLabels(container, labelledElement, {
+      selector: selector
+    });
+    labelList.filter(function (label) {
+      return Boolean(label.formControl);
+    }).forEach(function (label) {
+      if (matcher(label.content, label.formControl, text, matchNormalizer) && label.formControl) labelledElements.push(label.formControl);
+    });
+    var labelsValue = labelList.filter(function (label) {
+      return Boolean(label.content);
+    }).map(function (label) {
+      return label.content;
+    });
+    if (matcher(labelsValue.join(' '), labelledElement, text, matchNormalizer)) labelledElements.push(labelledElement);
+
+    if (labelsValue.length > 1) {
+      labelsValue.forEach(function (labelValue, index) {
+        if (matcher(labelValue, labelledElement, text, matchNormalizer)) labelledElements.push(labelledElement);
+        var labelsFiltered = [].concat(labelsValue);
+        labelsFiltered.splice(index, 1);
+
+        if (labelsFiltered.length > 1) {
+          if (matcher(labelsFiltered.join(' '), labelledElement, text, matchNormalizer)) labelledElements.push(labelledElement);
+        }
+      });
+    }
+
+    return labelledElements;
+  }, []).concat( // TODO: Remove ignore after `queryAllByAttribute` will be moved to TS
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
+  queryAllByAttribute('aria-label', container, text, {
+    exact: exact,
+    normalizer: matchNormalizer
+  }));
+  return Array.from(new Set(matchingLabelledElements)).filter(function (element) {
+    return element.matches(selector);
+  });
+}; // the getAll* query would normally look like this:
+// const getAllByLabelText = makeGetAllQuery(
+//   queryAllByLabelText,
+//   (c, text) => `Unable to find a label with the text of: ${text}`,
+// )
+// however, we can give a more helpful error message than the generic one,
+// so we're writing this one out by hand.
+
+
+var getAllByLabelText = function getAllByLabelText(container, text) {
+  for (var _len = arguments.length, rest = new Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+    rest[_key - 2] = arguments[_key];
+  }
+
+  var els = queryAllByLabelText.apply(void 0, [container, text].concat(rest));
+
+  if (!els.length) {
+    var labels = queryAllLabelsByText.apply(void 0, [container, text].concat(rest));
+
+    if (labels.length) {
+      var tagNames = labels.map(function (label) {
+        return getTagNameOfElementAssociatedWithLabelViaFor(container, label);
+      }).filter(function (tagName) {
+        return !!tagName;
+      });
+
+      if (tagNames.length) {
+        throw getConfig().getElementError(tagNames.map(function (tagName) {
+          return "Found a label with the text of: " + text + ", however the element associated with this label (<" + tagName + " />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <" + tagName + " />, you can use aria-label or aria-labelledby instead.";
+        }).join('\n\n'), container);
+      } else {
+        throw getConfig().getElementError("Found a label with the text of: " + text + ", however no form control was found associated to that label. Make sure you're using the \"for\" attribute or \"aria-labelledby\" attribute correctly.", container);
+      }
+    } else {
+      throw getConfig().getElementError("Unable to find a label with the text of: " + text, container);
+    }
+  }
+
+  return els;
+};
+
+function getTagNameOfElementAssociatedWithLabelViaFor(container, label) {
+  var htmlFor = label.getAttribute('for');
+
+  if (!htmlFor) {
+    return null;
+  }
+
+  var element = container.querySelector("[id=\"" + htmlFor + "\"]");
+  return element ? element.tagName.toLowerCase() : null;
+} // the reason mentioned above is the same reason we're not using buildQueries
+
+
+var getMultipleError$7 = function getMultipleError(c, text) {
+  return "Found multiple elements with the text of: " + text;
+};
+
+var queryByLabelText = wrapSingleQueryWithSuggestion(makeSingleQuery(queryAllByLabelText, getMultipleError$7), queryAllByLabelText.name, 'query');
+var getByLabelText = makeSingleQuery(getAllByLabelText, getMultipleError$7);
+var findAllByLabelText = makeFindQuery(wrapAllByQueryWithSuggestion(getAllByLabelText, getAllByLabelText.name, 'findAll'));
+var findByLabelText = makeFindQuery(wrapSingleQueryWithSuggestion(getByLabelText, getAllByLabelText.name, 'find'));
+var getAllByLabelTextWithSuggestions = wrapAllByQueryWithSuggestion(getAllByLabelText, getAllByLabelText.name, 'getAll');
+var getByLabelTextWithSuggestions = wrapSingleQueryWithSuggestion(getByLabelText, getAllByLabelText.name, 'get');
+var queryAllByLabelTextWithSuggestions = wrapAllByQueryWithSuggestion(queryAllByLabelText, queryAllByLabelText.name, 'queryAll');
+
+var queryAllByPlaceholderText = function queryAllByPlaceholderText() {
+  for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+    args[_key] = arguments[_key];
+  }
+
+  checkContainerType(args[0]); // TODO: Remove ignore after `queryAllByAttribute` will be moved to TS
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
+
+  return queryAllByAttribute.apply(void 0, ['placeholder'].concat(args));
+};
+
+var getMultipleError$6 = function getMultipleError(c, text) {
+  return "Found multiple elements with the placeholder text of: " + text;
+};
+
+var getMissingError$6 = function getMissingError(c, text) {
+  return "Unable to find an element with the placeholder text of: " + text;
+};
+
+var queryAllByPlaceholderTextWithSuggestions = wrapAllByQueryWithSuggestion(queryAllByPlaceholderText, queryAllByPlaceholderText.name, 'queryAll');
+
+var _buildQueries$6 = buildQueries(queryAllByPlaceholderText, getMultipleError$6, getMissingError$6),
+    queryByPlaceholderText = _buildQueries$6[0],
+    getAllByPlaceholderText = _buildQueries$6[1],
+    getByPlaceholderText = _buildQueries$6[2],
+    findAllByPlaceholderText = _buildQueries$6[3],
+    findByPlaceholderText = _buildQueries$6[4];
+
+var queryAllByText = function queryAllByText(container, text, _temp) {
+  var _ref = _temp === void 0 ? {} : _temp,
+      _ref$selector = _ref.selector,
+      selector = _ref$selector === void 0 ? '*' : _ref$selector,
+      _ref$exact = _ref.exact,
+      exact = _ref$exact === void 0 ? true : _ref$exact,
+      collapseWhitespace = _ref.collapseWhitespace,
+      trim = _ref.trim,
+      _ref$ignore = _ref.ignore,
+      ignore = _ref$ignore === void 0 ? DEFAULT_IGNORE_TAGS : _ref$ignore,
+      normalizer = _ref.normalizer;
+
+  checkContainerType(container);
+  var matcher = exact ? matches : fuzzyMatches;
+  var matchNormalizer = makeNormalizer({
+    collapseWhitespace: collapseWhitespace,
+    trim: trim,
+    normalizer: normalizer
+  });
+  var baseArray = [];
+
+  if (typeof container.matches === 'function' && container.matches(selector)) {
+    baseArray = [container];
+  }
+
+  return [].concat(baseArray, Array.from(container.querySelectorAll(selector))) // TODO: `matches` according lib.dom.d.ts can get only `string` but according our code it can handle also boolean :)
+  .filter(function (node) {
+    return !ignore || !node.matches(ignore);
+  }).filter(function (node) {
+    return matcher(getNodeText(node), node, text, matchNormalizer);
+  });
+};
+
+var getMultipleError$5 = function getMultipleError(c, text) {
+  return "Found multiple elements with the text: " + text;
+};
+
+var getMissingError$5 = function getMissingError(c, text) {
+  return "Unable to find an element with the text: " + text + ". This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.";
+};
+
+var queryAllByTextWithSuggestions = wrapAllByQueryWithSuggestion(queryAllByText, queryAllByText.name, 'queryAll');
+
+var _buildQueries$5 = buildQueries(queryAllByText, getMultipleError$5, getMissingError$5),
+    queryByText = _buildQueries$5[0],
+    getAllByText = _buildQueries$5[1],
+    getByText = _buildQueries$5[2],
+    findAllByText = _buildQueries$5[3],
+    findByText = _buildQueries$5[4];
+
+var queryAllByDisplayValue = function queryAllByDisplayValue(container, value, _temp) {
+  var _ref = _temp === void 0 ? {} : _temp,
+      _ref$exact = _ref.exact,
+      exact = _ref$exact === void 0 ? true : _ref$exact,
+      collapseWhitespace = _ref.collapseWhitespace,
+      trim = _ref.trim,
+      normalizer = _ref.normalizer;
+
+  checkContainerType(container);
+  var matcher = exact ? matches : fuzzyMatches;
+  var matchNormalizer = makeNormalizer({
+    collapseWhitespace: collapseWhitespace,
+    trim: trim,
+    normalizer: normalizer
+  });
+  return Array.from(container.querySelectorAll("input,textarea,select")).filter(function (node) {
+    if (node.tagName === 'SELECT') {
+      var selectedOptions = Array.from(node.options).filter(function (option) {
+        return option.selected;
+      });
+      return selectedOptions.some(function (optionNode) {
+        return matcher(getNodeText(optionNode), optionNode, value, matchNormalizer);
+      });
+    } else {
+      return matcher(node.value, node, value, matchNormalizer);
+    }
+  });
+};
+
+var getMultipleError$4 = function getMultipleError(c, value) {
+  return "Found multiple elements with the display value: " + value + ".";
+};
+
+var getMissingError$4 = function getMissingError(c, value) {
+  return "Unable to find an element with the display value: " + value + ".";
+};
+
+var queryAllByDisplayValueWithSuggestions = wrapAllByQueryWithSuggestion(queryAllByDisplayValue, queryAllByDisplayValue.name, 'queryAll');
+
+var _buildQueries$4 = buildQueries(queryAllByDisplayValue, getMultipleError$4, getMissingError$4),
+    queryByDisplayValue = _buildQueries$4[0],
+    getAllByDisplayValue = _buildQueries$4[1],
+    getByDisplayValue = _buildQueries$4[2],
+    findAllByDisplayValue = _buildQueries$4[3],
+    findByDisplayValue = _buildQueries$4[4];
+
+var queryAllByAltText = function queryAllByAltText(container, alt, _temp) {
+  var _ref = _temp === void 0 ? {} : _temp,
+      _ref$exact = _ref.exact,
+      exact = _ref$exact === void 0 ? true : _ref$exact,
+      collapseWhitespace = _ref.collapseWhitespace,
+      trim = _ref.trim,
+      normalizer = _ref.normalizer;
+
+  checkContainerType(container);
+  var matcher = exact ? matches : fuzzyMatches;
+  var matchNormalizer = makeNormalizer({
+    collapseWhitespace: collapseWhitespace,
+    trim: trim,
+    normalizer: normalizer
+  });
+  return Array.from(container.querySelectorAll('img,input,area')).filter(function (node) {
+    return matcher(node.getAttribute('alt'), node, alt, matchNormalizer);
+  });
+};
+
+var getMultipleError$3 = function getMultipleError(c, alt) {
+  return "Found multiple elements with the alt text: " + alt;
+};
+
+var getMissingError$3 = function getMissingError(c, alt) {
+  return "Unable to find an element with the alt text: " + alt;
+};
+
+var queryAllByAltTextWithSuggestions = wrapAllByQueryWithSuggestion(queryAllByAltText, queryAllByAltText.name, 'queryAll');
+
+var _buildQueries$3 = buildQueries(queryAllByAltText, getMultipleError$3, getMissingError$3),
+    queryByAltText = _buildQueries$3[0],
+    getAllByAltText = _buildQueries$3[1],
+    getByAltText = _buildQueries$3[2],
+    findAllByAltText = _buildQueries$3[3],
+    findByAltText = _buildQueries$3[4];
+
+var isSvgTitle = function isSvgTitle(node) {
+  var _node$parentElement;
+
+  return node.tagName.toLowerCase() === 'title' && ((_node$parentElement = node.parentElement) == null ? void 0 : _node$parentElement.tagName.toLowerCase()) === 'svg';
+};
+
+var queryAllByTitle = function queryAllByTitle(container, text, _temp) {
+  var _ref = _temp === void 0 ? {} : _temp,
+      _ref$exact = _ref.exact,
+      exact = _ref$exact === void 0 ? true : _ref$exact,
+      collapseWhitespace = _ref.collapseWhitespace,
+      trim = _ref.trim,
+      normalizer = _ref.normalizer;
+
+  checkContainerType(container);
+  var matcher = exact ? matches : fuzzyMatches;
+  var matchNormalizer = makeNormalizer({
+    collapseWhitespace: collapseWhitespace,
+    trim: trim,
+    normalizer: normalizer
+  });
+  return Array.from(container.querySelectorAll('[title], svg > title')).filter(function (node) {
+    return matcher(node.getAttribute('title'), node, text, matchNormalizer) || isSvgTitle(node) && matcher(getNodeText(node), node, text, matchNormalizer);
+  });
+};
+
+var getMultipleError$2 = function getMultipleError(c, title) {
+  return "Found multiple elements with the title: " + title + ".";
+};
+
+var getMissingError$2 = function getMissingError(c, title) {
+  return "Unable to find an element with the title: " + title + ".";
+};
+
+var queryAllByTitleWithSuggestions = wrapAllByQueryWithSuggestion(queryAllByTitle, queryAllByTitle.name, 'queryAll');
+
+var _buildQueries$2 = buildQueries(queryAllByTitle, getMultipleError$2, getMissingError$2),
+    queryByTitle = _buildQueries$2[0],
+    getAllByTitle = _buildQueries$2[1],
+    getByTitle = _buildQueries$2[2],
+    findAllByTitle = _buildQueries$2[3],
+    findByTitle = _buildQueries$2[4];
+
+function queryAllByRole(container, role, _temp) {
+  var _ref = _temp === void 0 ? {} : _temp,
+      _ref$exact = _ref.exact,
+      exact = _ref$exact === void 0 ? true : _ref$exact,
+      collapseWhitespace = _ref.collapseWhitespace,
+      _ref$hidden = _ref.hidden,
+      hidden = _ref$hidden === void 0 ? getConfig().defaultHidden : _ref$hidden,
+      name = _ref.name,
+      trim = _ref.trim,
+      normalizer = _ref.normalizer,
+      _ref$queryFallbacks = _ref.queryFallbacks,
+      queryFallbacks = _ref$queryFallbacks === void 0 ? false : _ref$queryFallbacks,
+      selected = _ref.selected,
+      checked = _ref.checked,
+      pressed = _ref.pressed,
+      level = _ref.level,
+      expanded = _ref.expanded;
+
+  checkContainerType(container);
+  var matcher = exact ? matches : fuzzyMatches;
+  var matchNormalizer = makeNormalizer({
+    collapseWhitespace: collapseWhitespace,
+    trim: trim,
+    normalizer: normalizer
+  });
+
+  if (selected !== undefined) {
+    var _allRoles$get;
+
+    // guard against unknown roles
+    if (((_allRoles$get = lib.roles.get(role)) == null ? void 0 : _allRoles$get.props['aria-selected']) === undefined) {
+      throw new Error("\"aria-selected\" is not supported on role \"" + role + "\".");
+    }
+  }
+
+  if (checked !== undefined) {
+    var _allRoles$get2;
+
+    // guard against unknown roles
+    if (((_allRoles$get2 = lib.roles.get(role)) == null ? void 0 : _allRoles$get2.props['aria-checked']) === undefined) {
+      throw new Error("\"aria-checked\" is not supported on role \"" + role + "\".");
+    }
+  }
+
+  if (pressed !== undefined) {
+    var _allRoles$get3;
+
+    // guard against unknown roles
+    if (((_allRoles$get3 = lib.roles.get(role)) == null ? void 0 : _allRoles$get3.props['aria-pressed']) === undefined) {
+      throw new Error("\"aria-pressed\" is not supported on role \"" + role + "\".");
+    }
+  }
+
+  if (level !== undefined) {
+    // guard against using `level` option with any role other than `heading`
+    if (role !== 'heading') {
+      throw new Error("Role \"" + role + "\" cannot have \"level\" property.");
+    }
+  }
+
+  if (expanded !== undefined) {
+    var _allRoles$get4;
+
+    // guard against unknown roles
+    if (((_allRoles$get4 = lib.roles.get(role)) == null ? void 0 : _allRoles$get4.props['aria-expanded']) === undefined) {
+      throw new Error("\"aria-expanded\" is not supported on role \"" + role + "\".");
+    }
+  }
+
+  var subtreeIsInaccessibleCache = new WeakMap();
+
+  function cachedIsSubtreeInaccessible(element) {
+    if (!subtreeIsInaccessibleCache.has(element)) {
+      subtreeIsInaccessibleCache.set(element, isSubtreeInaccessible(element));
+    }
+
+    return subtreeIsInaccessibleCache.get(element);
+  }
+
+  return Array.from(container.querySelectorAll('*')).filter(function (node) {
+    var isRoleSpecifiedExplicitly = node.hasAttribute('role');
+
+    if (isRoleSpecifiedExplicitly) {
+      var roleValue = node.getAttribute('role');
+
+      if (queryFallbacks) {
+        return roleValue.split(' ').filter(Boolean).some(function (text) {
+          return matcher(text, node, role, matchNormalizer);
+        });
+      } // if a custom normalizer is passed then let normalizer handle the role value
+
+
+      if (normalizer) {
+        return matcher(roleValue, node, role, matchNormalizer);
+      } // other wise only send the first word to match
+
+
+      var _roleValue$split = roleValue.split(' '),
+          firstWord = _roleValue$split[0];
+
+      return matcher(firstWord, node, role, matchNormalizer);
+    }
+
+    var implicitRoles = getImplicitAriaRoles(node);
+    return implicitRoles.some(function (implicitRole) {
+      return matcher(implicitRole, node, role, matchNormalizer);
+    });
+  }).filter(function (element) {
+    if (selected !== undefined) {
+      return selected === computeAriaSelected(element);
+    }
+
+    if (checked !== undefined) {
+      return checked === computeAriaChecked(element);
+    }
+
+    if (pressed !== undefined) {
+      return pressed === computeAriaPressed(element);
+    }
+
+    if (expanded !== undefined) {
+      return expanded === computeAriaExpanded(element);
+    }
+
+    if (level !== undefined) {
+      return level === computeHeadingLevel(element);
+    } // don't care if aria attributes are unspecified
+
+
+    return true;
+  }).filter(function (element) {
+    return hidden === false ? isInaccessible(element, {
+      isSubtreeInaccessible: cachedIsSubtreeInaccessible
+    }) === false : true;
+  }).filter(function (element) {
+    if (name === undefined) {
+      // Don't care
+      return true;
+    }
+
+    return matches(computeAccessibleName(element, {
+      computedStyleSupportsPseudoElements: getConfig().computedStyleSupportsPseudoElements
+    }), element, name, function (text) {
+      return text;
+    });
+  });
+}
+
+var getMultipleError$1 = function getMultipleError(c, role, _temp2) {
+  var _ref2 = _temp2 === void 0 ? {} : _temp2,
+      name = _ref2.name;
+
+  var nameHint = '';
+
+  if (name === undefined) {
+    nameHint = '';
+  } else if (typeof name === 'string') {
+    nameHint = " and name \"" + name + "\"";
+  } else {
+    nameHint = " and name `" + name + "`";
+  }
+
+  return "Found multiple elements with the role \"" + role + "\"" + nameHint;
+};
+
+var getMissingError$1 = function getMissingError(container, role, _temp3) {
+  var _ref3 = _temp3 === void 0 ? {} : _temp3,
+      _ref3$hidden = _ref3.hidden,
+      hidden = _ref3$hidden === void 0 ? getConfig().defaultHidden : _ref3$hidden,
+      name = _ref3.name;
+
+  if (getConfig()._disableExpensiveErrorDiagnostics) {
+    return "Unable to find role=\"" + role + "\"";
+  }
+
+  var roles = '';
+  Array.from(container.children).forEach(function (childElement) {
+    roles += prettyRoles(childElement, {
+      hidden: hidden,
+      includeName: name !== undefined
+    });
+  });
+  var roleMessage;
+
+  if (roles.length === 0) {
+    if (hidden === false) {
+      roleMessage = 'There are no accessible roles. But there might be some inaccessible roles. ' + 'If you wish to access them, then set the `hidden` option to `true`. ' + 'Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole';
+    } else {
+      roleMessage = 'There are no available roles.';
+    }
+  } else {
+    roleMessage = ("\nHere are the " + (hidden === false ? 'accessible' : 'available') + " roles:\n\n  " + roles.replace(/\n/g, '\n  ').replace(/\n\s\s\n/g, '\n\n') + "\n").trim();
+  }
+
+  var nameHint = '';
+
+  if (name === undefined) {
+    nameHint = '';
+  } else if (typeof name === 'string') {
+    nameHint = " and name \"" + name + "\"";
+  } else {
+    nameHint = " and name `" + name + "`";
+  }
+
+  return ("\nUnable to find an " + (hidden === false ? 'accessible ' : '') + "element with the role \"" + role + "\"" + nameHint + "\n\n" + roleMessage).trim();
+};
+
+var queryAllByRoleWithSuggestions = wrapAllByQueryWithSuggestion(queryAllByRole, queryAllByRole.name, 'queryAll');
+
+var _buildQueries$1 = buildQueries(queryAllByRole, getMultipleError$1, getMissingError$1),
+    queryByRole = _buildQueries$1[0],
+    getAllByRole = _buildQueries$1[1],
+    getByRole = _buildQueries$1[2],
+    findAllByRole = _buildQueries$1[3],
+    findByRole = _buildQueries$1[4];
+
+var getTestIdAttribute = function getTestIdAttribute() {
+  return getConfig().testIdAttribute;
+};
+
+var queryAllByTestId = function queryAllByTestId() {
+  for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+    args[_key] = arguments[_key];
+  }
+
+  checkContainerType(args[0]); // TODO: Remove ignore after `queryAllByAttribute` will be moved to TS
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
+
+  return queryAllByAttribute.apply(void 0, [getTestIdAttribute()].concat(args));
+};
+
+var getMultipleError = function getMultipleError(c, id) {
+  return "Found multiple elements by: [" + getTestIdAttribute() + "=\"" + id + "\"]";
+};
+
+var getMissingError = function getMissingError(c, id) {
+  return "Unable to find an element by: [" + getTestIdAttribute() + "=\"" + id + "\"]";
+};
+
+var queryAllByTestIdWithSuggestions = wrapAllByQueryWithSuggestion(queryAllByTestId, queryAllByTestId.name, 'queryAll');
+
+var _buildQueries = buildQueries(queryAllByTestId, getMultipleError, getMissingError),
+    queryByTestId = _buildQueries[0],
+    getAllByTestId = _buildQueries[1],
+    getByTestId = _buildQueries[2],
+    findAllByTestId = _buildQueries[3],
+    findByTestId = _buildQueries[4];
+
+var queries = /*#__PURE__*/Object.freeze({
+  __proto__: null,
+  queryAllByLabelText: queryAllByLabelTextWithSuggestions,
+  queryByLabelText: queryByLabelText,
+  getAllByLabelText: getAllByLabelTextWithSuggestions,
+  getByLabelText: getByLabelTextWithSuggestions,
+  findAllByLabelText: findAllByLabelText,
+  findByLabelText: findByLabelText,
+  queryByPlaceholderText: queryByPlaceholderText,
+  queryAllByPlaceholderText: queryAllByPlaceholderTextWithSuggestions,
+  getByPlaceholderText: getByPlaceholderText,
+  getAllByPlaceholderText: getAllByPlaceholderText,
+  findAllByPlaceholderText: findAllByPlaceholderText,
+  findByPlaceholderText: findByPlaceholderText,
+  queryByText: queryByText,
+  queryAllByText: queryAllByTextWithSuggestions,
+  getByText: getByText,
+  getAllByText: getAllByText,
+  findAllByText: findAllByText,
+  findByText: findByText,
+  queryByDisplayValue: queryByDisplayValue,
+  queryAllByDisplayValue: queryAllByDisplayValueWithSuggestions,
+  getByDisplayValue: getByDisplayValue,
+  getAllByDisplayValue: getAllByDisplayValue,
+  findAllByDisplayValue: findAllByDisplayValue,
+  findByDisplayValue: findByDisplayValue,
+  queryByAltText: queryByAltText,
+  queryAllByAltText: queryAllByAltTextWithSuggestions,
+  getByAltText: getByAltText,
+  getAllByAltText: getAllByAltText,
+  findAllByAltText: findAllByAltText,
+  findByAltText: findByAltText,
+  queryByTitle: queryByTitle,
+  queryAllByTitle: queryAllByTitleWithSuggestions,
+  getByTitle: getByTitle,
+  getAllByTitle: getAllByTitle,
+  findAllByTitle: findAllByTitle,
+  findByTitle: findByTitle,
+  queryByRole: queryByRole,
+  queryAllByRole: queryAllByRoleWithSuggestions,
+  getAllByRole: getAllByRole,
+  getByRole: getByRole,
+  findAllByRole: findAllByRole,
+  findByRole: findByRole,
+  queryByTestId: queryByTestId,
+  queryAllByTestId: queryAllByTestIdWithSuggestions,
+  getByTestId: getByTestId,
+  getAllByTestId: getAllByTestId,
+  findAllByTestId: findAllByTestId,
+  findByTestId: findByTestId
+});
+
+/**
+ * @typedef {{[key: string]: Function}} FuncMap
+ */
+
+/**
+ * @param {HTMLElement} element container
+ * @param {FuncMap} queries object of functions
+ * @param {Object} initialValue for reducer
+ * @returns {FuncMap} returns object of functions bound to container
+ */
+
+function getQueriesForElement(element, queries$1, initialValue) {
+  if (queries$1 === void 0) {
+    queries$1 = queries;
+  }
+
+  if (initialValue === void 0) {
+    initialValue = {};
+  }
+
+  return Object.keys(queries$1).reduce(function (helpers, key) {
+    var fn = queries$1[key];
+    helpers[key] = fn.bind(null, element);
+    return helpers;
+  }, initialValue);
+}
+
+var hasWarned$1 = false; // deprecated... TODO: remove this method. People should use a find* query or
+// wait instead the reasoning is that this doesn't really do anything useful
+// that you can't get from using find* or wait.
+
+function waitForElement(_x, _x2) {
+  return _waitForElement.apply(this, arguments);
+}
+
+function _waitForElement() {
+  _waitForElement = _asyncToGenerator( /*#__PURE__*/regenerator.mark(function _callee(callback, options) {
+    return regenerator.wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            if (!hasWarned$1) {
+              hasWarned$1 = true;
+              console.warn("`waitForElement` has been deprecated. Use a `find*` query (preferred: https://testing-library.com/docs/dom-testing-library/api-queries#findby) or use `waitFor` instead: https://testing-library.com/docs/dom-testing-library/api-async#waitfor");
+            }
+
+            if (callback) {
+              _context.next = 3;
+              break;
+            }
+
+            throw new Error('waitForElement requires a callback as the first parameter');
+
+          case 3:
+            return _context.abrupt("return", waitForWrapper(function () {
+              var result = callback();
+
+              if (!result) {
+                throw new Error('Timed out in waitForElement.');
+              }
+
+              return result;
+            }, options));
+
+          case 4:
+          case "end":
+            return _context.stop();
+        }
+      }
+    }, _callee);
+  }));
+  return _waitForElement.apply(this, arguments);
+}
+/*
+eslint
+  require-await: "off"
+*/
+
+var isRemoved = function isRemoved(result) {
+  return !result || Array.isArray(result) && !result.length;
+}; // Check if the element is not present.
+// As the name implies, waitForElementToBeRemoved should check `present` --> `removed`
+
+
+function initialCheck(elements) {
+  if (isRemoved(elements)) {
+    throw new Error('The element(s) given to waitForElementToBeRemoved are already removed. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal.');
+  }
+}
+
+function waitForElementToBeRemoved(_x, _x2) {
+  return _waitForElementToBeRemoved.apply(this, arguments);
+}
+
+function _waitForElementToBeRemoved() {
+  _waitForElementToBeRemoved = _asyncToGenerator( /*#__PURE__*/regenerator.mark(function _callee(callback, options) {
+    var timeoutError, elements, getRemainingElements;
+    return regenerator.wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            // created here so we get a nice stacktrace
+            timeoutError = new Error('Timed out in waitForElementToBeRemoved.');
+
+            if (typeof callback !== 'function') {
+              initialCheck(callback);
+              elements = Array.isArray(callback) ? callback : [callback];
+              getRemainingElements = elements.map(function (element) {
+                var parent = element.parentElement;
+                if (parent === null) return function () {
+                  return null;
+                };
+
+                while (parent.parentElement) {
+                  parent = parent.parentElement;
+                }
+
+                return function () {
+                  return parent.contains(element) ? element : null;
+                };
+              });
+
+              callback = function callback() {
+                return getRemainingElements.map(function (c) {
+                  return c();
+                }).filter(Boolean);
+              };
+            }
+
+            initialCheck(callback());
+            return _context.abrupt("return", waitForWrapper(function () {
+              var result;
+
+              try {
+                result = callback();
+              } catch (error) {
+                if (error.name === 'TestingLibraryElementError') {
+                  return undefined;
+                }
+
+                throw error;
+              }
+
+              if (!isRemoved(result)) {
+                throw timeoutError;
+              }
+
+              return undefined;
+            }, options));
+
+          case 4:
+          case "end":
+            return _context.stop();
+        }
+      }
+    }, _callee);
+  }));
+  return _waitForElementToBeRemoved.apply(this, arguments);
+}
+/*
+eslint
+  require-await: "off"
+*/
+
+var hasWarned = false; // deprecated... TODO: remove this method. People should use wait instead
+// the reasoning is that waiting for just any DOM change is an implementation
+// detail. People should be waiting for a specific thing to change.
+
+function waitForDomChange(_temp) {
+  var _ref = _temp === void 0 ? {} : _temp,
+      _ref$container = _ref.container,
+      container = _ref$container === void 0 ? getDocument() : _ref$container,
+      _ref$timeout = _ref.timeout,
+      timeout = _ref$timeout === void 0 ? getConfig().asyncUtilTimeout : _ref$timeout,
+      _ref$mutationObserver = _ref.mutationObserverOptions,
+      mutationObserverOptions = _ref$mutationObserver === void 0 ? {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    characterData: true
+  } : _ref$mutationObserver;
+
+  if (!hasWarned) {
+    hasWarned = true;
+    console.warn("`waitForDomChange` has been deprecated. Use `waitFor` instead: https://testing-library.com/docs/dom-testing-library/api-async#waitfor.");
+  }
+
+  return new Promise(function (resolve, reject) {
+    var timer = setTimeoutFn(onTimeout, timeout);
+
+    var _getWindowFromNode = getWindowFromNode(container),
+        MutationObserver = _getWindowFromNode.MutationObserver;
+
+    var observer = new MutationObserver(onMutation);
+    runWithRealTimers(function () {
+      return observer.observe(container, mutationObserverOptions);
+    });
+
+    function onDone(error, result) {
+      clearTimeoutFn(timer);
+      setImmediateFn(function () {
+        return observer.disconnect();
+      });
+
+      if (error) {
+        reject(error);
+      } else {
+        resolve(result);
+      }
+    }
+
+    function onMutation(mutationsList) {
+      onDone(null, mutationsList);
+    }
+
+    function onTimeout() {
+      onDone(new Error('Timed out in waitForDomChange.'), null);
+    }
+  });
+}
+
+function waitForDomChangeWrapper() {
+  for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+    args[_key] = arguments[_key];
+  }
+
+  return getConfig().asyncWrapper(function () {
+    return waitForDomChange.apply(void 0, args);
+  });
+}
+
+var eventMap = {
+  // Clipboard Events
+  copy: {
+    EventType: 'ClipboardEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  cut: {
+    EventType: 'ClipboardEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  paste: {
+    EventType: 'ClipboardEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  // Composition Events
+  compositionEnd: {
+    EventType: 'CompositionEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  compositionStart: {
+    EventType: 'CompositionEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  compositionUpdate: {
+    EventType: 'CompositionEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  // Keyboard Events
+  keyDown: {
+    EventType: 'KeyboardEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      charCode: 0,
+      composed: true
+    }
+  },
+  keyPress: {
+    EventType: 'KeyboardEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      charCode: 0,
+      composed: true
+    }
+  },
+  keyUp: {
+    EventType: 'KeyboardEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      charCode: 0,
+      composed: true
+    }
+  },
+  // Focus Events
+  focus: {
+    EventType: 'FocusEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false,
+      composed: true
+    }
+  },
+  blur: {
+    EventType: 'FocusEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false,
+      composed: true
+    }
+  },
+  focusIn: {
+    EventType: 'FocusEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  focusOut: {
+    EventType: 'FocusEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  // Form Events
+  change: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false
+    }
+  },
+  input: {
+    EventType: 'InputEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  invalid: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: true
+    }
+  },
+  submit: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true
+    }
+  },
+  reset: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true
+    }
+  },
+  // Mouse Events
+  click: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      composed: true
+    }
+  },
+  contextMenu: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  dblClick: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  drag: {
+    EventType: 'DragEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  dragEnd: {
+    EventType: 'DragEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  dragEnter: {
+    EventType: 'DragEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  dragExit: {
+    EventType: 'DragEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  dragLeave: {
+    EventType: 'DragEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  dragOver: {
+    EventType: 'DragEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  dragStart: {
+    EventType: 'DragEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  drop: {
+    EventType: 'DragEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  mouseDown: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  mouseEnter: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false,
+      composed: true
+    }
+  },
+  mouseLeave: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false,
+      composed: true
+    }
+  },
+  mouseMove: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  mouseOut: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  mouseOver: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  mouseUp: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  // Selection Events
+  select: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false
+    }
+  },
+  // Touch Events
+  touchCancel: {
+    EventType: 'TouchEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  touchEnd: {
+    EventType: 'TouchEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  touchMove: {
+    EventType: 'TouchEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  touchStart: {
+    EventType: 'TouchEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  // UI Events
+  scroll: {
+    EventType: 'UIEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  // Wheel Events
+  wheel: {
+    EventType: 'WheelEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  // Media Events
+  abort: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  canPlay: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  canPlayThrough: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  durationChange: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  emptied: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  encrypted: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  ended: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  loadedData: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  loadedMetadata: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  loadStart: {
+    EventType: 'ProgressEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  pause: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  play: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  playing: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  progress: {
+    EventType: 'ProgressEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  rateChange: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  seeked: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  seeking: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  stalled: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  suspend: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  timeUpdate: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  volumeChange: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  waiting: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  // Image Events
+  load: {
+    EventType: 'UIEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  error: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  // Animation Events
+  animationStart: {
+    EventType: 'AnimationEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false
+    }
+  },
+  animationEnd: {
+    EventType: 'AnimationEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false
+    }
+  },
+  animationIteration: {
+    EventType: 'AnimationEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false
+    }
+  },
+  // Transition Events
+  transitionEnd: {
+    EventType: 'TransitionEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true
+    }
+  },
+  // pointer events
+  pointerOver: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  pointerEnter: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  pointerDown: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  pointerMove: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  pointerUp: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  pointerCancel: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  pointerOut: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  pointerLeave: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  gotPointerCapture: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  lostPointerCapture: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  // history events
+  popState: {
+    EventType: 'PopStateEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false
+    }
+  }
+};
+var eventAliasMap = {
+  doubleClick: 'dblClick'
+};
+
+var _excluded = ["value", "files"],
+    _excluded2 = ["bubbles", "cancelable", "detail"];
+
+function fireEvent$1(element, event) {
+  return getConfig().eventWrapper(function () {
+    if (!event) {
+      throw new Error("Unable to fire an event - please provide an event object.");
+    }
+
+    if (!element) {
+      throw new Error("Unable to fire a \"" + event.type + "\" event - please provide a DOM element.");
+    }
+
+    return element.dispatchEvent(event);
+  });
+}
+
+function createEvent(eventName, node, init, _temp) {
+  var _ref = _temp === void 0 ? {} : _temp,
+      _ref$EventType = _ref.EventType,
+      EventType = _ref$EventType === void 0 ? 'Event' : _ref$EventType,
+      _ref$defaultInit = _ref.defaultInit,
+      defaultInit = _ref$defaultInit === void 0 ? {} : _ref$defaultInit;
+
+  if (!node) {
+    throw new Error("Unable to fire a \"" + eventName + "\" event - please provide a DOM element.");
+  }
+
+  var eventInit = _extends({}, defaultInit, init);
+
+  var _eventInit$target = eventInit.target;
+  _eventInit$target = _eventInit$target === void 0 ? {} : _eventInit$target;
+
+  var value = _eventInit$target.value,
+      files = _eventInit$target.files,
+      targetProperties = _objectWithoutPropertiesLoose(_eventInit$target, _excluded);
+
+  if (value !== undefined) {
+    setNativeValue(node, value);
+  }
+
+  if (files !== undefined) {
+    // input.files is a read-only property so this is not allowed:
+    // input.files = [file]
+    // so we have to use this workaround to set the property
+    Object.defineProperty(node, 'files', {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: files
+    });
+  }
+
+  Object.assign(node, targetProperties);
+  var window = getWindowFromNode(node);
+  var EventConstructor = window[EventType] || window.Event;
+  var event;
+  /* istanbul ignore else  */
+
+  if (typeof EventConstructor === 'function') {
+    event = new EventConstructor(eventName, eventInit);
+  } else {
+    // IE11 polyfill from https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
+    event = window.document.createEvent(EventType);
+
+    var bubbles = eventInit.bubbles,
+        cancelable = eventInit.cancelable,
+        detail = eventInit.detail,
+        otherInit = _objectWithoutPropertiesLoose(eventInit, _excluded2);
+
+    event.initEvent(eventName, bubbles, cancelable, detail);
+    Object.keys(otherInit).forEach(function (eventKey) {
+      event[eventKey] = otherInit[eventKey];
+    });
+  } // DataTransfer is not supported in jsdom: https://github.com/jsdom/jsdom/issues/1568
+
+
+  var dataTransferProperties = ['dataTransfer', 'clipboardData'];
+  dataTransferProperties.forEach(function (dataTransferKey) {
+    var dataTransferValue = eventInit[dataTransferKey];
+
+    if (typeof dataTransferValue === 'object') {
+      /* istanbul ignore if  */
+      if (typeof window.DataTransfer === 'function') {
+        Object.defineProperty(event, dataTransferKey, {
+          value: Object.getOwnPropertyNames(dataTransferValue).reduce(function (acc, propName) {
+            Object.defineProperty(acc, propName, {
+              value: dataTransferValue[propName]
+            });
+            return acc;
+          }, new window.DataTransfer())
+        });
+      } else {
+        Object.defineProperty(event, dataTransferKey, {
+          value: dataTransferValue
+        });
+      }
+    }
+  });
+  return event;
+}
+
+Object.keys(eventMap).forEach(function (key) {
+  var _eventMap$key = eventMap[key],
+      EventType = _eventMap$key.EventType,
+      defaultInit = _eventMap$key.defaultInit;
+  var eventName = key.toLowerCase();
+
+  createEvent[key] = function (node, init) {
+    return createEvent(eventName, node, init, {
+      EventType: EventType,
+      defaultInit: defaultInit
+    });
+  };
+
+  fireEvent$1[key] = function (node, init) {
+    return fireEvent$1(node, createEvent[key](node, init));
+  };
+}); // function written after some investigation here:
+// https://github.com/facebook/react/issues/10135#issuecomment-401496776
+
+function setNativeValue(element, value) {
+  var _ref2 = Object.getOwnPropertyDescriptor(element, 'value') || {},
+      valueSetter = _ref2.set;
+
+  var prototype = Object.getPrototypeOf(element);
+
+  var _ref3 = Object.getOwnPropertyDescriptor(prototype, 'value') || {},
+      prototypeValueSetter = _ref3.set;
+
+  if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
+    prototypeValueSetter.call(element, value);
+  }
+  /* istanbul ignore next (I don't want to bother) */
+  else if (valueSetter) {
+      valueSetter.call(element, value);
+    } else {
+      throw new Error('The given element does not have a value setter');
+    }
+}
+
+Object.keys(eventAliasMap).forEach(function (aliasKey) {
+  var key = eventAliasMap[aliasKey];
+
+  fireEvent$1[aliasKey] = function () {
+    return fireEvent$1[key].apply(fireEvent$1, arguments);
+  };
+});
+/* eslint complexity:["error", 9] */
+
+function unindent(string) {
+  // remove white spaces first, to save a few bytes.
+  // testing-playground will reformat on load any ways.
+  return string.replace(/[ \t]*[\n][ \t]*/g, '\n');
+}
+
+function encode(value) {
+  return lzString.compressToEncodedURIComponent(unindent(value));
+}
+
+function getPlaygroundUrl(markup) {
+  return "https://testing-playground.com/#markup=" + encode(markup);
+}
+
+var debug = function debug(element, maxLength, options) {
+  return Array.isArray(element) ? element.forEach(function (el) {
+    return logDOM(el, maxLength, options);
+  }) : logDOM(element, maxLength, options);
+};
+
+var logTestingPlaygroundURL = function logTestingPlaygroundURL(element) {
+  if (element === void 0) {
+    element = getDocument().body;
+  }
+
+  if (!element || !('innerHTML' in element)) {
+    console.log("The element you're providing isn't a valid DOM element.");
+    return;
+  }
+
+  if (!element.innerHTML) {
+    console.log("The provided element doesn't have any children.");
+    return;
+  }
+
+  console.log("Open this URL in your browser\n\n" + getPlaygroundUrl(element.innerHTML));
+};
+
+var initialValue = {
+  debug: debug,
+  logTestingPlaygroundURL: logTestingPlaygroundURL
+};
+var screen = typeof document !== 'undefined' && document.body ? getQueriesForElement(document.body, queries, initialValue) : Object.keys(queries).reduce(function (helpers, key) {
+  helpers[key] = function () {
+    throw new TypeError('For queries bound to document.body a global document has to be available... Learn more: https://testing-library.com/s/screen-global-error');
+  };
+
+  return helpers;
+}, initialValue);
+
+var dom_esm = /*#__PURE__*/Object.freeze({
+            __proto__: null,
+            buildQueries: buildQueries,
+            configure: configure,
+            createEvent: createEvent,
+            findAllByAltText: findAllByAltText,
+            findAllByDisplayValue: findAllByDisplayValue,
+            findAllByLabelText: findAllByLabelText,
+            findAllByPlaceholderText: findAllByPlaceholderText,
+            findAllByRole: findAllByRole,
+            findAllByTestId: findAllByTestId,
+            findAllByText: findAllByText,
+            findAllByTitle: findAllByTitle,
+            findByAltText: findByAltText,
+            findByDisplayValue: findByDisplayValue,
+            findByLabelText: findByLabelText,
+            findByPlaceholderText: findByPlaceholderText,
+            findByRole: findByRole,
+            findByTestId: findByTestId,
+            findByText: findByText,
+            findByTitle: findByTitle,
+            fireEvent: fireEvent$1,
+            getAllByAltText: getAllByAltText,
+            getAllByDisplayValue: getAllByDisplayValue,
+            getAllByLabelText: getAllByLabelTextWithSuggestions,
+            getAllByPlaceholderText: getAllByPlaceholderText,
+            getAllByRole: getAllByRole,
+            getAllByTestId: getAllByTestId,
+            getAllByText: getAllByText,
+            getAllByTitle: getAllByTitle,
+            getByAltText: getByAltText,
+            getByDisplayValue: getByDisplayValue,
+            getByLabelText: getByLabelTextWithSuggestions,
+            getByPlaceholderText: getByPlaceholderText,
+            getByRole: getByRole,
+            getByTestId: getByTestId,
+            getByText: getByText,
+            getByTitle: getByTitle,
+            getConfig: getConfig,
+            getDefaultNormalizer: getDefaultNormalizer,
+            getElementError: getElementError,
+            getMultipleElementsFoundError: getMultipleElementsFoundError,
+            getNodeText: getNodeText,
+            getQueriesForElement: getQueriesForElement,
+            getRoles: getRoles,
+            getSuggestedQuery: getSuggestedQuery,
+            isInaccessible: isInaccessible,
+            logDOM: logDOM,
+            logRoles: logRoles,
+            makeFindQuery: makeFindQuery,
+            makeGetAllQuery: makeGetAllQuery,
+            makeSingleQuery: makeSingleQuery,
+            prettyDOM: prettyDOM,
+            queries: queries,
+            queryAllByAltText: queryAllByAltTextWithSuggestions,
+            queryAllByAttribute: queryAllByAttribute,
+            queryAllByDisplayValue: queryAllByDisplayValueWithSuggestions,
+            queryAllByLabelText: queryAllByLabelTextWithSuggestions,
+            queryAllByPlaceholderText: queryAllByPlaceholderTextWithSuggestions,
+            queryAllByRole: queryAllByRoleWithSuggestions,
+            queryAllByTestId: queryAllByTestIdWithSuggestions,
+            queryAllByText: queryAllByTextWithSuggestions,
+            queryAllByTitle: queryAllByTitleWithSuggestions,
+            queryByAltText: queryByAltText,
+            queryByAttribute: queryByAttribute,
+            queryByDisplayValue: queryByDisplayValue,
+            queryByLabelText: queryByLabelText,
+            queryByPlaceholderText: queryByPlaceholderText,
+            queryByRole: queryByRole,
+            queryByTestId: queryByTestId,
+            queryByText: queryByText,
+            queryByTitle: queryByTitle,
+            queryHelpers: queryHelpers,
+            screen: screen,
+            wait: wait$1,
+            waitFor: waitForWrapper,
+            waitForDomChange: waitForDomChangeWrapper,
+            waitForElement: waitForElement,
+            waitForElementToBeRemoved: waitForElementToBeRemoved,
+            within: getQueriesForElement,
+            wrapAllByQueryWithSuggestion: wrapAllByQueryWithSuggestion,
+            wrapSingleQueryWithSuggestion: wrapSingleQueryWithSuggestion,
+            prettyFormat: build$1
+});
+
+/*
+object-assign
+(c) Sindre Sorhus
+@license MIT
+*/
+/* eslint-disable no-unused-vars */
+var getOwnPropertySymbols = Object.getOwnPropertySymbols;
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+
+function toObject(val) {
+	if (val === null || val === undefined) {
+		throw new TypeError('Object.assign cannot be called with null or undefined');
+	}
+
+	return Object(val);
+}
+
+function shouldUseNative() {
+	try {
+		if (!Object.assign) {
+			return false;
+		}
+
+		// Detect buggy property enumeration order in older V8 versions.
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=4118
+		var test1 = new String('abc');  // eslint-disable-line no-new-wrappers
+		test1[5] = 'de';
+		if (Object.getOwnPropertyNames(test1)[0] === '5') {
+			return false;
+		}
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+		var test2 = {};
+		for (var i = 0; i < 10; i++) {
+			test2['_' + String.fromCharCode(i)] = i;
+		}
+		var order2 = Object.getOwnPropertyNames(test2).map(function (n) {
+			return test2[n];
+		});
+		if (order2.join('') !== '0123456789') {
+			return false;
+		}
+
+		// https://bugs.chromium.org/p/v8/issues/detail?id=3056
+		var test3 = {};
+		'abcdefghijklmnopqrst'.split('').forEach(function (letter) {
+			test3[letter] = letter;
+		});
+		if (Object.keys(Object.assign({}, test3)).join('') !==
+				'abcdefghijklmnopqrst') {
+			return false;
+		}
+
+		return true;
+	} catch (err) {
+		// We don't expect any of the above to throw, but better to be safe.
+		return false;
+	}
+}
+
+var objectAssign = shouldUseNative() ? Object.assign : function (target, source) {
+	var from;
+	var to = toObject(target);
+	var symbols;
+
+	for (var s = 1; s < arguments.length; s++) {
+		from = Object(arguments[s]);
+
+		for (var key in from) {
+			if (hasOwnProperty.call(from, key)) {
+				to[key] = from[key];
+			}
+		}
+
+		if (getOwnPropertySymbols) {
+			symbols = getOwnPropertySymbols(from);
+			for (var i = 0; i < symbols.length; i++) {
+				if (propIsEnumerable.call(from, symbols[i])) {
+					to[symbols[i]] = from[symbols[i]];
+				}
+			}
+		}
+	}
+
+	return to;
+};
+
+/** @license React v0.20.2
+ * scheduler.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var scheduler_production_min = createCommonjsModule(function (module, exports) {
+var f,g,h,k;if("object"===typeof performance&&"function"===typeof performance.now){var l=performance;exports.unstable_now=function(){return l.now()};}else {var p=Date,q=p.now();exports.unstable_now=function(){return p.now()-q};}
+if("undefined"===typeof window||"function"!==typeof MessageChannel){var t=null,u=null,w=function(){if(null!==t)try{var a=exports.unstable_now();t(!0,a);t=null;}catch(b){throw setTimeout(w,0),b;}};f=function(a){null!==t?setTimeout(f,0,a):(t=a,setTimeout(w,0));};g=function(a,b){u=setTimeout(a,b);};h=function(){clearTimeout(u);};exports.unstable_shouldYield=function(){return !1};k=exports.unstable_forceFrameRate=function(){};}else {var x=window.setTimeout,y=window.clearTimeout;if("undefined"!==typeof console){var z=
+window.cancelAnimationFrame;"function"!==typeof window.requestAnimationFrame&&console.error("This browser doesn't support requestAnimationFrame. Make sure that you load a polyfill in older browsers. https://reactjs.org/link/react-polyfills");"function"!==typeof z&&console.error("This browser doesn't support cancelAnimationFrame. Make sure that you load a polyfill in older browsers. https://reactjs.org/link/react-polyfills");}var A=!1,B=null,C=-1,D=5,E=0;exports.unstable_shouldYield=function(){return exports.unstable_now()>=
+E};k=function(){};exports.unstable_forceFrameRate=function(a){0>a||125<a?console.error("forceFrameRate takes a positive int between 0 and 125, forcing frame rates higher than 125 fps is not supported"):D=0<a?Math.floor(1E3/a):5;};var F=new MessageChannel,G=F.port2;F.port1.onmessage=function(){if(null!==B){var a=exports.unstable_now();E=a+D;try{B(!0,a)?G.postMessage(null):(A=!1,B=null);}catch(b){throw G.postMessage(null),b;}}else A=!1;};f=function(a){B=a;A||(A=!0,G.postMessage(null));};g=function(a,b){C=
+x(function(){a(exports.unstable_now());},b);};h=function(){y(C);C=-1;};}function H(a,b){var c=a.length;a.push(b);a:for(;;){var d=c-1>>>1,e=a[d];if(void 0!==e&&0<I(e,b))a[d]=b,a[c]=e,c=d;else break a}}function J(a){a=a[0];return void 0===a?null:a}
+function K(a){var b=a[0];if(void 0!==b){var c=a.pop();if(c!==b){a[0]=c;a:for(var d=0,e=a.length;d<e;){var m=2*(d+1)-1,n=a[m],v=m+1,r=a[v];if(void 0!==n&&0>I(n,c))void 0!==r&&0>I(r,n)?(a[d]=r,a[v]=c,d=v):(a[d]=n,a[m]=c,d=m);else if(void 0!==r&&0>I(r,c))a[d]=r,a[v]=c,d=v;else break a}}return b}return null}function I(a,b){var c=a.sortIndex-b.sortIndex;return 0!==c?c:a.id-b.id}var L=[],M=[],N=1,O=null,P=3,Q=!1,R=!1,S=!1;
+function T(a){for(var b=J(M);null!==b;){if(null===b.callback)K(M);else if(b.startTime<=a)K(M),b.sortIndex=b.expirationTime,H(L,b);else break;b=J(M);}}function U(a){S=!1;T(a);if(!R)if(null!==J(L))R=!0,f(V);else {var b=J(M);null!==b&&g(U,b.startTime-a);}}
+function V(a,b){R=!1;S&&(S=!1,h());Q=!0;var c=P;try{T(b);for(O=J(L);null!==O&&(!(O.expirationTime>b)||a&&!exports.unstable_shouldYield());){var d=O.callback;if("function"===typeof d){O.callback=null;P=O.priorityLevel;var e=d(O.expirationTime<=b);b=exports.unstable_now();"function"===typeof e?O.callback=e:O===J(L)&&K(L);T(b);}else K(L);O=J(L);}if(null!==O)var m=!0;else {var n=J(M);null!==n&&g(U,n.startTime-b);m=!1;}return m}finally{O=null,P=c,Q=!1;}}var W=k;exports.unstable_IdlePriority=5;
+exports.unstable_ImmediatePriority=1;exports.unstable_LowPriority=4;exports.unstable_NormalPriority=3;exports.unstable_Profiling=null;exports.unstable_UserBlockingPriority=2;exports.unstable_cancelCallback=function(a){a.callback=null;};exports.unstable_continueExecution=function(){R||Q||(R=!0,f(V));};exports.unstable_getCurrentPriorityLevel=function(){return P};exports.unstable_getFirstCallbackNode=function(){return J(L)};
+exports.unstable_next=function(a){switch(P){case 1:case 2:case 3:var b=3;break;default:b=P;}var c=P;P=b;try{return a()}finally{P=c;}};exports.unstable_pauseExecution=function(){};exports.unstable_requestPaint=W;exports.unstable_runWithPriority=function(a,b){switch(a){case 1:case 2:case 3:case 4:case 5:break;default:a=3;}var c=P;P=a;try{return b()}finally{P=c;}};
+exports.unstable_scheduleCallback=function(a,b,c){var d=exports.unstable_now();"object"===typeof c&&null!==c?(c=c.delay,c="number"===typeof c&&0<c?d+c:d):c=d;switch(a){case 1:var e=-1;break;case 2:e=250;break;case 5:e=1073741823;break;case 4:e=1E4;break;default:e=5E3;}e=c+e;a={id:N++,callback:b,priorityLevel:a,startTime:c,expirationTime:e,sortIndex:-1};c>d?(a.sortIndex=c,H(M,a),null===J(L)&&a===J(M)&&(S?h():S=!0,g(U,c-d))):(a.sortIndex=e,H(L,a),R||Q||(R=!0,f(V)));return a};
+exports.unstable_wrapCallback=function(a){var b=P;return function(){var c=P;P=b;try{return a.apply(this,arguments)}finally{P=c;}}};
+});
+
+var scheduler_development = createCommonjsModule(function (module, exports) {
+
+if (process$1.env.NODE_ENV !== "production") {
+  (function() {
+
+var enableSchedulerDebugging = false;
+var enableProfiling = false;
+
+var requestHostCallback;
+var requestHostTimeout;
+var cancelHostTimeout;
+var requestPaint;
+var hasPerformanceNow = typeof performance === 'object' && typeof performance.now === 'function';
+
+if (hasPerformanceNow) {
+  var localPerformance = performance;
+
+  exports.unstable_now = function () {
+    return localPerformance.now();
+  };
+} else {
+  var localDate = Date;
+  var initialTime = localDate.now();
+
+  exports.unstable_now = function () {
+    return localDate.now() - initialTime;
+  };
+}
+
+if ( // If Scheduler runs in a non-DOM environment, it falls back to a naive
+// implementation using setTimeout.
+typeof window === 'undefined' || // Check if MessageChannel is supported, too.
+typeof MessageChannel !== 'function') {
+  // If this accidentally gets imported in a non-browser environment, e.g. JavaScriptCore,
+  // fallback to a naive implementation.
+  var _callback = null;
+  var _timeoutID = null;
+
+  var _flushCallback = function () {
+    if (_callback !== null) {
+      try {
+        var currentTime = exports.unstable_now();
+        var hasRemainingTime = true;
+
+        _callback(hasRemainingTime, currentTime);
+
+        _callback = null;
+      } catch (e) {
+        setTimeout(_flushCallback, 0);
+        throw e;
+      }
+    }
+  };
+
+  requestHostCallback = function (cb) {
+    if (_callback !== null) {
+      // Protect against re-entrancy.
+      setTimeout(requestHostCallback, 0, cb);
+    } else {
+      _callback = cb;
+      setTimeout(_flushCallback, 0);
+    }
+  };
+
+  requestHostTimeout = function (cb, ms) {
+    _timeoutID = setTimeout(cb, ms);
+  };
+
+  cancelHostTimeout = function () {
+    clearTimeout(_timeoutID);
+  };
+
+  exports.unstable_shouldYield = function () {
+    return false;
+  };
+
+  requestPaint = exports.unstable_forceFrameRate = function () {};
+} else {
+  // Capture local references to native APIs, in case a polyfill overrides them.
+  var _setTimeout = window.setTimeout;
+  var _clearTimeout = window.clearTimeout;
+
+  if (typeof console !== 'undefined') {
+    // TODO: Scheduler no longer requires these methods to be polyfilled. But
+    // maybe we want to continue warning if they don't exist, to preserve the
+    // option to rely on it in the future?
+    var requestAnimationFrame = window.requestAnimationFrame;
+    var cancelAnimationFrame = window.cancelAnimationFrame;
+
+    if (typeof requestAnimationFrame !== 'function') {
+      // Using console['error'] to evade Babel and ESLint
+      console['error']("This browser doesn't support requestAnimationFrame. " + 'Make sure that you load a ' + 'polyfill in older browsers. https://reactjs.org/link/react-polyfills');
+    }
+
+    if (typeof cancelAnimationFrame !== 'function') {
+      // Using console['error'] to evade Babel and ESLint
+      console['error']("This browser doesn't support cancelAnimationFrame. " + 'Make sure that you load a ' + 'polyfill in older browsers. https://reactjs.org/link/react-polyfills');
+    }
+  }
+
+  var isMessageLoopRunning = false;
+  var scheduledHostCallback = null;
+  var taskTimeoutID = -1; // Scheduler periodically yields in case there is other work on the main
+  // thread, like user events. By default, it yields multiple times per frame.
+  // It does not attempt to align with frame boundaries, since most tasks don't
+  // need to be frame aligned; for those that do, use requestAnimationFrame.
+
+  var yieldInterval = 5;
+  var deadline = 0; // TODO: Make this configurable
+
+  {
+    // `isInputPending` is not available. Since we have no way of knowing if
+    // there's pending input, always yield at the end of the frame.
+    exports.unstable_shouldYield = function () {
+      return exports.unstable_now() >= deadline;
+    }; // Since we yield every frame regardless, `requestPaint` has no effect.
+
+
+    requestPaint = function () {};
+  }
+
+  exports.unstable_forceFrameRate = function (fps) {
+    if (fps < 0 || fps > 125) {
+      // Using console['error'] to evade Babel and ESLint
+      console['error']('forceFrameRate takes a positive int between 0 and 125, ' + 'forcing frame rates higher than 125 fps is not supported');
+      return;
+    }
+
+    if (fps > 0) {
+      yieldInterval = Math.floor(1000 / fps);
+    } else {
+      // reset the framerate
+      yieldInterval = 5;
+    }
+  };
+
+  var performWorkUntilDeadline = function () {
+    if (scheduledHostCallback !== null) {
+      var currentTime = exports.unstable_now(); // Yield after `yieldInterval` ms, regardless of where we are in the vsync
+      // cycle. This means there's always time remaining at the beginning of
+      // the message event.
+
+      deadline = currentTime + yieldInterval;
+      var hasTimeRemaining = true;
+
+      try {
+        var hasMoreWork = scheduledHostCallback(hasTimeRemaining, currentTime);
+
+        if (!hasMoreWork) {
+          isMessageLoopRunning = false;
+          scheduledHostCallback = null;
+        } else {
+          // If there's more work, schedule the next message event at the end
+          // of the preceding one.
+          port.postMessage(null);
+        }
+      } catch (error) {
+        // If a scheduler task throws, exit the current browser task so the
+        // error can be observed.
+        port.postMessage(null);
+        throw error;
+      }
+    } else {
+      isMessageLoopRunning = false;
+    } // Yielding to the browser will give it a chance to paint, so we can
+  };
+
+  var channel = new MessageChannel();
+  var port = channel.port2;
+  channel.port1.onmessage = performWorkUntilDeadline;
+
+  requestHostCallback = function (callback) {
+    scheduledHostCallback = callback;
+
+    if (!isMessageLoopRunning) {
+      isMessageLoopRunning = true;
+      port.postMessage(null);
+    }
+  };
+
+  requestHostTimeout = function (callback, ms) {
+    taskTimeoutID = _setTimeout(function () {
+      callback(exports.unstable_now());
+    }, ms);
+  };
+
+  cancelHostTimeout = function () {
+    _clearTimeout(taskTimeoutID);
+
+    taskTimeoutID = -1;
+  };
+}
+
+function push(heap, node) {
+  var index = heap.length;
+  heap.push(node);
+  siftUp(heap, node, index);
+}
+function peek(heap) {
+  var first = heap[0];
+  return first === undefined ? null : first;
+}
+function pop(heap) {
+  var first = heap[0];
+
+  if (first !== undefined) {
+    var last = heap.pop();
+
+    if (last !== first) {
+      heap[0] = last;
+      siftDown(heap, last, 0);
+    }
+
+    return first;
+  } else {
+    return null;
+  }
+}
+
+function siftUp(heap, node, i) {
+  var index = i;
+
+  while (true) {
+    var parentIndex = index - 1 >>> 1;
+    var parent = heap[parentIndex];
+
+    if (parent !== undefined && compare(parent, node) > 0) {
+      // The parent is larger. Swap positions.
+      heap[parentIndex] = node;
+      heap[index] = parent;
+      index = parentIndex;
+    } else {
+      // The parent is smaller. Exit.
+      return;
+    }
+  }
+}
+
+function siftDown(heap, node, i) {
+  var index = i;
+  var length = heap.length;
+
+  while (index < length) {
+    var leftIndex = (index + 1) * 2 - 1;
+    var left = heap[leftIndex];
+    var rightIndex = leftIndex + 1;
+    var right = heap[rightIndex]; // If the left or right node is smaller, swap with the smaller of those.
+
+    if (left !== undefined && compare(left, node) < 0) {
+      if (right !== undefined && compare(right, left) < 0) {
+        heap[index] = right;
+        heap[rightIndex] = node;
+        index = rightIndex;
+      } else {
+        heap[index] = left;
+        heap[leftIndex] = node;
+        index = leftIndex;
+      }
+    } else if (right !== undefined && compare(right, node) < 0) {
+      heap[index] = right;
+      heap[rightIndex] = node;
+      index = rightIndex;
+    } else {
+      // Neither child is smaller. Exit.
+      return;
+    }
+  }
+}
+
+function compare(a, b) {
+  // Compare sort index first, then task id.
+  var diff = a.sortIndex - b.sortIndex;
+  return diff !== 0 ? diff : a.id - b.id;
+}
+
+// TODO: Use symbols?
+var ImmediatePriority = 1;
+var UserBlockingPriority = 2;
+var NormalPriority = 3;
+var LowPriority = 4;
+var IdlePriority = 5;
+
+function markTaskErrored(task, ms) {
+}
+
+/* eslint-disable no-var */
+// Math.pow(2, 30) - 1
+// 0b111111111111111111111111111111
+
+var maxSigned31BitInt = 1073741823; // Times out immediately
+
+var IMMEDIATE_PRIORITY_TIMEOUT = -1; // Eventually times out
+
+var USER_BLOCKING_PRIORITY_TIMEOUT = 250;
+var NORMAL_PRIORITY_TIMEOUT = 5000;
+var LOW_PRIORITY_TIMEOUT = 10000; // Never times out
+
+var IDLE_PRIORITY_TIMEOUT = maxSigned31BitInt; // Tasks are stored on a min heap
+
+var taskQueue = [];
+var timerQueue = []; // Incrementing id counter. Used to maintain insertion order.
+
+var taskIdCounter = 1; // Pausing the scheduler is useful for debugging.
+var currentTask = null;
+var currentPriorityLevel = NormalPriority; // This is set while performing work, to prevent re-entrancy.
+
+var isPerformingWork = false;
+var isHostCallbackScheduled = false;
+var isHostTimeoutScheduled = false;
+
+function advanceTimers(currentTime) {
+  // Check for tasks that are no longer delayed and add them to the queue.
+  var timer = peek(timerQueue);
+
+  while (timer !== null) {
+    if (timer.callback === null) {
+      // Timer was cancelled.
+      pop(timerQueue);
+    } else if (timer.startTime <= currentTime) {
+      // Timer fired. Transfer to the task queue.
+      pop(timerQueue);
+      timer.sortIndex = timer.expirationTime;
+      push(taskQueue, timer);
+    } else {
+      // Remaining timers are pending.
+      return;
+    }
+
+    timer = peek(timerQueue);
+  }
+}
+
+function handleTimeout(currentTime) {
+  isHostTimeoutScheduled = false;
+  advanceTimers(currentTime);
+
+  if (!isHostCallbackScheduled) {
+    if (peek(taskQueue) !== null) {
+      isHostCallbackScheduled = true;
+      requestHostCallback(flushWork);
+    } else {
+      var firstTimer = peek(timerQueue);
+
+      if (firstTimer !== null) {
+        requestHostTimeout(handleTimeout, firstTimer.startTime - currentTime);
+      }
+    }
+  }
+}
+
+function flushWork(hasTimeRemaining, initialTime) {
+
+
+  isHostCallbackScheduled = false;
+
+  if (isHostTimeoutScheduled) {
+    // We scheduled a timeout but it's no longer needed. Cancel it.
+    isHostTimeoutScheduled = false;
+    cancelHostTimeout();
+  }
+
+  isPerformingWork = true;
+  var previousPriorityLevel = currentPriorityLevel;
+
+  try {
+    var currentTime; if (enableProfiling) ; else {
+      // No catch in prod code path.
+      return workLoop(hasTimeRemaining, initialTime);
+    }
+  } finally {
+    currentTask = null;
+    currentPriorityLevel = previousPriorityLevel;
+    isPerformingWork = false;
+  }
+}
+
+function workLoop(hasTimeRemaining, initialTime) {
+  var currentTime = initialTime;
+  advanceTimers(currentTime);
+  currentTask = peek(taskQueue);
+
+  while (currentTask !== null && !(enableSchedulerDebugging )) {
+    if (currentTask.expirationTime > currentTime && (!hasTimeRemaining || exports.unstable_shouldYield())) {
+      // This currentTask hasn't expired, and we've reached the deadline.
+      break;
+    }
+
+    var callback = currentTask.callback;
+
+    if (typeof callback === 'function') {
+      currentTask.callback = null;
+      currentPriorityLevel = currentTask.priorityLevel;
+      var didUserCallbackTimeout = currentTask.expirationTime <= currentTime;
+
+      var continuationCallback = callback(didUserCallbackTimeout);
+      currentTime = exports.unstable_now();
+
+      if (typeof continuationCallback === 'function') {
+        currentTask.callback = continuationCallback;
+      } else {
+
+        if (currentTask === peek(taskQueue)) {
+          pop(taskQueue);
+        }
+      }
+
+      advanceTimers(currentTime);
+    } else {
+      pop(taskQueue);
+    }
+
+    currentTask = peek(taskQueue);
+  } // Return whether there's additional work
+
+
+  if (currentTask !== null) {
+    return true;
+  } else {
+    var firstTimer = peek(timerQueue);
+
+    if (firstTimer !== null) {
+      requestHostTimeout(handleTimeout, firstTimer.startTime - currentTime);
+    }
+
+    return false;
+  }
+}
+
+function unstable_runWithPriority(priorityLevel, eventHandler) {
+  switch (priorityLevel) {
+    case ImmediatePriority:
+    case UserBlockingPriority:
+    case NormalPriority:
+    case LowPriority:
+    case IdlePriority:
+      break;
+
+    default:
+      priorityLevel = NormalPriority;
+  }
+
+  var previousPriorityLevel = currentPriorityLevel;
+  currentPriorityLevel = priorityLevel;
+
+  try {
+    return eventHandler();
+  } finally {
+    currentPriorityLevel = previousPriorityLevel;
+  }
+}
+
+function unstable_next(eventHandler) {
+  var priorityLevel;
+
+  switch (currentPriorityLevel) {
+    case ImmediatePriority:
+    case UserBlockingPriority:
+    case NormalPriority:
+      // Shift down to normal priority
+      priorityLevel = NormalPriority;
+      break;
+
+    default:
+      // Anything lower than normal priority should remain at the current level.
+      priorityLevel = currentPriorityLevel;
+      break;
+  }
+
+  var previousPriorityLevel = currentPriorityLevel;
+  currentPriorityLevel = priorityLevel;
+
+  try {
+    return eventHandler();
+  } finally {
+    currentPriorityLevel = previousPriorityLevel;
+  }
+}
+
+function unstable_wrapCallback(callback) {
+  var parentPriorityLevel = currentPriorityLevel;
+  return function () {
+    // This is a fork of runWithPriority, inlined for performance.
+    var previousPriorityLevel = currentPriorityLevel;
+    currentPriorityLevel = parentPriorityLevel;
+
+    try {
+      return callback.apply(this, arguments);
+    } finally {
+      currentPriorityLevel = previousPriorityLevel;
+    }
+  };
+}
+
+function unstable_scheduleCallback(priorityLevel, callback, options) {
+  var currentTime = exports.unstable_now();
+  var startTime;
+
+  if (typeof options === 'object' && options !== null) {
+    var delay = options.delay;
+
+    if (typeof delay === 'number' && delay > 0) {
+      startTime = currentTime + delay;
+    } else {
+      startTime = currentTime;
+    }
+  } else {
+    startTime = currentTime;
+  }
+
+  var timeout;
+
+  switch (priorityLevel) {
+    case ImmediatePriority:
+      timeout = IMMEDIATE_PRIORITY_TIMEOUT;
+      break;
+
+    case UserBlockingPriority:
+      timeout = USER_BLOCKING_PRIORITY_TIMEOUT;
+      break;
+
+    case IdlePriority:
+      timeout = IDLE_PRIORITY_TIMEOUT;
+      break;
+
+    case LowPriority:
+      timeout = LOW_PRIORITY_TIMEOUT;
+      break;
+
+    case NormalPriority:
+    default:
+      timeout = NORMAL_PRIORITY_TIMEOUT;
+      break;
+  }
+
+  var expirationTime = startTime + timeout;
+  var newTask = {
+    id: taskIdCounter++,
+    callback: callback,
+    priorityLevel: priorityLevel,
+    startTime: startTime,
+    expirationTime: expirationTime,
+    sortIndex: -1
+  };
+
+  if (startTime > currentTime) {
+    // This is a delayed task.
+    newTask.sortIndex = startTime;
+    push(timerQueue, newTask);
+
+    if (peek(taskQueue) === null && newTask === peek(timerQueue)) {
+      // All tasks are delayed, and this is the task with the earliest delay.
+      if (isHostTimeoutScheduled) {
+        // Cancel an existing timeout.
+        cancelHostTimeout();
+      } else {
+        isHostTimeoutScheduled = true;
+      } // Schedule a timeout.
+
+
+      requestHostTimeout(handleTimeout, startTime - currentTime);
+    }
+  } else {
+    newTask.sortIndex = expirationTime;
+    push(taskQueue, newTask);
+    // wait until the next time we yield.
+
+
+    if (!isHostCallbackScheduled && !isPerformingWork) {
+      isHostCallbackScheduled = true;
+      requestHostCallback(flushWork);
+    }
+  }
+
+  return newTask;
+}
+
+function unstable_pauseExecution() {
+}
+
+function unstable_continueExecution() {
+
+  if (!isHostCallbackScheduled && !isPerformingWork) {
+    isHostCallbackScheduled = true;
+    requestHostCallback(flushWork);
+  }
+}
+
+function unstable_getFirstCallbackNode() {
+  return peek(taskQueue);
+}
+
+function unstable_cancelCallback(task) {
+  // remove from the queue because you can't remove arbitrary nodes from an
+  // array based heap, only the first one.)
+
+
+  task.callback = null;
+}
+
+function unstable_getCurrentPriorityLevel() {
+  return currentPriorityLevel;
+}
+
+var unstable_requestPaint = requestPaint;
+var unstable_Profiling =  null;
+
+exports.unstable_IdlePriority = IdlePriority;
+exports.unstable_ImmediatePriority = ImmediatePriority;
+exports.unstable_LowPriority = LowPriority;
+exports.unstable_NormalPriority = NormalPriority;
+exports.unstable_Profiling = unstable_Profiling;
+exports.unstable_UserBlockingPriority = UserBlockingPriority;
+exports.unstable_cancelCallback = unstable_cancelCallback;
+exports.unstable_continueExecution = unstable_continueExecution;
+exports.unstable_getCurrentPriorityLevel = unstable_getCurrentPriorityLevel;
+exports.unstable_getFirstCallbackNode = unstable_getFirstCallbackNode;
+exports.unstable_next = unstable_next;
+exports.unstable_pauseExecution = unstable_pauseExecution;
+exports.unstable_requestPaint = unstable_requestPaint;
+exports.unstable_runWithPriority = unstable_runWithPriority;
+exports.unstable_scheduleCallback = unstable_scheduleCallback;
+exports.unstable_wrapCallback = unstable_wrapCallback;
+  })();
+}
+});
+
+var scheduler = createCommonjsModule(function (module) {
+
+if (process$1.env.NODE_ENV === 'production') {
+  module.exports = scheduler_production_min;
+} else {
+  module.exports = scheduler_development;
+}
+});
+
+/** @license React v17.0.2
+ * react-dom-test-utils.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var reactDomTestUtils_production_min = createCommonjsModule(function (module, exports) {
+function p(a){for(var b="https://reactjs.org/docs/error-decoder.html?invariant="+a,c=1;c<arguments.length;c++)b+="&args[]="+encodeURIComponent(arguments[c]);return "Minified React error #"+a+"; visit "+b+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}var q=l__default.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+function r(a){var b=a,c=a;if(a.alternate)for(;b.return;)b=b.return;else {a=b;do b=a,0!==(b.flags&1026)&&(c=b.return),a=b.return;while(a)}return 3===b.tag?c:null}function t(a){if(r(a)!==a)throw Error(p(188));}
+function aa(a){var b=a.alternate;if(!b){b=r(a);if(null===b)throw Error(p(188));return b!==a?null:a}for(var c=a,d=b;;){var e=c.return;if(null===e)break;var g=e.alternate;if(null===g){d=e.return;if(null!==d){c=d;continue}break}if(e.child===g.child){for(g=e.child;g;){if(g===c)return t(e),a;if(g===d)return t(e),b;g=g.sibling;}throw Error(p(188));}if(c.return!==d.return)c=e,d=g;else {for(var f=!1,k=e.child;k;){if(k===c){f=!0;c=e;d=g;break}if(k===d){f=!0;d=e;c=g;break}k=k.sibling;}if(!f){for(k=g.child;k;){if(k===
+c){f=!0;c=g;d=e;break}if(k===d){f=!0;d=g;c=e;break}k=k.sibling;}if(!f)throw Error(p(189));}}if(c.alternate!==d)throw Error(p(190));}if(3!==c.tag)throw Error(p(188));return c.stateNode.current===c?a:b}function u(a){var b=a.keyCode;"charCode"in a?(a=a.charCode,0===a&&13===b&&(a=13)):a=b;10===a&&(a=13);return 32<=a||13===a?a:0}function v(){return !0}function w(){return !1}
+function x(a){function b(c,b,e,g,f){this._reactName=c;this._targetInst=e;this.type=b;this.nativeEvent=g;this.target=f;this.currentTarget=null;for(var d in a)a.hasOwnProperty(d)&&(c=a[d],this[d]=c?c(g):g[d]);this.isDefaultPrevented=(null!=g.defaultPrevented?g.defaultPrevented:!1===g.returnValue)?v:w;this.isPropagationStopped=w;return this}objectAssign(b.prototype,{preventDefault:function(){this.defaultPrevented=!0;var a=this.nativeEvent;a&&(a.preventDefault?a.preventDefault():"unknown"!==typeof a.returnValue&&
+(a.returnValue=!1),this.isDefaultPrevented=v);},stopPropagation:function(){var a=this.nativeEvent;a&&(a.stopPropagation?a.stopPropagation():"unknown"!==typeof a.cancelBubble&&(a.cancelBubble=!0),this.isPropagationStopped=v);},persist:function(){},isPersistent:v});return b}var y={eventPhase:0,bubbles:0,cancelable:0,timeStamp:function(a){return a.timeStamp||Date.now()},defaultPrevented:0,isTrusted:0},ba=x(y),z=objectAssign({},y,{view:0,detail:0});x(z);
+var A,B,C,E=objectAssign({},z,{screenX:0,screenY:0,clientX:0,clientY:0,pageX:0,pageY:0,ctrlKey:0,shiftKey:0,altKey:0,metaKey:0,getModifierState:D,button:0,buttons:0,relatedTarget:function(a){return void 0===a.relatedTarget?a.fromElement===a.srcElement?a.toElement:a.fromElement:a.relatedTarget},movementX:function(a){if("movementX"in a)return a.movementX;a!==C&&(C&&"mousemove"===a.type?(A=a.screenX-C.screenX,B=a.screenY-C.screenY):B=A=0,C=a);return A},movementY:function(a){return "movementY"in a?a.movementY:B}});
+x(E);var da=objectAssign({},E,{dataTransfer:0});x(da);var ea=objectAssign({},z,{relatedTarget:0});x(ea);var fa=objectAssign({},y,{animationName:0,elapsedTime:0,pseudoElement:0});x(fa);var ha=objectAssign({},y,{clipboardData:function(a){return "clipboardData"in a?a.clipboardData:window.clipboardData}});x(ha);var ia=objectAssign({},y,{data:0});x(ia);
+var ja={Esc:"Escape",Spacebar:" ",Left:"ArrowLeft",Up:"ArrowUp",Right:"ArrowRight",Down:"ArrowDown",Del:"Delete",Win:"OS",Menu:"ContextMenu",Apps:"ContextMenu",Scroll:"ScrollLock",MozPrintableKey:"Unidentified"},ka={8:"Backspace",9:"Tab",12:"Clear",13:"Enter",16:"Shift",17:"Control",18:"Alt",19:"Pause",20:"CapsLock",27:"Escape",32:" ",33:"PageUp",34:"PageDown",35:"End",36:"Home",37:"ArrowLeft",38:"ArrowUp",39:"ArrowRight",40:"ArrowDown",45:"Insert",46:"Delete",112:"F1",113:"F2",114:"F3",115:"F4",
+116:"F5",117:"F6",118:"F7",119:"F8",120:"F9",121:"F10",122:"F11",123:"F12",144:"NumLock",145:"ScrollLock",224:"Meta"},la={Alt:"altKey",Control:"ctrlKey",Meta:"metaKey",Shift:"shiftKey"};function ma(a){var b=this.nativeEvent;return b.getModifierState?b.getModifierState(a):(a=la[a])?!!b[a]:!1}function D(){return ma}
+var na=objectAssign({},z,{key:function(a){if(a.key){var b=ja[a.key]||a.key;if("Unidentified"!==b)return b}return "keypress"===a.type?(a=u(a),13===a?"Enter":String.fromCharCode(a)):"keydown"===a.type||"keyup"===a.type?ka[a.keyCode]||"Unidentified":""},code:0,location:0,ctrlKey:0,shiftKey:0,altKey:0,metaKey:0,repeat:0,locale:0,getModifierState:D,charCode:function(a){return "keypress"===a.type?u(a):0},keyCode:function(a){return "keydown"===a.type||"keyup"===a.type?a.keyCode:0},which:function(a){return "keypress"===
+a.type?u(a):"keydown"===a.type||"keyup"===a.type?a.keyCode:0}});x(na);var oa=objectAssign({},E,{pointerId:0,width:0,height:0,pressure:0,tangentialPressure:0,tiltX:0,tiltY:0,twist:0,pointerType:0,isPrimary:0});x(oa);var pa=objectAssign({},z,{touches:0,targetTouches:0,changedTouches:0,altKey:0,metaKey:0,ctrlKey:0,shiftKey:0,getModifierState:D});x(pa);var qa=objectAssign({},y,{propertyName:0,elapsedTime:0,pseudoElement:0});x(qa);
+var ra=objectAssign({},E,{deltaX:function(a){return "deltaX"in a?a.deltaX:"wheelDeltaX"in a?-a.wheelDeltaX:0},deltaY:function(a){return "deltaY"in a?a.deltaY:"wheelDeltaY"in a?-a.wheelDeltaY:"wheelDelta"in a?-a.wheelDelta:0},deltaZ:0,deltaMode:0});x(ra);var F=null;function G(a){if(null===F)try{var b=("require"+Math.random()).slice(0,7);F=(module&&module[b]).call(module,"timers").setImmediate;}catch(c){F=function(a){var b=new MessageChannel;b.port1.onmessage=a;b.port2.postMessage(void 0);};}return F(a)}
+var H=m$1.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events,sa=H[5],I=H[6],ta=m$1.unstable_batchedUpdates,J=q.IsSomeRendererActing,K="function"===typeof scheduler.unstable_flushAllWithoutAsserting,L=scheduler.unstable_flushAllWithoutAsserting||function(){for(var a=!1;sa();)a=!0;return a};function M(a){try{L(),G(function(){L()?M(a):a();});}catch(b){a(b);}}var N=0,ua=!1,O=m$1.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events[6],va=m$1.unstable_batchedUpdates,Q=q.IsSomeRendererActing;
+function wa(a,b){jest.runOnlyPendingTimers();G(function(){try{scheduler.unstable_flushAllWithoutAsserting()?wa(a,b):a();}catch(c){b(c);}});}function xa(a,b,c,d,e,g,f,k,ca){var P=Array.prototype.slice.call(arguments,3);try{b.apply(c,P);}catch(Ga){this.onError(Ga);}}var R=!1,S=null,T=!1,U=null,ya={onError:function(a){R=!0;S=a;}};function za(a,b,c,d,e,g,f,k,ca){R=!1;S=null;xa.apply(ya,arguments);}
+function Aa(a,b,c,d,e,g,f,k,ca){za.apply(this,arguments);if(R){if(R){var P=S;R=!1;S=null;}else throw Error(p(198));T||(T=!0,U=P);}}var V=m$1.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events,Ba=V[0],Ca=V[1],Da=V[2],Ea=V[3],Fa=V[4];function Ha(){}
+function Ia(a,b){if(!a)return [];a=aa(a);if(!a)return [];for(var c=a,d=[];;){if(5===c.tag||6===c.tag||1===c.tag||0===c.tag){var e=c.stateNode;b(e)&&d.push(e);}if(c.child)c.child.return=c,c=c.child;else {if(c===a)return d;for(;!c.sibling;){if(!c.return||c.return===a)return d;c=c.return;}c.sibling.return=c.return;c=c.sibling;}}}
+function W(a,b){if(a&&!a._reactInternals){var c=""+a;a=Array.isArray(a)?"an array":a&&1===a.nodeType&&a.tagName?"a DOM node":"[object Object]"===c?"object with keys {"+Object.keys(a).join(", ")+"}":c;throw Error(p(286,b,a));}}function X(a){return !(!a||1!==a.nodeType||!a.tagName)}function Y(a){return X(a)?!1:null!=a&&"function"===typeof a.render&&"function"===typeof a.setState}function Ja(a,b){return Y(a)?a._reactInternals.type===b:!1}
+function Z(a,b){W(a,"findAllInRenderedTree");return a?Ia(a._reactInternals,b):[]}function Ka(a,b){W(a,"scryRenderedDOMComponentsWithClass");return Z(a,function(a){if(X(a)){var c=a.className;"string"!==typeof c&&(c=a.getAttribute("class")||"");var e=c.split(/\s+/);if(!Array.isArray(b)){if(void 0===b)throw Error(p(11));b=b.split(/\s+/);}return b.every(function(a){return -1!==e.indexOf(a)})}return !1})}
+function La(a,b){W(a,"scryRenderedDOMComponentsWithTag");return Z(a,function(a){return X(a)&&a.tagName.toUpperCase()===b.toUpperCase()})}function Ma(a,b){W(a,"scryRenderedComponentsWithType");return Z(a,function(a){return Ja(a,b)})}function Na(a,b,c){var d=a.type||"unknown-event";a.currentTarget=Ca(c);Aa(d,b,void 0,a);a.currentTarget=null;}
+function Oa(a,b,c){for(var d=[];a;){d.push(a);do a=a.return;while(a&&5!==a.tag);a=a?a:null;}for(a=d.length;0<a--;)b(d[a],"captured",c);for(a=0;a<d.length;a++)b(d[a],"bubbled",c);}
+function Pa(a,b){var c=a.stateNode;if(!c)return null;var d=Da(c);if(!d)return null;c=d[b];a:switch(b){case "onClick":case "onClickCapture":case "onDoubleClick":case "onDoubleClickCapture":case "onMouseDown":case "onMouseDownCapture":case "onMouseMove":case "onMouseMoveCapture":case "onMouseUp":case "onMouseUpCapture":case "onMouseEnter":(d=!d.disabled)||(a=a.type,d=!("button"===a||"input"===a||"select"===a||"textarea"===a));a=!d;break a;default:a=!1;}if(a)return null;if(c&&"function"!==typeof c)throw Error(p(231,
+b,typeof c));return c}function Qa(a,b,c){a&&c&&c._reactName&&(b=Pa(a,c._reactName))&&(null==c._dispatchListeners&&(c._dispatchListeners=[]),null==c._dispatchInstances&&(c._dispatchInstances=[]),c._dispatchListeners.push(b),c._dispatchInstances.push(a));}
+function Ra(a,b,c){var d=c._reactName;"captured"===b&&(d+="Capture");if(b=Pa(a,d))null==c._dispatchListeners&&(c._dispatchListeners=[]),null==c._dispatchInstances&&(c._dispatchInstances=[]),c._dispatchListeners.push(b),c._dispatchInstances.push(a);}var Sa={},Ta=new Set(["mouseEnter","mouseLeave","pointerEnter","pointerLeave"]);
+function Ua(a){return function(b,c){if(l__default.isValidElement(b))throw Error(p(228));if(Y(b))throw Error(p(229));var d="on"+a[0].toUpperCase()+a.slice(1),e=new Ha;e.target=b;e.type=a.toLowerCase();var g=Ba(b),f=new ba(d,e.type,g,e,b);f.persist();objectAssign(f,c);Ta.has(a)?f&&f._reactName&&Qa(f._targetInst,null,f):f&&f._reactName&&Oa(f._targetInst,Ra,f);m$1.unstable_batchedUpdates(function(){Ea(b);if(f){var a=f._dispatchListeners,c=f._dispatchInstances;if(Array.isArray(a))for(var d=0;d<a.length&&!f.isPropagationStopped();d++)Na(f,
+a[d],c[d]);else a&&Na(f,a,c);f._dispatchListeners=null;f._dispatchInstances=null;f.isPersistent()||f.constructor.release(f);}if(T)throw a=U,T=!1,U=null,a;});Fa();}}
+"blur cancel click close contextMenu copy cut auxClick doubleClick dragEnd dragStart drop focus input invalid keyDown keyPress keyUp mouseDown mouseUp paste pause play pointerCancel pointerDown pointerUp rateChange reset seeked submit touchCancel touchEnd touchStart volumeChange drag dragEnter dragExit dragLeave dragOver mouseMove mouseOut mouseOver pointerMove pointerOut pointerOver scroll toggle touchMove wheel abort animationEnd animationIteration animationStart canPlay canPlayThrough durationChange emptied encrypted ended error gotPointerCapture load loadedData loadedMetadata loadStart lostPointerCapture playing progress seeking stalled suspend timeUpdate transitionEnd waiting mouseEnter mouseLeave pointerEnter pointerLeave change select beforeInput compositionEnd compositionStart compositionUpdate".split(" ").forEach(function(a){Sa[a]=Ua(a);});
+exports.Simulate=Sa;
+exports.act=function(a){function b(){N--;J.current=c;I.current=d;}!1===ua&&(ua=!0,console.error("act(...) is not supported in production builds of React, and might not behave as expected."));N++;var c=J.current,d=I.current;J.current=!0;I.current=!0;try{var e=ta(a);}catch(g){throw b(),g;}if(null!==e&&"object"===typeof e&&"function"===typeof e.then)return {then:function(a,d){e.then(function(){1<N||!0===K&&!0===c?(b(),a()):M(function(c){b();c?d(c):a();});},function(a){b();d(a);});}};try{1!==N||!1!==K&&!1!==
+c||L(),b();}catch(g){throw b(),g;}return {then:function(a){a();}}};exports.findAllInRenderedTree=Z;exports.findRenderedComponentWithType=function(a,b){W(a,"findRenderedComponentWithType");a=Ma(a,b);if(1!==a.length)throw Error("Did not find exactly one match (found: "+a.length+") for componentType:"+b);return a[0]};
+exports.findRenderedDOMComponentWithClass=function(a,b){W(a,"findRenderedDOMComponentWithClass");a=Ka(a,b);if(1!==a.length)throw Error("Did not find exactly one match (found: "+a.length+") for class:"+b);return a[0]};exports.findRenderedDOMComponentWithTag=function(a,b){W(a,"findRenderedDOMComponentWithTag");a=La(a,b);if(1!==a.length)throw Error("Did not find exactly one match (found: "+a.length+") for tag:"+b);return a[0]};exports.isCompositeComponent=Y;exports.isCompositeComponentWithType=Ja;
+exports.isDOMComponent=X;exports.isDOMComponentElement=function(a){return !!(a&&l__default.isValidElement(a)&&a.tagName)};exports.isElement=function(a){return l__default.isValidElement(a)};exports.isElementOfType=function(a,b){return l__default.isValidElement(a)&&a.type===b};exports.mockComponent=function(a,b){b=b||a.mockTagName||"div";a.prototype.render.mockImplementation(function(){return l__default.createElement(b,null,this.props.children)});return this};exports.nativeTouchData=function(a,b){return {touches:[{pageX:a,pageY:b}]}};
+exports.renderIntoDocument=function(a){var b=document.createElement("div");return m$1.render(a,b)};exports.scryRenderedComponentsWithType=Ma;exports.scryRenderedDOMComponentsWithClass=Ka;exports.scryRenderedDOMComponentsWithTag=La;exports.traverseTwoPhase=Oa;
+exports.unstable_concurrentAct=function(a){function b(){Q.current=c;O.current=d;}if(void 0===scheduler.unstable_flushAllWithoutAsserting)throw Error("This version of `act` requires a special mock build of Scheduler.");if(!0!==setTimeout._isMockFunction)throw Error("This version of `act` requires Jest's timer mocks (i.e. jest.useFakeTimers).");var c=Q.current,d=O.current;Q.current=!0;O.current=!0;try{var e=va(a);if("object"===typeof e&&null!==e&&"function"===typeof e.then)return {then:function(a,c){e.then(function(){wa(function(){b();
+a();},function(a){b();c(a);});},function(a){b();c(a);});}};try{do var g=scheduler.unstable_flushAllWithoutAsserting();while(g)}finally{b();}}catch(f){throw b(),f;}};
+});
+
+var reactDomTestUtils_development = createCommonjsModule(function (module, exports) {
+
+if (process$1.env.NODE_ENV !== "production") {
+  (function() {
+
+var _assign = objectAssign;
+var React = l__default;
+var ReactDOM = m$1;
+var Scheduler = scheduler;
+
+var ReactSharedInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+
+// by calls to these methods by a Babel plugin.
+//
+// In PROD (or in packages without access to React internals),
+// they are left as they are instead.
+
+function warn(format) {
+  {
+    for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+      args[_key - 1] = arguments[_key];
+    }
+
+    printWarning('warn', format, args);
+  }
+}
+function error(format) {
+  {
+    for (var _len2 = arguments.length, args = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
+      args[_key2 - 1] = arguments[_key2];
+    }
+
+    printWarning('error', format, args);
+  }
+}
+
+function printWarning(level, format, args) {
+  // When changing this logic, you might want to also
+  // update consoleWithStackDev.www.js as well.
+  {
+    var ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
+    var stack = ReactDebugCurrentFrame.getStackAddendum();
+
+    if (stack !== '') {
+      format += '%s';
+      args = args.concat([stack]);
+    }
+
+    var argsWithFormat = args.map(function (item) {
+      return '' + item;
+    }); // Careful: RN currently depends on this prefix
+
+    argsWithFormat.unshift('Warning: ' + format); // We intentionally don't use spread (or .apply) directly because it
+    // breaks IE9: https://github.com/facebook/react/issues/13610
+    // eslint-disable-next-line react-internal/no-production-logging
+
+    Function.prototype.apply.call(console[level], console, argsWithFormat);
+  }
+}
+
+/**
+ * `ReactInstanceMap` maintains a mapping from a public facing stateful
+ * instance (key) and the internal representation (value). This allows public
+ * methods to accept the user facing instance as an argument and map them back
+ * to internal methods.
+ *
+ * Note that this module is currently shared and assumed to be stateless.
+ * If this becomes an actual Map, that will break.
+ */
+function get(key) {
+  return key._reactInternals;
+}
+
+if (typeof Symbol === 'function' && Symbol.for) {
+  var symbolFor = Symbol.for;
+  symbolFor('react.element');
+  symbolFor('react.portal');
+  symbolFor('react.fragment');
+  symbolFor('react.strict_mode');
+  symbolFor('react.profiler');
+  symbolFor('react.provider');
+  symbolFor('react.context');
+  symbolFor('react.forward_ref');
+  symbolFor('react.suspense');
+  symbolFor('react.suspense_list');
+  symbolFor('react.memo');
+  symbolFor('react.lazy');
+  symbolFor('react.block');
+  symbolFor('react.server.block');
+  symbolFor('react.fundamental');
+  symbolFor('react.scope');
+  symbolFor('react.opaque.id');
+  symbolFor('react.debug_trace_mode');
+  symbolFor('react.offscreen');
+  symbolFor('react.legacy_hidden');
+}
+
+var FunctionComponent = 0;
+var ClassComponent = 1;
+
+var HostRoot = 3; // Root of a host tree. Could be nested inside another node.
+
+var HostComponent = 5;
+var HostText = 6;
+
+// Don't change these two values. They're used by React Dev Tools.
+var NoFlags =
+/*                      */
+0;
+
+var Placement =
+/*                    */
+2;
+var Hydrating =
+/*                    */
+1024;
+
+ReactSharedInternals.ReactCurrentOwner;
+function getNearestMountedFiber(fiber) {
+  var node = fiber;
+  var nearestMounted = fiber;
+
+  if (!fiber.alternate) {
+    // If there is no alternate, this might be a new tree that isn't inserted
+    // yet. If it is, then it will have a pending insertion effect on it.
+    var nextNode = node;
+
+    do {
+      node = nextNode;
+
+      if ((node.flags & (Placement | Hydrating)) !== NoFlags) {
+        // This is an insertion or in-progress hydration. The nearest possible
+        // mounted fiber is the parent but we need to continue to figure out
+        // if that one is still mounted.
+        nearestMounted = node.return;
+      }
+
+      nextNode = node.return;
+    } while (nextNode);
+  } else {
+    while (node.return) {
+      node = node.return;
+    }
+  }
+
+  if (node.tag === HostRoot) {
+    // TODO: Check if this was a nested HostRoot when used with
+    // renderContainerIntoSubtree.
+    return nearestMounted;
+  } // If we didn't hit the root, that means that we're in an disconnected tree
+  // that has been unmounted.
+
+
+  return null;
+}
+
+function assertIsMounted(fiber) {
+  if (!(getNearestMountedFiber(fiber) === fiber)) {
+    {
+      throw Error( "Unable to find node on an unmounted component." );
+    }
+  }
+}
+
+function findCurrentFiberUsingSlowPath(fiber) {
+  var alternate = fiber.alternate;
+
+  if (!alternate) {
+    // If there is no alternate, then we only need to check if it is mounted.
+    var nearestMounted = getNearestMountedFiber(fiber);
+
+    if (!(nearestMounted !== null)) {
+      {
+        throw Error( "Unable to find node on an unmounted component." );
+      }
+    }
+
+    if (nearestMounted !== fiber) {
+      return null;
+    }
+
+    return fiber;
+  } // If we have two possible branches, we'll walk backwards up to the root
+  // to see what path the root points to. On the way we may hit one of the
+  // special cases and we'll deal with them.
+
+
+  var a = fiber;
+  var b = alternate;
+
+  while (true) {
+    var parentA = a.return;
+
+    if (parentA === null) {
+      // We're at the root.
+      break;
+    }
+
+    var parentB = parentA.alternate;
+
+    if (parentB === null) {
+      // There is no alternate. This is an unusual case. Currently, it only
+      // happens when a Suspense component is hidden. An extra fragment fiber
+      // is inserted in between the Suspense fiber and its children. Skip
+      // over this extra fragment fiber and proceed to the next parent.
+      var nextParent = parentA.return;
+
+      if (nextParent !== null) {
+        a = b = nextParent;
+        continue;
+      } // If there's no parent, we're at the root.
+
+
+      break;
+    } // If both copies of the parent fiber point to the same child, we can
+    // assume that the child is current. This happens when we bailout on low
+    // priority: the bailed out fiber's child reuses the current child.
+
+
+    if (parentA.child === parentB.child) {
+      var child = parentA.child;
+
+      while (child) {
+        if (child === a) {
+          // We've determined that A is the current branch.
+          assertIsMounted(parentA);
+          return fiber;
+        }
+
+        if (child === b) {
+          // We've determined that B is the current branch.
+          assertIsMounted(parentA);
+          return alternate;
+        }
+
+        child = child.sibling;
+      } // We should never have an alternate for any mounting node. So the only
+      // way this could possibly happen is if this was unmounted, if at all.
+
+
+      {
+        {
+          throw Error( "Unable to find node on an unmounted component." );
+        }
+      }
+    }
+
+    if (a.return !== b.return) {
+      // The return pointer of A and the return pointer of B point to different
+      // fibers. We assume that return pointers never criss-cross, so A must
+      // belong to the child set of A.return, and B must belong to the child
+      // set of B.return.
+      a = parentA;
+      b = parentB;
+    } else {
+      // The return pointers point to the same fiber. We'll have to use the
+      // default, slow path: scan the child sets of each parent alternate to see
+      // which child belongs to which set.
+      //
+      // Search parent A's child set
+      var didFindChild = false;
+      var _child = parentA.child;
+
+      while (_child) {
+        if (_child === a) {
+          didFindChild = true;
+          a = parentA;
+          b = parentB;
+          break;
+        }
+
+        if (_child === b) {
+          didFindChild = true;
+          b = parentA;
+          a = parentB;
+          break;
+        }
+
+        _child = _child.sibling;
+      }
+
+      if (!didFindChild) {
+        // Search parent B's child set
+        _child = parentB.child;
+
+        while (_child) {
+          if (_child === a) {
+            didFindChild = true;
+            a = parentB;
+            b = parentA;
+            break;
+          }
+
+          if (_child === b) {
+            didFindChild = true;
+            b = parentB;
+            a = parentA;
+            break;
+          }
+
+          _child = _child.sibling;
+        }
+
+        if (!didFindChild) {
+          {
+            throw Error( "Child was not found in either parent set. This indicates a bug in React related to the return pointer. Please file an issue." );
+          }
+        }
+      }
+    }
+
+    if (!(a.alternate === b)) {
+      {
+        throw Error( "Return fibers should always be each others' alternates. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+  } // If the root is not a host container, we're in a disconnected tree. I.e.
+  // unmounted.
+
+
+  if (!(a.tag === HostRoot)) {
+    {
+      throw Error( "Unable to find node on an unmounted component." );
+    }
+  }
+
+  if (a.stateNode.current === a) {
+    // We've determined that A is the current branch.
+    return fiber;
+  } // Otherwise B has to be current branch.
+
+
+  return alternate;
+}
+
+/**
+ * `charCode` represents the actual "character code" and is safe to use with
+ * `String.fromCharCode`. As such, only keys that correspond to printable
+ * characters produce a valid `charCode`, the only exception to this is Enter.
+ * The Tab-key is considered non-printable and does not have a `charCode`,
+ * presumably because it does not produce a tab-character in browsers.
+ *
+ * @param {object} nativeEvent Native browser event.
+ * @return {number} Normalized `charCode` property.
+ */
+function getEventCharCode(nativeEvent) {
+  var charCode;
+  var keyCode = nativeEvent.keyCode;
+
+  if ('charCode' in nativeEvent) {
+    charCode = nativeEvent.charCode; // FF does not set `charCode` for the Enter-key, check against `keyCode`.
+
+    if (charCode === 0 && keyCode === 13) {
+      charCode = 13;
+    }
+  } else {
+    // IE8 does not implement `charCode`, but `keyCode` has the correct value.
+    charCode = keyCode;
+  } // IE and Edge (on Windows) and Chrome / Safari (on Windows and Linux)
+  // report Enter as charCode 10 when ctrl is pressed.
+
+
+  if (charCode === 10) {
+    charCode = 13;
+  } // Some non-printable keys are reported in `charCode`/`keyCode`, discard them.
+  // Must not discard the (non-)printable Enter-key.
+
+
+  if (charCode >= 32 || charCode === 13) {
+    return charCode;
+  }
+
+  return 0;
+}
+
+function functionThatReturnsTrue() {
+  return true;
+}
+
+function functionThatReturnsFalse() {
+  return false;
+} // This is intentionally a factory so that we have different returned constructors.
+// If we had a single constructor, it would be megamorphic and engines would deopt.
+
+
+function createSyntheticEvent(Interface) {
+  /**
+   * Synthetic events are dispatched by event plugins, typically in response to a
+   * top-level event delegation handler.
+   *
+   * These systems should generally use pooling to reduce the frequency of garbage
+   * collection. The system should check `isPersistent` to determine whether the
+   * event should be released into the pool after being dispatched. Users that
+   * need a persisted event should invoke `persist`.
+   *
+   * Synthetic events (and subclasses) implement the DOM Level 3 Events API by
+   * normalizing browser quirks. Subclasses do not necessarily have to implement a
+   * DOM interface; custom application-specific events can also subclass this.
+   */
+  function SyntheticBaseEvent(reactName, reactEventType, targetInst, nativeEvent, nativeEventTarget) {
+    this._reactName = reactName;
+    this._targetInst = targetInst;
+    this.type = reactEventType;
+    this.nativeEvent = nativeEvent;
+    this.target = nativeEventTarget;
+    this.currentTarget = null;
+
+    for (var _propName in Interface) {
+      if (!Interface.hasOwnProperty(_propName)) {
+        continue;
+      }
+
+      var normalize = Interface[_propName];
+
+      if (normalize) {
+        this[_propName] = normalize(nativeEvent);
+      } else {
+        this[_propName] = nativeEvent[_propName];
+      }
+    }
+
+    var defaultPrevented = nativeEvent.defaultPrevented != null ? nativeEvent.defaultPrevented : nativeEvent.returnValue === false;
+
+    if (defaultPrevented) {
+      this.isDefaultPrevented = functionThatReturnsTrue;
+    } else {
+      this.isDefaultPrevented = functionThatReturnsFalse;
+    }
+
+    this.isPropagationStopped = functionThatReturnsFalse;
+    return this;
+  }
+
+  _assign(SyntheticBaseEvent.prototype, {
+    preventDefault: function () {
+      this.defaultPrevented = true;
+      var event = this.nativeEvent;
+
+      if (!event) {
+        return;
+      }
+
+      if (event.preventDefault) {
+        event.preventDefault(); // $FlowFixMe - flow is not aware of `unknown` in IE
+      } else if (typeof event.returnValue !== 'unknown') {
+        event.returnValue = false;
+      }
+
+      this.isDefaultPrevented = functionThatReturnsTrue;
+    },
+    stopPropagation: function () {
+      var event = this.nativeEvent;
+
+      if (!event) {
+        return;
+      }
+
+      if (event.stopPropagation) {
+        event.stopPropagation(); // $FlowFixMe - flow is not aware of `unknown` in IE
+      } else if (typeof event.cancelBubble !== 'unknown') {
+        // The ChangeEventPlugin registers a "propertychange" event for
+        // IE. This event does not support bubbling or cancelling, and
+        // any references to cancelBubble throw "Member not found".  A
+        // typeof check of "unknown" circumvents this issue (and is also
+        // IE specific).
+        event.cancelBubble = true;
+      }
+
+      this.isPropagationStopped = functionThatReturnsTrue;
+    },
+
+    /**
+     * We release all dispatched `SyntheticEvent`s after each event loop, adding
+     * them back into the pool. This allows a way to hold onto a reference that
+     * won't be added back into the pool.
+     */
+    persist: function () {// Modern event system doesn't use pooling.
+    },
+
+    /**
+     * Checks if this event should be released back into the pool.
+     *
+     * @return {boolean} True if this should not be released, false otherwise.
+     */
+    isPersistent: functionThatReturnsTrue
+  });
+
+  return SyntheticBaseEvent;
+}
+/**
+ * @interface Event
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/
+ */
+
+
+var EventInterface = {
+  eventPhase: 0,
+  bubbles: 0,
+  cancelable: 0,
+  timeStamp: function (event) {
+    return event.timeStamp || Date.now();
+  },
+  defaultPrevented: 0,
+  isTrusted: 0
+};
+var SyntheticEvent = createSyntheticEvent(EventInterface);
+
+var UIEventInterface = _assign({}, EventInterface, {
+  view: 0,
+  detail: 0
+});
+
+createSyntheticEvent(UIEventInterface);
+var lastMovementX;
+var lastMovementY;
+var lastMouseEvent;
+
+function updateMouseMovementPolyfillState(event) {
+  if (event !== lastMouseEvent) {
+    if (lastMouseEvent && event.type === 'mousemove') {
+      lastMovementX = event.screenX - lastMouseEvent.screenX;
+      lastMovementY = event.screenY - lastMouseEvent.screenY;
+    } else {
+      lastMovementX = 0;
+      lastMovementY = 0;
+    }
+
+    lastMouseEvent = event;
+  }
+}
+/**
+ * @interface MouseEvent
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/
+ */
+
+
+var MouseEventInterface = _assign({}, UIEventInterface, {
+  screenX: 0,
+  screenY: 0,
+  clientX: 0,
+  clientY: 0,
+  pageX: 0,
+  pageY: 0,
+  ctrlKey: 0,
+  shiftKey: 0,
+  altKey: 0,
+  metaKey: 0,
+  getModifierState: getEventModifierState,
+  button: 0,
+  buttons: 0,
+  relatedTarget: function (event) {
+    if (event.relatedTarget === undefined) return event.fromElement === event.srcElement ? event.toElement : event.fromElement;
+    return event.relatedTarget;
+  },
+  movementX: function (event) {
+    if ('movementX' in event) {
+      return event.movementX;
+    }
+
+    updateMouseMovementPolyfillState(event);
+    return lastMovementX;
+  },
+  movementY: function (event) {
+    if ('movementY' in event) {
+      return event.movementY;
+    } // Don't need to call updateMouseMovementPolyfillState() here
+    // because it's guaranteed to have already run when movementX
+    // was copied.
+
+
+    return lastMovementY;
+  }
+});
+
+createSyntheticEvent(MouseEventInterface);
+/**
+ * @interface DragEvent
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/
+ */
+
+var DragEventInterface = _assign({}, MouseEventInterface, {
+  dataTransfer: 0
+});
+
+createSyntheticEvent(DragEventInterface);
+/**
+ * @interface FocusEvent
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/
+ */
+
+var FocusEventInterface = _assign({}, UIEventInterface, {
+  relatedTarget: 0
+});
+
+createSyntheticEvent(FocusEventInterface);
+/**
+ * @interface Event
+ * @see http://www.w3.org/TR/css3-animations/#AnimationEvent-interface
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/AnimationEvent
+ */
+
+var AnimationEventInterface = _assign({}, EventInterface, {
+  animationName: 0,
+  elapsedTime: 0,
+  pseudoElement: 0
+});
+
+createSyntheticEvent(AnimationEventInterface);
+/**
+ * @interface Event
+ * @see http://www.w3.org/TR/clipboard-apis/
+ */
+
+var ClipboardEventInterface = _assign({}, EventInterface, {
+  clipboardData: function (event) {
+    return 'clipboardData' in event ? event.clipboardData : window.clipboardData;
+  }
+});
+
+createSyntheticEvent(ClipboardEventInterface);
+/**
+ * @interface Event
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/#events-compositionevents
+ */
+
+var CompositionEventInterface = _assign({}, EventInterface, {
+  data: 0
+});
+
+createSyntheticEvent(CompositionEventInterface);
+/**
+ * Normalization of deprecated HTML5 `key` values
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Key_names
+ */
+
+var normalizeKey = {
+  Esc: 'Escape',
+  Spacebar: ' ',
+  Left: 'ArrowLeft',
+  Up: 'ArrowUp',
+  Right: 'ArrowRight',
+  Down: 'ArrowDown',
+  Del: 'Delete',
+  Win: 'OS',
+  Menu: 'ContextMenu',
+  Apps: 'ContextMenu',
+  Scroll: 'ScrollLock',
+  MozPrintableKey: 'Unidentified'
+};
+/**
+ * Translation from legacy `keyCode` to HTML5 `key`
+ * Only special keys supported, all others depend on keyboard layout or browser
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Key_names
+ */
+
+var translateToKey = {
+  '8': 'Backspace',
+  '9': 'Tab',
+  '12': 'Clear',
+  '13': 'Enter',
+  '16': 'Shift',
+  '17': 'Control',
+  '18': 'Alt',
+  '19': 'Pause',
+  '20': 'CapsLock',
+  '27': 'Escape',
+  '32': ' ',
+  '33': 'PageUp',
+  '34': 'PageDown',
+  '35': 'End',
+  '36': 'Home',
+  '37': 'ArrowLeft',
+  '38': 'ArrowUp',
+  '39': 'ArrowRight',
+  '40': 'ArrowDown',
+  '45': 'Insert',
+  '46': 'Delete',
+  '112': 'F1',
+  '113': 'F2',
+  '114': 'F3',
+  '115': 'F4',
+  '116': 'F5',
+  '117': 'F6',
+  '118': 'F7',
+  '119': 'F8',
+  '120': 'F9',
+  '121': 'F10',
+  '122': 'F11',
+  '123': 'F12',
+  '144': 'NumLock',
+  '145': 'ScrollLock',
+  '224': 'Meta'
+};
+/**
+ * @param {object} nativeEvent Native browser event.
+ * @return {string} Normalized `key` property.
+ */
+
+function getEventKey(nativeEvent) {
+  if (nativeEvent.key) {
+    // Normalize inconsistent values reported by browsers due to
+    // implementations of a working draft specification.
+    // FireFox implements `key` but returns `MozPrintableKey` for all
+    // printable characters (normalized to `Unidentified`), ignore it.
+    var key = normalizeKey[nativeEvent.key] || nativeEvent.key;
+
+    if (key !== 'Unidentified') {
+      return key;
+    }
+  } // Browser does not implement `key`, polyfill as much of it as we can.
+
+
+  if (nativeEvent.type === 'keypress') {
+    var charCode = getEventCharCode(nativeEvent); // The enter-key is technically both printable and non-printable and can
+    // thus be captured by `keypress`, no other non-printable key should.
+
+    return charCode === 13 ? 'Enter' : String.fromCharCode(charCode);
+  }
+
+  if (nativeEvent.type === 'keydown' || nativeEvent.type === 'keyup') {
+    // While user keyboard layout determines the actual meaning of each
+    // `keyCode` value, almost all function keys have a universal value.
+    return translateToKey[nativeEvent.keyCode] || 'Unidentified';
+  }
+
+  return '';
+}
+/**
+ * Translation from modifier key to the associated property in the event.
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/#keys-Modifiers
+ */
+
+
+var modifierKeyToProp = {
+  Alt: 'altKey',
+  Control: 'ctrlKey',
+  Meta: 'metaKey',
+  Shift: 'shiftKey'
+}; // Older browsers (Safari <= 10, iOS Safari <= 10.2) do not support
+// getModifierState. If getModifierState is not supported, we map it to a set of
+// modifier keys exposed by the event. In this case, Lock-keys are not supported.
+
+function modifierStateGetter(keyArg) {
+  var syntheticEvent = this;
+  var nativeEvent = syntheticEvent.nativeEvent;
+
+  if (nativeEvent.getModifierState) {
+    return nativeEvent.getModifierState(keyArg);
+  }
+
+  var keyProp = modifierKeyToProp[keyArg];
+  return keyProp ? !!nativeEvent[keyProp] : false;
+}
+
+function getEventModifierState(nativeEvent) {
+  return modifierStateGetter;
+}
+/**
+ * @interface KeyboardEvent
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/
+ */
+
+
+var KeyboardEventInterface = _assign({}, UIEventInterface, {
+  key: getEventKey,
+  code: 0,
+  location: 0,
+  ctrlKey: 0,
+  shiftKey: 0,
+  altKey: 0,
+  metaKey: 0,
+  repeat: 0,
+  locale: 0,
+  getModifierState: getEventModifierState,
+  // Legacy Interface
+  charCode: function (event) {
+    // `charCode` is the result of a KeyPress event and represents the value of
+    // the actual printable character.
+    // KeyPress is deprecated, but its replacement is not yet final and not
+    // implemented in any major browser. Only KeyPress has charCode.
+    if (event.type === 'keypress') {
+      return getEventCharCode(event);
+    }
+
+    return 0;
+  },
+  keyCode: function (event) {
+    // `keyCode` is the result of a KeyDown/Up event and represents the value of
+    // physical keyboard key.
+    // The actual meaning of the value depends on the users' keyboard layout
+    // which cannot be detected. Assuming that it is a US keyboard layout
+    // provides a surprisingly accurate mapping for US and European users.
+    // Due to this, it is left to the user to implement at this time.
+    if (event.type === 'keydown' || event.type === 'keyup') {
+      return event.keyCode;
+    }
+
+    return 0;
+  },
+  which: function (event) {
+    // `which` is an alias for either `keyCode` or `charCode` depending on the
+    // type of the event.
+    if (event.type === 'keypress') {
+      return getEventCharCode(event);
+    }
+
+    if (event.type === 'keydown' || event.type === 'keyup') {
+      return event.keyCode;
+    }
+
+    return 0;
+  }
+});
+
+createSyntheticEvent(KeyboardEventInterface);
+/**
+ * @interface PointerEvent
+ * @see http://www.w3.org/TR/pointerevents/
+ */
+
+var PointerEventInterface = _assign({}, MouseEventInterface, {
+  pointerId: 0,
+  width: 0,
+  height: 0,
+  pressure: 0,
+  tangentialPressure: 0,
+  tiltX: 0,
+  tiltY: 0,
+  twist: 0,
+  pointerType: 0,
+  isPrimary: 0
+});
+
+createSyntheticEvent(PointerEventInterface);
+/**
+ * @interface TouchEvent
+ * @see http://www.w3.org/TR/touch-events/
+ */
+
+var TouchEventInterface = _assign({}, UIEventInterface, {
+  touches: 0,
+  targetTouches: 0,
+  changedTouches: 0,
+  altKey: 0,
+  metaKey: 0,
+  ctrlKey: 0,
+  shiftKey: 0,
+  getModifierState: getEventModifierState
+});
+
+createSyntheticEvent(TouchEventInterface);
+/**
+ * @interface Event
+ * @see http://www.w3.org/TR/2009/WD-css3-transitions-20090320/#transition-events-
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/TransitionEvent
+ */
+
+var TransitionEventInterface = _assign({}, EventInterface, {
+  propertyName: 0,
+  elapsedTime: 0,
+  pseudoElement: 0
+});
+
+createSyntheticEvent(TransitionEventInterface);
+/**
+ * @interface WheelEvent
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/
+ */
+
+var WheelEventInterface = _assign({}, MouseEventInterface, {
+  deltaX: function (event) {
+    return 'deltaX' in event ? event.deltaX : // Fallback to `wheelDeltaX` for Webkit and normalize (right is positive).
+    'wheelDeltaX' in event ? -event.wheelDeltaX : 0;
+  },
+  deltaY: function (event) {
+    return 'deltaY' in event ? event.deltaY : // Fallback to `wheelDeltaY` for Webkit and normalize (down is positive).
+    'wheelDeltaY' in event ? -event.wheelDeltaY : // Fallback to `wheelDelta` for IE<9 and normalize (down is positive).
+    'wheelDelta' in event ? -event.wheelDelta : 0;
+  },
+  deltaZ: 0,
+  // Browsers without "deltaMode" is reporting in raw wheel delta where one
+  // notch on the scroll is always +/- 120, roughly equivalent to pixels.
+  // A good approximation of DOM_DELTA_LINE (1) is 5% of viewport size or
+  // ~40 pixels, for DOM_DELTA_SCREEN (2) it is 87.5% of viewport size.
+  deltaMode: 0
+});
+
+createSyntheticEvent(WheelEventInterface);
+
+/**
+ * HTML nodeType values that represent the type of the node
+ */
+var ELEMENT_NODE = 1;
+
+var didWarnAboutMessageChannel = false;
+var enqueueTaskImpl = null;
+function enqueueTask(task) {
+  if (enqueueTaskImpl === null) {
+    try {
+      // read require off the module object to get around the bundlers.
+      // we don't want them to detect a require and bundle a Node polyfill.
+      var requireString = ('require' + Math.random()).slice(0, 7);
+      var nodeRequire = module && module[requireString]; // assuming we're in node, let's try to get node's
+      // version of setImmediate, bypassing fake timers if any.
+
+      enqueueTaskImpl = nodeRequire.call(module, 'timers').setImmediate;
+    } catch (_err) {
+      // we're in a browser
+      // we can't use regular timers because they may still be faked
+      // so we try MessageChannel+postMessage instead
+      enqueueTaskImpl = function (callback) {
+        {
+          if (didWarnAboutMessageChannel === false) {
+            didWarnAboutMessageChannel = true;
+
+            if (typeof MessageChannel === 'undefined') {
+              error('This browser does not have a MessageChannel implementation, ' + 'so enqueuing tasks via await act(async () => ...) will fail. ' + 'Please file an issue at https://github.com/facebook/react/issues ' + 'if you encounter this warning.');
+            }
+          }
+        }
+
+        var channel = new MessageChannel();
+        channel.port1.onmessage = callback;
+        channel.port2.postMessage(undefined);
+      };
+    }
+  }
+
+  return enqueueTaskImpl(task);
+}
+
+var EventInternals = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events; // const getInstanceFromNode = EventInternals[0];
+// const getNodeFromInstance = EventInternals[1];
+// const getFiberCurrentPropsFromNode = EventInternals[2];
+// const enqueueStateRestore = EventInternals[3];
+// const restoreStateIfNeeded = EventInternals[4];
+
+var flushPassiveEffects = EventInternals[5];
+var IsThisRendererActing = EventInternals[6];
+var batchedUpdates = ReactDOM.unstable_batchedUpdates;
+var IsSomeRendererActing = ReactSharedInternals.IsSomeRendererActing; // This is the public version of `ReactTestUtils.act`. It is implemented in
+// "userspace" (i.e. not the reconciler), so that it doesn't add to the
+// production bundle size.
+// TODO: Remove this implementation of `act` in favor of the one exported by
+// the reconciler. To do this, we must first drop support for `act` in
+// production mode.
+// TODO: Remove support for the mock scheduler build, which was only added for
+// the purposes of internal testing. Internal tests should use
+// `unstable_concurrentAct` instead.
+
+var isSchedulerMocked = typeof Scheduler.unstable_flushAllWithoutAsserting === 'function';
+
+var flushWork = Scheduler.unstable_flushAllWithoutAsserting || function () {
+  var didFlushWork = false;
+
+  while (flushPassiveEffects()) {
+    didFlushWork = true;
+  }
+
+  return didFlushWork;
+};
+
+function flushWorkAndMicroTasks(onDone) {
+  try {
+    flushWork();
+    enqueueTask(function () {
+      if (flushWork()) {
+        flushWorkAndMicroTasks(onDone);
+      } else {
+        onDone();
+      }
+    });
+  } catch (err) {
+    onDone(err);
+  }
+} // we track the 'depth' of the act() calls with this counter,
+// so we can tell if any async act() calls try to run in parallel.
+
+
+var actingUpdatesScopeDepth = 0;
+function act(callback) {
+
+  var previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
+  actingUpdatesScopeDepth++;
+  var previousIsSomeRendererActing = IsSomeRendererActing.current;
+  var previousIsThisRendererActing = IsThisRendererActing.current;
+  IsSomeRendererActing.current = true;
+  IsThisRendererActing.current = true;
+
+  function onDone() {
+    actingUpdatesScopeDepth--;
+    IsSomeRendererActing.current = previousIsSomeRendererActing;
+    IsThisRendererActing.current = previousIsThisRendererActing;
+
+    {
+      if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
+        // if it's _less than_ previousActingUpdatesScopeDepth, then we can assume the 'other' one has warned
+        error('You seem to have overlapping act() calls, this is not supported. ' + 'Be sure to await previous act() calls before making a new one. ');
+      }
+    }
+  }
+
+  var result;
+
+  try {
+    result = batchedUpdates(callback);
+  } catch (error) {
+    // on sync errors, we still want to 'cleanup' and decrement actingUpdatesScopeDepth
+    onDone();
+    throw error;
+  }
+
+  if (result !== null && typeof result === 'object' && typeof result.then === 'function') {
+    // setup a boolean that gets set to true only
+    // once this act() call is await-ed
+    var called = false;
+
+    {
+      if (typeof Promise !== 'undefined') {
+        //eslint-disable-next-line no-undef
+        Promise.resolve().then(function () {}).then(function () {
+          if (called === false) {
+            error('You called act(async () => ...) without await. ' + 'This could lead to unexpected testing behaviour, interleaving multiple act ' + 'calls and mixing their scopes. You should - await act(async () => ...);');
+          }
+        });
+      }
+    } // in the async case, the returned thenable runs the callback, flushes
+    // effects and  microtasks in a loop until flushPassiveEffects() === false,
+    // and cleans up
+
+
+    return {
+      then: function (resolve, reject) {
+        called = true;
+        result.then(function () {
+          if (actingUpdatesScopeDepth > 1 || isSchedulerMocked === true && previousIsSomeRendererActing === true) {
+            onDone();
+            resolve();
+            return;
+          } // we're about to exit the act() scope,
+          // now's the time to flush tasks/effects
+
+
+          flushWorkAndMicroTasks(function (err) {
+            onDone();
+
+            if (err) {
+              reject(err);
+            } else {
+              resolve();
+            }
+          });
+        }, function (err) {
+          onDone();
+          reject(err);
+        });
+      }
+    };
+  } else {
+    {
+      if (result !== undefined) {
+        error('The callback passed to act(...) function ' + 'must return undefined, or a Promise. You returned %s', result);
+      }
+    } // flush effects until none remain, and cleanup
+
+
+    try {
+      if (actingUpdatesScopeDepth === 1 && (isSchedulerMocked === false || previousIsSomeRendererActing === false)) {
+        // we're about to exit the act() scope,
+        // now's the time to flush effects
+        flushWork();
+      }
+
+      onDone();
+    } catch (err) {
+      onDone();
+      throw err;
+    } // in the sync case, the returned thenable only warns *if* await-ed
+
+
+    return {
+      then: function (resolve) {
+        {
+          error('Do not await the result of calling act(...) with sync logic, it is not a Promise.');
+        }
+
+        resolve();
+      }
+    };
+  }
+}
+
+var EventInternals$1 = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events; // const getInstanceFromNode = EventInternals[0];
+// const getNodeFromInstance = EventInternals[1];
+// const getFiberCurrentPropsFromNode = EventInternals[2];
+// const enqueueStateRestore = EventInternals[3];
+// const restoreStateIfNeeded = EventInternals[4];
+// const flushPassiveEffects = EventInternals[5];
+
+var IsThisRendererActing$1 = EventInternals$1[6];
+var batchedUpdates$1 = ReactDOM.unstable_batchedUpdates;
+var IsSomeRendererActing$1 = ReactSharedInternals.IsSomeRendererActing; // This version of `act` is only used by our tests. Unlike the public version
+// of `act`, it's designed to work identically in both production and
+// development. It may have slightly different behavior from the public
+// version, too, since our constraints in our test suite are not the same as
+// those of developers using React — we're testing React itself, as opposed to
+// building an app with React.
+
+var actingUpdatesScopeDepth$1 = 0;
+function unstable_concurrentAct(scope) {
+  if (Scheduler.unstable_flushAllWithoutAsserting === undefined) {
+    throw Error('This version of `act` requires a special mock build of Scheduler.');
+  }
+
+  if (setTimeout._isMockFunction !== true) {
+    throw Error("This version of `act` requires Jest's timer mocks " + '(i.e. jest.useFakeTimers).');
+  }
+
+  var previousActingUpdatesScopeDepth = actingUpdatesScopeDepth$1;
+  var previousIsSomeRendererActing = IsSomeRendererActing$1.current;
+  var previousIsThisRendererActing = IsThisRendererActing$1.current;
+  IsSomeRendererActing$1.current = true;
+  IsThisRendererActing$1.current = true;
+  actingUpdatesScopeDepth$1++;
+
+  var unwind = function () {
+    actingUpdatesScopeDepth$1--;
+    IsSomeRendererActing$1.current = previousIsSomeRendererActing;
+    IsThisRendererActing$1.current = previousIsThisRendererActing;
+
+    {
+      if (actingUpdatesScopeDepth$1 > previousActingUpdatesScopeDepth) {
+        // if it's _less than_ previousActingUpdatesScopeDepth, then we can
+        // assume the 'other' one has warned
+        error('You seem to have overlapping act() calls, this is not supported. ' + 'Be sure to await previous act() calls before making a new one. ');
+      }
+    }
+  }; // TODO: This would be way simpler if 1) we required a promise to be
+  // returned and 2) we could use async/await. Since it's only our used in
+  // our test suite, we should be able to.
+
+
+  try {
+    var thenable = batchedUpdates$1(scope);
+
+    if (typeof thenable === 'object' && thenable !== null && typeof thenable.then === 'function') {
+      return {
+        then: function (resolve, reject) {
+          thenable.then(function () {
+            flushActWork(function () {
+              unwind();
+              resolve();
+            }, function (error) {
+              unwind();
+              reject(error);
+            });
+          }, function (error) {
+            unwind();
+            reject(error);
+          });
+        }
+      };
+    } else {
+      try {
+        // TODO: Let's not support non-async scopes at all in our tests. Need to
+        // migrate existing tests.
+        var didFlushWork;
+
+        do {
+          didFlushWork = Scheduler.unstable_flushAllWithoutAsserting();
+        } while (didFlushWork);
+      } finally {
+        unwind();
+      }
+    }
+  } catch (error) {
+    unwind();
+    throw error;
+  }
+}
+
+function flushActWork(resolve, reject) {
+  // Flush suspended fallbacks
+  // $FlowFixMe: Flow doesn't know about global Jest object
+  jest.runOnlyPendingTimers();
+  enqueueTask(function () {
+    try {
+      var didFlushWork = Scheduler.unstable_flushAllWithoutAsserting();
+
+      if (didFlushWork) {
+        flushActWork(resolve, reject);
+      } else {
+        resolve();
+      }
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+function invokeGuardedCallbackProd(name, func, context, a, b, c, d, e, f) {
+  var funcArgs = Array.prototype.slice.call(arguments, 3);
+
+  try {
+    func.apply(context, funcArgs);
+  } catch (error) {
+    this.onError(error);
+  }
+}
+
+var invokeGuardedCallbackImpl = invokeGuardedCallbackProd;
+
+{
+  // In DEV mode, we swap out invokeGuardedCallback for a special version
+  // that plays more nicely with the browser's DevTools. The idea is to preserve
+  // "Pause on exceptions" behavior. Because React wraps all user-provided
+  // functions in invokeGuardedCallback, and the production version of
+  // invokeGuardedCallback uses a try-catch, all user exceptions are treated
+  // like caught exceptions, and the DevTools won't pause unless the developer
+  // takes the extra step of enabling pause on caught exceptions. This is
+  // unintuitive, though, because even though React has caught the error, from
+  // the developer's perspective, the error is uncaught.
+  //
+  // To preserve the expected "Pause on exceptions" behavior, we don't use a
+  // try-catch in DEV. Instead, we synchronously dispatch a fake event to a fake
+  // DOM node, and call the user-provided callback from inside an event handler
+  // for that fake event. If the callback throws, the error is "captured" using
+  // a global event handler. But because the error happens in a different
+  // event loop context, it does not interrupt the normal program flow.
+  // Effectively, this gives us try-catch behavior without actually using
+  // try-catch. Neat!
+  // Check that the browser supports the APIs we need to implement our special
+  // DEV version of invokeGuardedCallback
+  if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function' && typeof document !== 'undefined' && typeof document.createEvent === 'function') {
+    var fakeNode = document.createElement('react');
+
+    invokeGuardedCallbackImpl = function invokeGuardedCallbackDev(name, func, context, a, b, c, d, e, f) {
+      // If document doesn't exist we know for sure we will crash in this method
+      // when we call document.createEvent(). However this can cause confusing
+      // errors: https://github.com/facebookincubator/create-react-app/issues/3482
+      // So we preemptively throw with a better message instead.
+      if (!(typeof document !== 'undefined')) {
+        {
+          throw Error( "The `document` global was defined when React was initialized, but is not defined anymore. This can happen in a test environment if a component schedules an update from an asynchronous callback, but the test has already finished running. To solve this, you can either unmount the component at the end of your test (and ensure that any asynchronous operations get canceled in `componentWillUnmount`), or you can change the test itself to be asynchronous." );
+        }
+      }
+
+      var evt = document.createEvent('Event');
+      var didCall = false; // Keeps track of whether the user-provided callback threw an error. We
+      // set this to true at the beginning, then set it to false right after
+      // calling the function. If the function errors, `didError` will never be
+      // set to false. This strategy works even if the browser is flaky and
+      // fails to call our global error handler, because it doesn't rely on
+      // the error event at all.
+
+      var didError = true; // Keeps track of the value of window.event so that we can reset it
+      // during the callback to let user code access window.event in the
+      // browsers that support it.
+
+      var windowEvent = window.event; // Keeps track of the descriptor of window.event to restore it after event
+      // dispatching: https://github.com/facebook/react/issues/13688
+
+      var windowEventDescriptor = Object.getOwnPropertyDescriptor(window, 'event');
+
+      function restoreAfterDispatch() {
+        // We immediately remove the callback from event listeners so that
+        // nested `invokeGuardedCallback` calls do not clash. Otherwise, a
+        // nested call would trigger the fake event handlers of any call higher
+        // in the stack.
+        fakeNode.removeEventListener(evtType, callCallback, false); // We check for window.hasOwnProperty('event') to prevent the
+        // window.event assignment in both IE <= 10 as they throw an error
+        // "Member not found" in strict mode, and in Firefox which does not
+        // support window.event.
+
+        if (typeof window.event !== 'undefined' && window.hasOwnProperty('event')) {
+          window.event = windowEvent;
+        }
+      } // Create an event handler for our fake event. We will synchronously
+      // dispatch our fake event using `dispatchEvent`. Inside the handler, we
+      // call the user-provided callback.
+
+
+      var funcArgs = Array.prototype.slice.call(arguments, 3);
+
+      function callCallback() {
+        didCall = true;
+        restoreAfterDispatch();
+        func.apply(context, funcArgs);
+        didError = false;
+      } // Create a global error event handler. We use this to capture the value
+      // that was thrown. It's possible that this error handler will fire more
+      // than once; for example, if non-React code also calls `dispatchEvent`
+      // and a handler for that event throws. We should be resilient to most of
+      // those cases. Even if our error event handler fires more than once, the
+      // last error event is always used. If the callback actually does error,
+      // we know that the last error event is the correct one, because it's not
+      // possible for anything else to have happened in between our callback
+      // erroring and the code that follows the `dispatchEvent` call below. If
+      // the callback doesn't error, but the error event was fired, we know to
+      // ignore it because `didError` will be false, as described above.
+
+
+      var error; // Use this to track whether the error event is ever called.
+
+      var didSetError = false;
+      var isCrossOriginError = false;
+
+      function handleWindowError(event) {
+        error = event.error;
+        didSetError = true;
+
+        if (error === null && event.colno === 0 && event.lineno === 0) {
+          isCrossOriginError = true;
+        }
+
+        if (event.defaultPrevented) {
+          // Some other error handler has prevented default.
+          // Browsers silence the error report if this happens.
+          // We'll remember this to later decide whether to log it or not.
+          if (error != null && typeof error === 'object') {
+            try {
+              error._suppressLogging = true;
+            } catch (inner) {// Ignore.
+            }
+          }
+        }
+      } // Create a fake event type.
+
+
+      var evtType = "react-" + (name ? name : 'invokeguardedcallback'); // Attach our event handlers
+
+      window.addEventListener('error', handleWindowError);
+      fakeNode.addEventListener(evtType, callCallback, false); // Synchronously dispatch our fake event. If the user-provided function
+      // errors, it will trigger our global error handler.
+
+      evt.initEvent(evtType, false, false);
+      fakeNode.dispatchEvent(evt);
+
+      if (windowEventDescriptor) {
+        Object.defineProperty(window, 'event', windowEventDescriptor);
+      }
+
+      if (didCall && didError) {
+        if (!didSetError) {
+          // The callback errored, but the error event never fired.
+          error = new Error('An error was thrown inside one of your components, but React ' + "doesn't know what it was. This is likely due to browser " + 'flakiness. React does its best to preserve the "Pause on ' + 'exceptions" behavior of the DevTools, which requires some ' + "DEV-mode only tricks. It's possible that these don't work in " + 'your browser. Try triggering the error in production mode, ' + 'or switching to a modern browser. If you suspect that this is ' + 'actually an issue with React, please file an issue.');
+        } else if (isCrossOriginError) {
+          error = new Error("A cross-origin error was thrown. React doesn't have access to " + 'the actual error object in development. ' + 'See https://reactjs.org/link/crossorigin-error for more information.');
+        }
+
+        this.onError(error);
+      } // Remove our event listeners
+
+
+      window.removeEventListener('error', handleWindowError);
+
+      if (!didCall) {
+        // Something went really wrong, and our event was not dispatched.
+        // https://github.com/facebook/react/issues/16734
+        // https://github.com/facebook/react/issues/16585
+        // Fall back to the production implementation.
+        restoreAfterDispatch();
+        return invokeGuardedCallbackProd.apply(this, arguments);
+      }
+    };
+  }
+}
+
+var invokeGuardedCallbackImpl$1 = invokeGuardedCallbackImpl;
+
+var hasError = false;
+var caughtError = null; // Used by event system to capture/rethrow the first error.
+
+var hasRethrowError = false;
+var rethrowError = null;
+var reporter = {
+  onError: function (error) {
+    hasError = true;
+    caughtError = error;
+  }
+};
+/**
+ * Call a function while guarding against errors that happens within it.
+ * Returns an error if it throws, otherwise null.
+ *
+ * In production, this is implemented using a try-catch. The reason we don't
+ * use a try-catch directly is so that we can swap out a different
+ * implementation in DEV mode.
+ *
+ * @param {String} name of the guard to use for logging or debugging
+ * @param {Function} func The function to invoke
+ * @param {*} context The context to use when calling the function
+ * @param {...*} args Arguments for function
+ */
+
+function invokeGuardedCallback(name, func, context, a, b, c, d, e, f) {
+  hasError = false;
+  caughtError = null;
+  invokeGuardedCallbackImpl$1.apply(reporter, arguments);
+}
+/**
+ * Same as invokeGuardedCallback, but instead of returning an error, it stores
+ * it in a global so it can be rethrown by `rethrowCaughtError` later.
+ * TODO: See if caughtError and rethrowError can be unified.
+ *
+ * @param {String} name of the guard to use for logging or debugging
+ * @param {Function} func The function to invoke
+ * @param {*} context The context to use when calling the function
+ * @param {...*} args Arguments for function
+ */
+
+function invokeGuardedCallbackAndCatchFirstError(name, func, context, a, b, c, d, e, f) {
+  invokeGuardedCallback.apply(this, arguments);
+
+  if (hasError) {
+    var error = clearCaughtError();
+
+    if (!hasRethrowError) {
+      hasRethrowError = true;
+      rethrowError = error;
+    }
+  }
+}
+/**
+ * During execution of guarded functions we will capture the first error which
+ * we will rethrow to be handled by the top level error handler.
+ */
+
+function rethrowCaughtError() {
+  if (hasRethrowError) {
+    var error = rethrowError;
+    hasRethrowError = false;
+    rethrowError = null;
+    throw error;
+  }
+}
+function clearCaughtError() {
+  if (hasError) {
+    var error = caughtError;
+    hasError = false;
+    caughtError = null;
+    return error;
+  } else {
+    {
+      {
+        throw Error( "clearCaughtError was called but no error was captured. This error is likely caused by a bug in React. Please file an issue." );
+      }
+    }
+  }
+}
+
+var EventInternals$2 = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
+var getInstanceFromNode = EventInternals$2[0];
+var getNodeFromInstance = EventInternals$2[1];
+var getFiberCurrentPropsFromNode = EventInternals$2[2];
+var enqueueStateRestore = EventInternals$2[3];
+var restoreStateIfNeeded = EventInternals$2[4]; // const flushPassiveEffects = EventInternals[5];
+// TODO: This is related to `act`, not events. Move to separate key?
+// const IsThisRendererActing = EventInternals[6];
+
+function Event(suffix) {}
+
+var hasWarnedAboutDeprecatedMockComponent = false;
+/**
+ * @class ReactTestUtils
+ */
+
+function findAllInRenderedFiberTreeInternal(fiber, test) {
+  if (!fiber) {
+    return [];
+  }
+
+  var currentParent = findCurrentFiberUsingSlowPath(fiber);
+
+  if (!currentParent) {
+    return [];
+  }
+
+  var node = currentParent;
+  var ret = [];
+
+  while (true) {
+    if (node.tag === HostComponent || node.tag === HostText || node.tag === ClassComponent || node.tag === FunctionComponent) {
+      var publicInst = node.stateNode;
+
+      if (test(publicInst)) {
+        ret.push(publicInst);
+      }
+    }
+
+    if (node.child) {
+      node.child.return = node;
+      node = node.child;
+      continue;
+    }
+
+    if (node === currentParent) {
+      return ret;
+    }
+
+    while (!node.sibling) {
+      if (!node.return || node.return === currentParent) {
+        return ret;
+      }
+
+      node = node.return;
+    }
+
+    node.sibling.return = node.return;
+    node = node.sibling;
+  }
+}
+
+function validateClassInstance(inst, methodName) {
+  if (!inst) {
+    // This is probably too relaxed but it's existing behavior.
+    return;
+  }
+
+  if (get(inst)) {
+    // This is a public instance indeed.
+    return;
+  }
+
+  var received;
+  var stringified = '' + inst;
+
+  if (Array.isArray(inst)) {
+    received = 'an array';
+  } else if (inst && inst.nodeType === ELEMENT_NODE && inst.tagName) {
+    received = 'a DOM node';
+  } else if (stringified === '[object Object]') {
+    received = 'object with keys {' + Object.keys(inst).join(', ') + '}';
+  } else {
+    received = stringified;
+  }
+
+  {
+    {
+      throw Error( methodName + "(...): the first argument must be a React class instance. Instead received: " + received + "." );
+    }
+  }
+}
+/**
+ * Utilities for making it easy to test React components.
+ *
+ * See https://reactjs.org/docs/test-utils.html
+ *
+ * Todo: Support the entire DOM.scry query syntax. For now, these simple
+ * utilities will suffice for testing purposes.
+ * @lends ReactTestUtils
+ */
+
+
+function renderIntoDocument(element) {
+  var div = document.createElement('div'); // None of our tests actually require attaching the container to the
+  // DOM, and doing so creates a mess that we rely on test isolation to
+  // clean up, so we're going to stop honoring the name of this method
+  // (and probably rename it eventually) if no problems arise.
+  // document.documentElement.appendChild(div);
+
+  return ReactDOM.render(element, div);
+}
+
+function isElement(element) {
+  return React.isValidElement(element);
+}
+
+function isElementOfType(inst, convenienceConstructor) {
+  return React.isValidElement(inst) && inst.type === convenienceConstructor;
+}
+
+function isDOMComponent(inst) {
+  return !!(inst && inst.nodeType === ELEMENT_NODE && inst.tagName);
+}
+
+function isDOMComponentElement(inst) {
+  return !!(inst && React.isValidElement(inst) && !!inst.tagName);
+}
+
+function isCompositeComponent(inst) {
+  if (isDOMComponent(inst)) {
+    // Accessing inst.setState warns; just return false as that'll be what
+    // this returns when we have DOM nodes as refs directly
+    return false;
+  }
+
+  return inst != null && typeof inst.render === 'function' && typeof inst.setState === 'function';
+}
+
+function isCompositeComponentWithType(inst, type) {
+  if (!isCompositeComponent(inst)) {
+    return false;
+  }
+
+  var internalInstance = get(inst);
+  var constructor = internalInstance.type;
+  return constructor === type;
+}
+
+function findAllInRenderedTree(inst, test) {
+  validateClassInstance(inst, 'findAllInRenderedTree');
+
+  if (!inst) {
+    return [];
+  }
+
+  var internalInstance = get(inst);
+  return findAllInRenderedFiberTreeInternal(internalInstance, test);
+}
+/**
+ * Finds all instance of components in the rendered tree that are DOM
+ * components with the class name matching `className`.
+ * @return {array} an array of all the matches.
+ */
+
+
+function scryRenderedDOMComponentsWithClass(root, classNames) {
+  validateClassInstance(root, 'scryRenderedDOMComponentsWithClass');
+  return findAllInRenderedTree(root, function (inst) {
+    if (isDOMComponent(inst)) {
+      var className = inst.className;
+
+      if (typeof className !== 'string') {
+        // SVG, probably.
+        className = inst.getAttribute('class') || '';
+      }
+
+      var classList = className.split(/\s+/);
+
+      if (!Array.isArray(classNames)) {
+        if (!(classNames !== undefined)) {
+          {
+            throw Error( "TestUtils.scryRenderedDOMComponentsWithClass expects a className as a second argument." );
+          }
+        }
+
+        classNames = classNames.split(/\s+/);
+      }
+
+      return classNames.every(function (name) {
+        return classList.indexOf(name) !== -1;
+      });
+    }
+
+    return false;
+  });
+}
+/**
+ * Like scryRenderedDOMComponentsWithClass but expects there to be one result,
+ * and returns that one result, or throws exception if there is any other
+ * number of matches besides one.
+ * @return {!ReactDOMComponent} The one match.
+ */
+
+
+function findRenderedDOMComponentWithClass(root, className) {
+  validateClassInstance(root, 'findRenderedDOMComponentWithClass');
+  var all = scryRenderedDOMComponentsWithClass(root, className);
+
+  if (all.length !== 1) {
+    throw new Error('Did not find exactly one match (found: ' + all.length + ') ' + 'for class:' + className);
+  }
+
+  return all[0];
+}
+/**
+ * Finds all instance of components in the rendered tree that are DOM
+ * components with the tag name matching `tagName`.
+ * @return {array} an array of all the matches.
+ */
+
+
+function scryRenderedDOMComponentsWithTag(root, tagName) {
+  validateClassInstance(root, 'scryRenderedDOMComponentsWithTag');
+  return findAllInRenderedTree(root, function (inst) {
+    return isDOMComponent(inst) && inst.tagName.toUpperCase() === tagName.toUpperCase();
+  });
+}
+/**
+ * Like scryRenderedDOMComponentsWithTag but expects there to be one result,
+ * and returns that one result, or throws exception if there is any other
+ * number of matches besides one.
+ * @return {!ReactDOMComponent} The one match.
+ */
+
+
+function findRenderedDOMComponentWithTag(root, tagName) {
+  validateClassInstance(root, 'findRenderedDOMComponentWithTag');
+  var all = scryRenderedDOMComponentsWithTag(root, tagName);
+
+  if (all.length !== 1) {
+    throw new Error('Did not find exactly one match (found: ' + all.length + ') ' + 'for tag:' + tagName);
+  }
+
+  return all[0];
+}
+/**
+ * Finds all instances of components with type equal to `componentType`.
+ * @return {array} an array of all the matches.
+ */
+
+
+function scryRenderedComponentsWithType(root, componentType) {
+  validateClassInstance(root, 'scryRenderedComponentsWithType');
+  return findAllInRenderedTree(root, function (inst) {
+    return isCompositeComponentWithType(inst, componentType);
+  });
+}
+/**
+ * Same as `scryRenderedComponentsWithType` but expects there to be one result
+ * and returns that one result, or throws exception if there is any other
+ * number of matches besides one.
+ * @return {!ReactComponent} The one match.
+ */
+
+
+function findRenderedComponentWithType(root, componentType) {
+  validateClassInstance(root, 'findRenderedComponentWithType');
+  var all = scryRenderedComponentsWithType(root, componentType);
+
+  if (all.length !== 1) {
+    throw new Error('Did not find exactly one match (found: ' + all.length + ') ' + 'for componentType:' + componentType);
+  }
+
+  return all[0];
+}
+/**
+ * Pass a mocked component module to this method to augment it with
+ * useful methods that allow it to be used as a dummy React component.
+ * Instead of rendering as usual, the component will become a simple
+ * <div> containing any provided children.
+ *
+ * @param {object} module the mock function object exported from a
+ *                        module that defines the component to be mocked
+ * @param {?string} mockTagName optional dummy root tag name to return
+ *                              from render method (overrides
+ *                              module.mockTagName if provided)
+ * @return {object} the ReactTestUtils object (for chaining)
+ */
+
+
+function mockComponent(module, mockTagName) {
+  {
+    if (!hasWarnedAboutDeprecatedMockComponent) {
+      hasWarnedAboutDeprecatedMockComponent = true;
+
+      warn('ReactTestUtils.mockComponent() is deprecated. ' + 'Use shallow rendering or jest.mock() instead.\n\n' + 'See https://reactjs.org/link/test-utils-mock-component for more information.');
+    }
+  }
+
+  mockTagName = mockTagName || module.mockTagName || 'div';
+  module.prototype.render.mockImplementation(function () {
+    return React.createElement(mockTagName, null, this.props.children);
+  });
+  return this;
+}
+
+function nativeTouchData(x, y) {
+  return {
+    touches: [{
+      pageX: x,
+      pageY: y
+    }]
+  };
+} // Start of inline: the below functions were inlined from
+// EventPropagator.js, as they deviated from ReactDOM's newer
+// implementations.
+
+/**
+ * Dispatch the event to the listener.
+ * @param {SyntheticEvent} event SyntheticEvent to handle
+ * @param {function} listener Application-level callback
+ * @param {*} inst Internal component instance
+ */
+
+
+function executeDispatch(event, listener, inst) {
+  var type = event.type || 'unknown-event';
+  event.currentTarget = getNodeFromInstance(inst);
+  invokeGuardedCallbackAndCatchFirstError(type, listener, undefined, event);
+  event.currentTarget = null;
+}
+/**
+ * Standard/simple iteration through an event's collected dispatches.
+ */
+
+
+function executeDispatchesInOrder(event) {
+  var dispatchListeners = event._dispatchListeners;
+  var dispatchInstances = event._dispatchInstances;
+
+  if (Array.isArray(dispatchListeners)) {
+    for (var i = 0; i < dispatchListeners.length; i++) {
+      if (event.isPropagationStopped()) {
+        break;
+      } // Listeners and Instances are two parallel arrays that are always in sync.
+
+
+      executeDispatch(event, dispatchListeners[i], dispatchInstances[i]);
+    }
+  } else if (dispatchListeners) {
+    executeDispatch(event, dispatchListeners, dispatchInstances);
+  }
+
+  event._dispatchListeners = null;
+  event._dispatchInstances = null;
+}
+/**
+ * Dispatches an event and releases it back into the pool, unless persistent.
+ *
+ * @param {?object} event Synthetic event to be dispatched.
+ * @private
+ */
+
+
+var executeDispatchesAndRelease = function (event) {
+  if (event) {
+    executeDispatchesInOrder(event);
+
+    if (!event.isPersistent()) {
+      event.constructor.release(event);
+    }
+  }
+};
+
+function isInteractive(tag) {
+  return tag === 'button' || tag === 'input' || tag === 'select' || tag === 'textarea';
+}
+
+function getParent(inst) {
+  do {
+    inst = inst.return; // TODO: If this is a HostRoot we might want to bail out.
+    // That is depending on if we want nested subtrees (layers) to bubble
+    // events to their parent. We could also go through parentNode on the
+    // host node but that wouldn't work for React Native and doesn't let us
+    // do the portal feature.
+  } while (inst && inst.tag !== HostComponent);
+
+  if (inst) {
+    return inst;
+  }
+
+  return null;
+}
+/**
+ * Simulates the traversal of a two-phase, capture/bubble event dispatch.
+ */
+
+
+function traverseTwoPhase(inst, fn, arg) {
+  var path = [];
+
+  while (inst) {
+    path.push(inst);
+    inst = getParent(inst);
+  }
+
+  var i;
+
+  for (i = path.length; i-- > 0;) {
+    fn(path[i], 'captured', arg);
+  }
+
+  for (i = 0; i < path.length; i++) {
+    fn(path[i], 'bubbled', arg);
+  }
+}
+
+function shouldPreventMouseEvent(name, type, props) {
+  switch (name) {
+    case 'onClick':
+    case 'onClickCapture':
+    case 'onDoubleClick':
+    case 'onDoubleClickCapture':
+    case 'onMouseDown':
+    case 'onMouseDownCapture':
+    case 'onMouseMove':
+    case 'onMouseMoveCapture':
+    case 'onMouseUp':
+    case 'onMouseUpCapture':
+    case 'onMouseEnter':
+      return !!(props.disabled && isInteractive(type));
+
+    default:
+      return false;
+  }
+}
+/**
+ * @param {object} inst The instance, which is the source of events.
+ * @param {string} registrationName Name of listener (e.g. `onClick`).
+ * @return {?function} The stored callback.
+ */
+
+
+function getListener(inst, registrationName) {
+  // TODO: shouldPreventMouseEvent is DOM-specific and definitely should not
+  // live here; needs to be moved to a better place soon
+  var stateNode = inst.stateNode;
+
+  if (!stateNode) {
+    // Work in progress (ex: onload events in incremental mode).
+    return null;
+  }
+
+  var props = getFiberCurrentPropsFromNode(stateNode);
+
+  if (!props) {
+    // Work in progress.
+    return null;
+  }
+
+  var listener = props[registrationName];
+
+  if (shouldPreventMouseEvent(registrationName, inst.type, props)) {
+    return null;
+  }
+
+  if (!(!listener || typeof listener === 'function')) {
+    {
+      throw Error( "Expected `" + registrationName + "` listener to be a function, instead got a value of `" + typeof listener + "` type." );
+    }
+  }
+
+  return listener;
+}
+
+function listenerAtPhase(inst, event, propagationPhase) {
+  var registrationName = event._reactName;
+
+  if (propagationPhase === 'captured') {
+    registrationName += 'Capture';
+  }
+
+  return getListener(inst, registrationName);
+}
+
+function accumulateDispatches(inst, ignoredDirection, event) {
+  if (inst && event && event._reactName) {
+    var registrationName = event._reactName;
+    var listener = getListener(inst, registrationName);
+
+    if (listener) {
+      if (event._dispatchListeners == null) {
+        event._dispatchListeners = [];
+      }
+
+      if (event._dispatchInstances == null) {
+        event._dispatchInstances = [];
+      }
+
+      event._dispatchListeners.push(listener);
+
+      event._dispatchInstances.push(inst);
+    }
+  }
+}
+
+function accumulateDirectionalDispatches(inst, phase, event) {
+  {
+    if (!inst) {
+      error('Dispatching inst must not be null');
+    }
+  }
+
+  var listener = listenerAtPhase(inst, event, phase);
+
+  if (listener) {
+    if (event._dispatchListeners == null) {
+      event._dispatchListeners = [];
+    }
+
+    if (event._dispatchInstances == null) {
+      event._dispatchInstances = [];
+    }
+
+    event._dispatchListeners.push(listener);
+
+    event._dispatchInstances.push(inst);
+  }
+}
+
+function accumulateDirectDispatchesSingle(event) {
+  if (event && event._reactName) {
+    accumulateDispatches(event._targetInst, null, event);
+  }
+}
+
+function accumulateTwoPhaseDispatchesSingle(event) {
+  if (event && event._reactName) {
+    traverseTwoPhase(event._targetInst, accumulateDirectionalDispatches, event);
+  }
+} // End of inline
+
+
+var Simulate = {};
+var directDispatchEventTypes = new Set(['mouseEnter', 'mouseLeave', 'pointerEnter', 'pointerLeave']);
+/**
+ * Exports:
+ *
+ * - `Simulate.click(Element)`
+ * - `Simulate.mouseMove(Element)`
+ * - `Simulate.change(Element)`
+ * - ... (All keys from event plugin `eventTypes` objects)
+ */
+
+function makeSimulator(eventType) {
+  return function (domNode, eventData) {
+    if (!!React.isValidElement(domNode)) {
+      {
+        throw Error( "TestUtils.Simulate expected a DOM node as the first argument but received a React element. Pass the DOM node you wish to simulate the event on instead. Note that TestUtils.Simulate will not work if you are using shallow rendering." );
+      }
+    }
+
+    if (!!isCompositeComponent(domNode)) {
+      {
+        throw Error( "TestUtils.Simulate expected a DOM node as the first argument but received a component instance. Pass the DOM node you wish to simulate the event on instead." );
+      }
+    }
+
+    var reactName = 'on' + eventType[0].toUpperCase() + eventType.slice(1);
+    var fakeNativeEvent = new Event();
+    fakeNativeEvent.target = domNode;
+    fakeNativeEvent.type = eventType.toLowerCase();
+    var targetInst = getInstanceFromNode(domNode);
+    var event = new SyntheticEvent(reactName, fakeNativeEvent.type, targetInst, fakeNativeEvent, domNode); // Since we aren't using pooling, always persist the event. This will make
+    // sure it's marked and won't warn when setting additional properties.
+
+    event.persist();
+
+    _assign(event, eventData);
+
+    if (directDispatchEventTypes.has(eventType)) {
+      accumulateDirectDispatchesSingle(event);
+    } else {
+      accumulateTwoPhaseDispatchesSingle(event);
+    }
+
+    ReactDOM.unstable_batchedUpdates(function () {
+      // Normally extractEvent enqueues a state restore, but we'll just always
+      // do that since we're by-passing it here.
+      enqueueStateRestore(domNode);
+      executeDispatchesAndRelease(event);
+      rethrowCaughtError();
+    });
+    restoreStateIfNeeded();
+  };
+} // A one-time snapshot with no plans to update. We'll probably want to deprecate Simulate API.
+
+
+var simulatedEventTypes = ['blur', 'cancel', 'click', 'close', 'contextMenu', 'copy', 'cut', 'auxClick', 'doubleClick', 'dragEnd', 'dragStart', 'drop', 'focus', 'input', 'invalid', 'keyDown', 'keyPress', 'keyUp', 'mouseDown', 'mouseUp', 'paste', 'pause', 'play', 'pointerCancel', 'pointerDown', 'pointerUp', 'rateChange', 'reset', 'seeked', 'submit', 'touchCancel', 'touchEnd', 'touchStart', 'volumeChange', 'drag', 'dragEnter', 'dragExit', 'dragLeave', 'dragOver', 'mouseMove', 'mouseOut', 'mouseOver', 'pointerMove', 'pointerOut', 'pointerOver', 'scroll', 'toggle', 'touchMove', 'wheel', 'abort', 'animationEnd', 'animationIteration', 'animationStart', 'canPlay', 'canPlayThrough', 'durationChange', 'emptied', 'encrypted', 'ended', 'error', 'gotPointerCapture', 'load', 'loadedData', 'loadedMetadata', 'loadStart', 'lostPointerCapture', 'playing', 'progress', 'seeking', 'stalled', 'suspend', 'timeUpdate', 'transitionEnd', 'waiting', 'mouseEnter', 'mouseLeave', 'pointerEnter', 'pointerLeave', 'change', 'select', 'beforeInput', 'compositionEnd', 'compositionStart', 'compositionUpdate'];
+
+function buildSimulators() {
+  simulatedEventTypes.forEach(function (eventType) {
+    Simulate[eventType] = makeSimulator(eventType);
+  });
+}
+
+buildSimulators();
+
+exports.Simulate = Simulate;
+exports.act = act;
+exports.findAllInRenderedTree = findAllInRenderedTree;
+exports.findRenderedComponentWithType = findRenderedComponentWithType;
+exports.findRenderedDOMComponentWithClass = findRenderedDOMComponentWithClass;
+exports.findRenderedDOMComponentWithTag = findRenderedDOMComponentWithTag;
+exports.isCompositeComponent = isCompositeComponent;
+exports.isCompositeComponentWithType = isCompositeComponentWithType;
+exports.isDOMComponent = isDOMComponent;
+exports.isDOMComponentElement = isDOMComponentElement;
+exports.isElement = isElement;
+exports.isElementOfType = isElementOfType;
+exports.mockComponent = mockComponent;
+exports.nativeTouchData = nativeTouchData;
+exports.renderIntoDocument = renderIntoDocument;
+exports.scryRenderedComponentsWithType = scryRenderedComponentsWithType;
+exports.scryRenderedDOMComponentsWithClass = scryRenderedDOMComponentsWithClass;
+exports.scryRenderedDOMComponentsWithTag = scryRenderedDOMComponentsWithTag;
+exports.traverseTwoPhase = traverseTwoPhase;
+exports.unstable_concurrentAct = unstable_concurrentAct;
+  })();
+}
+});
+
+var testUtils = createCommonjsModule(function (module) {
+
+if (process$1.env.NODE_ENV === 'production') {
+  module.exports = reactDomTestUtils_production_min;
+} else {
+  module.exports = reactDomTestUtils_development;
+}
+});
+
+var reactAct = testUtils.act;
+var actSupported = reactAct !== undefined; // act is supported react-dom@16.8.0
+// so for versions that don't have act from test utils
+// we do this little polyfill. No warnings, but it's
+// better than nothing.
+
+function actPolyfill(cb) {
+  m$1.unstable_batchedUpdates(cb);
+  m$1.render( /*#__PURE__*/l$1.createElement("div", null), document.createElement('div'));
+}
+
+var act = reactAct || actPolyfill;
+var youHaveBeenWarned = false;
+var isAsyncActSupported = null;
+
+function asyncAct(cb) {
+  if (actSupported === true) {
+    if (isAsyncActSupported === null) {
+      return new Promise(function (resolve, reject) {
+        // patch console.error here
+        var originalConsoleError = console.error;
+
+        console.error = function error() {
+          for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+            args[_key] = arguments[_key];
+          }
+
+          /* if console.error fired *with that specific message* */
+
+          /* istanbul ignore next */
+          var firstArgIsString = typeof args[0] === 'string';
+
+          if (firstArgIsString && args[0].indexOf('Warning: Do not await the result of calling ReactTestUtils.act') === 0) {
+            // v16.8.6
+            isAsyncActSupported = false;
+          } else if (firstArgIsString && args[0].indexOf('Warning: The callback passed to ReactTestUtils.act(...) function must not return anything') === 0) ; else {
+            originalConsoleError.apply(console, args);
+          }
+        };
+
+        var cbReturn, result;
+
+        try {
+          result = reactAct(function () {
+            cbReturn = cb();
+            return cbReturn;
+          });
+        } catch (err) {
+          console.error = originalConsoleError;
+          reject(err);
+          return;
+        }
+
+        result.then(function () {
+          console.error = originalConsoleError; // if it got here, it means async act is supported
+
+          isAsyncActSupported = true;
+          resolve();
+        }, function (err) {
+          console.error = originalConsoleError;
+          isAsyncActSupported = true;
+          reject(err);
+        }); // 16.8.6's act().then() doesn't call a resolve handler, so we need to manually flush here, sigh
+
+        if (isAsyncActSupported === false) {
+          console.error = originalConsoleError;
+          /* istanbul ignore next */
+
+          if (!youHaveBeenWarned) {
+            // if act is supported and async act isn't and they're trying to use async
+            // act, then they need to upgrade from 16.8 to 16.9.
+            // This is a seamless upgrade, so we'll add a warning
+            console.error("It looks like you're using a version of react-dom that supports the \"act\" function, but not an awaitable version of \"act\" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.");
+            youHaveBeenWarned = true;
+          }
+
+          cbReturn.then(function () {
+            // a faux-version.
+            // todo - copy https://github.com/facebook/react/blob/master/packages/shared/enqueueTask.js
+            Promise.resolve().then(function () {
+              // use sync act to flush effects
+              act(function () {});
+              resolve();
+            });
+          }, reject);
+        }
+      });
+    } else if (isAsyncActSupported === false) {
+      // use the polyfill directly
+      var _result;
+
+      act(function () {
+        _result = cb();
+      });
+      return _result.then(function () {
+        return Promise.resolve().then(function () {
+          // use sync act to flush effects
+          act(function () {});
+        });
+      });
+    } // all good! regular act
+
+
+    return act(cb);
+  } // use the polyfill
+
+
+  var result;
+  act(function () {
+    result = cb();
+  });
+  return result.then(function () {
+    return Promise.resolve().then(function () {
+      // use sync act to flush effects
+      act(function () {});
+    });
+  });
+}
+/* eslint no-console:0 */
+
+// dom-testing-library's version of fireEvent. The reason
+// we make this distinction however is because we have
+// a few extra events that work a bit differently
+
+var fireEvent = function fireEvent() {
+  return fireEvent$1.apply(void 0, arguments);
+};
+
+Object.keys(fireEvent$1).forEach(function (key) {
+  fireEvent[key] = function () {
+    return fireEvent$1[key].apply(fireEvent$1, arguments);
+  };
+}); // React event system tracks native mouseOver/mouseOut events for
+// running onMouseEnter/onMouseLeave handlers
+// @link https://github.com/facebook/react/blob/b87aabdfe1b7461e7331abb3601d9e6bb27544bc/packages/react-dom/src/events/EnterLeaveEventPlugin.js#L24-L31
+
+var mouseEnter = fireEvent.mouseEnter;
+var mouseLeave = fireEvent.mouseLeave;
+
+fireEvent.mouseEnter = function () {
+  mouseEnter.apply(void 0, arguments);
+  return fireEvent.mouseOver.apply(fireEvent, arguments);
+};
+
+fireEvent.mouseLeave = function () {
+  mouseLeave.apply(void 0, arguments);
+  return fireEvent.mouseOut.apply(fireEvent, arguments);
+};
+
+var pointerEnter = fireEvent.pointerEnter;
+var pointerLeave = fireEvent.pointerLeave;
+
+fireEvent.pointerEnter = function () {
+  pointerEnter.apply(void 0, arguments);
+  return fireEvent.pointerOver.apply(fireEvent, arguments);
+};
+
+fireEvent.pointerLeave = function () {
+  pointerLeave.apply(void 0, arguments);
+  return fireEvent.pointerOut.apply(fireEvent, arguments);
+};
+
+var select = fireEvent.select;
+
+fireEvent.select = function (node, init) {
+  select(node, init); // React tracks this event only on focused inputs
+
+  node.focus(); // React creates this event when one of the following native events happens
+  // - contextMenu
+  // - mouseUp
+  // - dragEnd
+  // - keyUp
+  // - keyDown
+  // so we can use any here
+  // @link https://github.com/facebook/react/blob/b87aabdfe1b7461e7331abb3601d9e6bb27544bc/packages/react-dom/src/events/SelectEventPlugin.js#L203-L224
+
+  fireEvent.keyUp(node, init);
+}; // React event system tracks native focusout/focusin events for
+// running blur/focus handlers
+// @link https://github.com/facebook/react/pull/19186
+
+
+var blur$1 = fireEvent.blur;
+var focus$1 = fireEvent.focus;
+
+fireEvent.blur = function () {
+  fireEvent.focusOut.apply(fireEvent, arguments);
+  return blur$1.apply(void 0, arguments);
+};
+
+fireEvent.focus = function () {
+  fireEvent.focusIn.apply(fireEvent, arguments);
+  return focus$1.apply(void 0, arguments);
+};
+
+configure({
+  asyncWrapper: function () {
+    var _asyncWrapper = _asyncToGenerator( /*#__PURE__*/regenerator.mark(function _callee2(cb) {
+      var result;
+      return regenerator.wrap(function _callee2$(_context2) {
+        while (1) {
+          switch (_context2.prev = _context2.next) {
+            case 0:
+              _context2.next = 2;
+              return asyncAct( /*#__PURE__*/_asyncToGenerator( /*#__PURE__*/regenerator.mark(function _callee() {
+                return regenerator.wrap(function _callee$(_context) {
+                  while (1) {
+                    switch (_context.prev = _context.next) {
+                      case 0:
+                        _context.next = 2;
+                        return cb();
+
+                      case 2:
+                        result = _context.sent;
+
+                      case 3:
+                      case "end":
+                        return _context.stop();
+                    }
+                  }
+                }, _callee);
+              })));
+
+            case 2:
+              return _context2.abrupt("return", result);
+
+            case 3:
+            case "end":
+              return _context2.stop();
+          }
+        }
+      }, _callee2);
+    }));
+
+    function asyncWrapper(_x) {
+      return _asyncWrapper.apply(this, arguments);
+    }
+
+    return asyncWrapper;
+  }(),
+  eventWrapper: function eventWrapper(cb) {
+    var result;
+    act(function () {
+      result = cb();
+    });
+    return result;
+  }
+});
+var mountedContainers = new Set();
+
+function render(ui, _temp) {
+  var _ref2 = _temp === void 0 ? {} : _temp,
+      container = _ref2.container,
+      _ref2$baseElement = _ref2.baseElement,
+      baseElement = _ref2$baseElement === void 0 ? container : _ref2$baseElement,
+      queries = _ref2.queries,
+      _ref2$hydrate = _ref2.hydrate,
+      hydrate = _ref2$hydrate === void 0 ? false : _ref2$hydrate,
+      WrapperComponent = _ref2.wrapper;
+
+  if (!baseElement) {
+    // default to document.body instead of documentElement to avoid output of potentially-large
+    // head elements (such as JSS style blocks) in debug output
+    baseElement = document.body;
+  }
+
+  if (!container) {
+    container = baseElement.appendChild(document.createElement('div'));
+  } // we'll add it to the mounted containers regardless of whether it's actually
+  // added to document.body so the cleanup method works regardless of whether
+  // they're passing us a custom container or not.
+
+
+  mountedContainers.add(container);
+
+  var wrapUiIfNeeded = function wrapUiIfNeeded(innerElement) {
+    return WrapperComponent ? /*#__PURE__*/l$1.createElement(WrapperComponent, null, innerElement) : innerElement;
+  };
+
+  act(function () {
+    if (hydrate) {
+      m$1.hydrate(wrapUiIfNeeded(ui), container);
+    } else {
+      m$1.render(wrapUiIfNeeded(ui), container);
+    }
+  });
+  return _extends({
+    container: container,
+    baseElement: baseElement,
+    debug: function debug(el, maxLength, options) {
+      if (el === void 0) {
+        el = baseElement;
+      }
+
+      return Array.isArray(el) ? // eslint-disable-next-line no-console
+      el.forEach(function (e) {
+        return console.log(prettyDOM(e, maxLength, options));
+      }) : // eslint-disable-next-line no-console,
+      console.log(prettyDOM(el, maxLength, options));
+    },
+    unmount: function unmount() {
+      act(function () {
+        m$1.unmountComponentAtNode(container);
+      });
+    },
+    rerender: function rerender(rerenderUi) {
+      render(wrapUiIfNeeded(rerenderUi), {
+        container: container,
+        baseElement: baseElement
+      }); // Intentionally do not return anything to avoid unnecessarily complicating the API.
+      // folks can use all the same utilities we return in the first place that are bound to the container
+    },
+    asFragment: function asFragment() {
+      /* istanbul ignore else (old jsdom limitation) */
+      if (typeof document.createRange === 'function') {
+        return document.createRange().createContextualFragment(container.innerHTML);
+      } else {
+        var template = document.createElement('template');
+        template.innerHTML = container.innerHTML;
+        return template.content;
+      }
+    }
+  }, getQueriesForElement(baseElement, queries));
+}
+
+function cleanup() {
+  mountedContainers.forEach(cleanupAtContainer);
+} // maybe one day we'll expose this (perhaps even as a utility returned by render).
+// but let's wait until someone asks for it.
+
+
+function cleanupAtContainer(container) {
+  act(function () {
+    m$1.unmountComponentAtNode(container);
+  });
+
+  if (container.parentNode === document.body) {
+    document.body.removeChild(container);
+  }
+
+  mountedContainers.delete(container);
+} // just re-export everything from dom-testing-library
+// thing for people using react-dom@16.8.0. Anyone else doesn't need it and
+// people should just upgrade anyway.
+
+/* eslint func-name-matching:0 */
+
+var _process$env;
+// or teardown then we'll automatically run cleanup afterEach test
+// this ensures that tests run in isolation from each other
+// if you don't like this then either import the `pure` module
+// or set the RTL_SKIP_AUTO_CLEANUP env variable to 'true'.
+
+if (typeof process$1 === "undefined" || !((_process$env = process$1.env) != null && _process$env.RTL_SKIP_AUTO_CLEANUP)) {
+  // ignore teardown() in code coverage because Jest does not support it
+
+  /* istanbul ignore else */
+  if (typeof afterEach === 'function') {
+    afterEach(function () {
+      cleanup();
+    });
+  } else if (typeof teardown === 'function') {
+    // Block is guarded by `typeof` check.
+    // eslint does not support `typeof` guards.
+    // eslint-disable-next-line no-undef
+    teardown(function () {
+      cleanup();
+    });
+  }
+}
+
+// Copyright 2021 Workiva Inc.
+var buildTestingLibraryElementError = function buildTestingLibraryElementError(message) {
+  var err = new Error(message);
+  err.name = 'TestingLibraryElementError';
+  return err;
+};
+var buildJsGetElementError = function buildJsGetElementError(message, container) {
+  var _message$replace;
+  // With findBy* async queries, there is a race condition during which `originalMessage` will already
+  // contain the prettyDOM-printed HTML of the `container`. This causes the prettyDOM-printed HTML to be
+  // output twice in the error because of the call to `setEphemeralElementErrorMessage`,
+  // which calls `buildCustomTestingLibraryElementJsError`, which assumes that the prettyDOM-printed output
+  // is not already there. So we'll do an additional replace here to get rid of the prettyDOM-printed output
+  // if found.
+  var prettyDOMRegex = /(?<=[\s\S]*)\s*<\w+>[\s\S]+/gm;
+  var newMessage = (_message$replace = message === null || message === void 0 ? void 0 : message.replace(prettyDOMRegex, '')) !== null && _message$replace !== void 0 ? _message$replace : '';
+  var prettyDomOutput = prettyDOM(container);
+  return buildTestingLibraryElementError([newMessage, prettyDomOutput].filter(Boolean).join('\n\n'));
+};
+
+var getMouseEventOptions_2 = getMouseEventOptions;
+
+function isMousePressEvent(event) {
+  return event === 'mousedown' || event === 'mouseup' || event === 'click' || event === 'dblclick';
+} // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
+
+
+const BUTTONS_NAMES = {
+  none: 0,
+  primary: 1,
+  secondary: 2,
+  auxiliary: 4
+}; // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+
+const BUTTON_NAMES = {
+  primary: 0,
+  auxiliary: 1,
+  secondary: 2
+};
+
+function translateButtonNumber(value, from) {
+  var _Object$entries$find;
+
+  const [mapIn, mapOut] = from === 'button' ? [BUTTON_NAMES, BUTTONS_NAMES] : [BUTTONS_NAMES, BUTTON_NAMES];
+  const name = (_Object$entries$find = Object.entries(mapIn).find(([, i]) => i === value)) == null ? void 0 : _Object$entries$find[0]; // istanbul ignore next
+
+  return name && Object.prototype.hasOwnProperty.call(mapOut, name) ? mapOut[name] : 0;
+}
+
+function convertMouseButtons(event, init, property) {
+  if (!isMousePressEvent(event)) {
+    return 0;
+  }
+
+  if (typeof init[property] === 'number') {
+    return init[property];
+  } else if (property === 'button' && typeof init.buttons === 'number') {
+    return translateButtonNumber(init.buttons, 'buttons');
+  } else if (property === 'buttons' && typeof init.button === 'number') {
+    return translateButtonNumber(init.button, 'button');
+  }
+
+  return property != 'button' && isMousePressEvent(event) ? 1 : 0;
+}
+
+function getMouseEventOptions(event, init, clickCount = 0) {
+  var _init;
+
+  init = (_init = init) != null ? _init : {};
+  return { ...init,
+    // https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail
+    detail: event === 'mousedown' || event === 'mouseup' || event === 'click' ? 1 + clickCount : clickCount,
+    buttons: convertMouseButtons(event, init, 'buttons'),
+    button: convertMouseButtons(event, init, 'button')
+  };
+}
+
+var getMouseEventOptions_1 = /*#__PURE__*/Object.defineProperty({
+	getMouseEventOptions: getMouseEventOptions_2
+}, '__esModule', {value: true});
+
+var isElementType_2 = isElementType;
+
+function isElementType(element, tag, props) {
+  if (element.namespaceURI && element.namespaceURI !== 'http://www.w3.org/1999/xhtml') {
+    return false;
+  }
+
+  tag = Array.isArray(tag) ? tag : [tag]; // tagName is uppercase in HTMLDocument and lowercase in XMLDocument
+
+  if (!tag.includes(element.tagName.toLowerCase())) {
+    return false;
+  }
+
+  if (props) {
+    return Object.entries(props).every(([k, v]) => element[k] === v);
+  }
+
+  return true;
+}
+
+var isElementType_1 = /*#__PURE__*/Object.defineProperty({
+	isElementType: isElementType_2
+}, '__esModule', {value: true});
+
+var isClickableInput_2 = isClickableInput;
+
+
+
+const CLICKABLE_INPUT_TYPES = ['button', 'color', 'file', 'image', 'reset', 'submit', 'checkbox', 'radio'];
+
+function isClickableInput(element) {
+  return (0, isElementType_1.isElementType)(element, 'button') || (0, isElementType_1.isElementType)(element, 'input') && CLICKABLE_INPUT_TYPES.includes(element.type);
+}
+
+var isClickableInput_1 = /*#__PURE__*/Object.defineProperty({
+	isClickableInput: isClickableInput_2
+}, '__esModule', {value: true});
+
+var buildTimeValue_2 = buildTimeValue;
+
+function buildTimeValue(value) {
+  const onlyDigitsValue = value.replace(/\D/g, '');
+
+  if (onlyDigitsValue.length < 2) {
+    return value;
+  }
+
+  const firstDigit = parseInt(onlyDigitsValue[0], 10);
+  const secondDigit = parseInt(onlyDigitsValue[1], 10);
+
+  if (firstDigit >= 3 || firstDigit === 2 && secondDigit >= 4) {
+    let index;
+
+    if (firstDigit >= 3) {
+      index = 1;
+    } else {
+      index = 2;
+    }
+
+    return build(onlyDigitsValue, index);
+  }
+
+  if (value.length === 2) {
+    return value;
+  }
+
+  return build(onlyDigitsValue, 2);
+}
+
+function build(onlyDigitsValue, index) {
+  const hours = onlyDigitsValue.slice(0, index);
+  const validHours = Math.min(parseInt(hours, 10), 23);
+  const minuteCharacters = onlyDigitsValue.slice(index);
+  const parsedMinutes = parseInt(minuteCharacters, 10);
+  const validMinutes = Math.min(parsedMinutes, 59);
+  return `${validHours.toString().padStart(2, '0')}:${validMinutes.toString().padStart(2, '0')}`;
+}
+
+var buildTimeValue_1 = /*#__PURE__*/Object.defineProperty({
+	buildTimeValue: buildTimeValue_2
+}, '__esModule', {value: true});
+
+var getSelectionRange_1 = getSelectionRange;
+var hasSelectionSupport_1 = hasSelectionSupport;
+var setSelectionRange_1 = setSelectionRange;
+
+
+
+// https://github.com/jsdom/jsdom/blob/c2fb8ff94917a4d45e2398543f5dd2a8fed0bdab/lib/jsdom/living/nodes/HTMLInputElement-impl.js#L45
+var selectionSupportType;
+
+(function (selectionSupportType) {
+  selectionSupportType["text"] = "text";
+  selectionSupportType["search"] = "search";
+  selectionSupportType["url"] = "url";
+  selectionSupportType["tel"] = "tel";
+  selectionSupportType["password"] = "password";
+})(selectionSupportType || (selectionSupportType = {}));
+
+const InputSelection = Symbol('inputSelection');
+
+function hasSelectionSupport(element) {
+  return (0, isElementType_1.isElementType)(element, 'textarea') || (0, isElementType_1.isElementType)(element, 'input') && Boolean(selectionSupportType[element.type]);
+}
+
+function getSelectionRange(element) {
+  if (hasSelectionSupport(element)) {
+    return {
+      selectionStart: element.selectionStart,
+      selectionEnd: element.selectionEnd
+    };
+  }
+
+  if ((0, isElementType_1.isElementType)(element, 'input')) {
+    var _InputSelection;
+
+    return (_InputSelection = element[InputSelection]) != null ? _InputSelection : {
+      selectionStart: null,
+      selectionEnd: null
+    };
+  }
+
+  const selection = element.ownerDocument.getSelection(); // there should be no editing if the focusNode is outside of element
+  // TODO: properly handle selection ranges
+
+  if (selection != null && selection.rangeCount && element.contains(selection.focusNode)) {
+    const range = selection.getRangeAt(0);
+    return {
+      selectionStart: range.startOffset,
+      selectionEnd: range.endOffset
+    };
+  } else {
+    return {
+      selectionStart: null,
+      selectionEnd: null
+    };
+  }
+}
+
+function setSelectionRange(element, newSelectionStart, newSelectionEnd) {
+  const {
+    selectionStart,
+    selectionEnd
+  } = getSelectionRange(element);
+
+  if (selectionStart === newSelectionStart && selectionEnd === newSelectionEnd) {
+    return;
+  }
+
+  if (hasSelectionSupport(element)) {
+    element.setSelectionRange(newSelectionStart, newSelectionEnd);
+  }
+
+  if ((0, isElementType_1.isElementType)(element, 'input')) {
+    element[InputSelection] = {
+      selectionStart: newSelectionStart,
+      selectionEnd: newSelectionEnd
+    };
+  } // Moving the selection inside <input> or <textarea> does not alter the document Selection.
+
+
+  if ((0, isElementType_1.isElementType)(element, 'input') || (0, isElementType_1.isElementType)(element, 'textarea')) {
+    return;
+  }
+
+  const range = element.ownerDocument.createRange();
+  range.selectNodeContents(element); // istanbul ignore else
+
+  if (element.firstChild) {
+    range.setStart(element.firstChild, newSelectionStart);
+    range.setEnd(element.firstChild, newSelectionEnd);
+  }
+
+  const selection = element.ownerDocument.getSelection(); // istanbul ignore else
+
+  if (selection) {
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+}
+
+var selectionRange = /*#__PURE__*/Object.defineProperty({
+	getSelectionRange: getSelectionRange_1,
+	hasSelectionSupport: hasSelectionSupport_1,
+	setSelectionRange: setSelectionRange_1
+}, '__esModule', {value: true});
+
+var isContentEditable_2 = isContentEditable;
+
+//jsdom is not supporting isContentEditable
+function isContentEditable(element) {
+  return element.hasAttribute('contenteditable') && (element.getAttribute('contenteditable') == 'true' || element.getAttribute('contenteditable') == '');
+}
+
+var isContentEditable_1 = /*#__PURE__*/Object.defineProperty({
+	isContentEditable: isContentEditable_2
+}, '__esModule', {value: true});
+
+var getValue_2 = getValue;
+
+
+
+function getValue(element) {
+  // istanbul ignore if
+  if (!element) {
+    return null;
+  }
+
+  if ((0, isContentEditable_1.isContentEditable)(element)) {
+    return element.textContent;
+  }
+
+  return element.value;
+}
+
+var getValue_1 = /*#__PURE__*/Object.defineProperty({
+	getValue: getValue_2
+}, '__esModule', {value: true});
+
+var isValidDateValue_2 = isValidDateValue;
+
+function isValidDateValue(element, value) {
+  const clone = element.cloneNode();
+  clone.value = value;
+  return clone.value === value;
+}
+
+var isValidDateValue_1 = /*#__PURE__*/Object.defineProperty({
+	isValidDateValue: isValidDateValue_2
+}, '__esModule', {value: true});
+
+var isValidInputTimeValue_2 = isValidInputTimeValue;
+
+function isValidInputTimeValue(element, timeValue) {
+  const clone = element.cloneNode();
+  clone.value = timeValue;
+  return clone.value === timeValue;
+}
+
+var isValidInputTimeValue_1 = /*#__PURE__*/Object.defineProperty({
+	isValidInputTimeValue: isValidInputTimeValue_2
+}, '__esModule', {value: true});
+
+var calculateNewValue_2 = calculateNewValue;
+
+
+
+
+
+
+
+
+
+function calculateNewValue(newEntry, element, value = (() => {
+  var _getValue;
+
+  return (_getValue = (0, getValue_1.getValue)(element)) != null ? _getValue :
+  /* istanbul ignore next */
+  '';
+})(), selectionRange$1 = (0, selectionRange.getSelectionRange)(element), deleteContent) {
+  const selectionStart = selectionRange$1.selectionStart === null ? value.length : selectionRange$1.selectionStart;
+  const selectionEnd = selectionRange$1.selectionEnd === null ? value.length : selectionRange$1.selectionEnd;
+  const prologEnd = Math.max(0, selectionStart === selectionEnd && deleteContent === 'backward' ? selectionStart - 1 : selectionStart);
+  const prolog = value.substring(0, prologEnd);
+  const epilogStart = Math.min(value.length, selectionStart === selectionEnd && deleteContent === 'forward' ? selectionEnd + 1 : selectionEnd);
+  const epilog = value.substring(epilogStart, value.length);
+  let newValue = `${prolog}${newEntry}${epilog}`;
+  const newSelectionStart = prologEnd + newEntry.length;
+
+  if (element.type === 'date' && !(0, isValidDateValue_1.isValidDateValue)(element, newValue)) {
+    newValue = value;
+  }
+
+  if (element.type === 'time' && !(0, isValidInputTimeValue_1.isValidInputTimeValue)(element, newValue)) {
+    if ((0, isValidInputTimeValue_1.isValidInputTimeValue)(element, newEntry)) {
+      newValue = newEntry;
+    } else {
+      newValue = value;
+    }
+  }
+
+  return {
+    newValue,
+    newSelectionStart
+  };
+}
+
+var calculateNewValue_1 = /*#__PURE__*/Object.defineProperty({
+	calculateNewValue: calculateNewValue_2
+}, '__esModule', {value: true});
+
+var isCursorAtEnd_1 = isCursorAtEnd;
+var isCursorAtStart_1 = isCursorAtStart;
+
+
+
+
+
+function isCursorAtEnd(element) {
+  var _getValue;
+
+  const {
+    selectionStart,
+    selectionEnd
+  } = (0, selectionRange.getSelectionRange)(element);
+  return selectionStart === selectionEnd && (selectionStart != null ? selectionStart :
+  /* istanbul ignore next */
+  0) === ((_getValue = (0, getValue_1.getValue)(element)) != null ? _getValue :
+  /* istanbul ignore next */
+  '').length;
+}
+
+function isCursorAtStart(element) {
+  const {
+    selectionStart,
+    selectionEnd
+  } = (0, selectionRange.getSelectionRange)(element);
+  return selectionStart === selectionEnd && (selectionStart != null ? selectionStart :
+  /* istanbul ignore next */
+  0) === 0;
+}
+
+var cursorPosition = /*#__PURE__*/Object.defineProperty({
+	isCursorAtEnd: isCursorAtEnd_1,
+	isCursorAtStart: isCursorAtStart_1
+}, '__esModule', {value: true});
+
+var hasUnreliableEmptyValue_2 = hasUnreliableEmptyValue;
+
+
+
+var unreliableValueInputTypes;
+/**
+ * Check if an empty IDL value on the element could mean a derivation of displayed value and IDL value
+ */
+
+(function (unreliableValueInputTypes) {
+  unreliableValueInputTypes["number"] = "number";
+})(unreliableValueInputTypes || (unreliableValueInputTypes = {}));
+
+function hasUnreliableEmptyValue(element) {
+  return (0, isElementType_1.isElementType)(element, 'input') && Boolean(unreliableValueInputTypes[element.type]);
+}
+
+var hasUnreliableEmptyValue_1 = /*#__PURE__*/Object.defineProperty({
+	hasUnreliableEmptyValue: hasUnreliableEmptyValue_2
+}, '__esModule', {value: true});
+
+var isEditable_1 = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.editableInputTypes = void 0;
+exports.isEditable = isEditable;
+exports.isEditableInput = isEditableInput;
+
+
+
+
+
+function isEditable(element) {
+  return isEditableInput(element) || (0, isElementType_1.isElementType)(element, 'textarea', {
+    readOnly: false
+  }) || (0, isContentEditable_1.isContentEditable)(element);
+}
+
+let editableInputTypes;
+exports.editableInputTypes = editableInputTypes;
+
+(function (editableInputTypes) {
+  editableInputTypes["text"] = "text";
+  editableInputTypes["date"] = "date";
+  editableInputTypes["datetime-local"] = "datetime-local";
+  editableInputTypes["email"] = "email";
+  editableInputTypes["month"] = "month";
+  editableInputTypes["number"] = "number";
+  editableInputTypes["password"] = "password";
+  editableInputTypes["search"] = "search";
+  editableInputTypes["tel"] = "tel";
+  editableInputTypes["time"] = "time";
+  editableInputTypes["url"] = "url";
+  editableInputTypes["week"] = "week";
+})(editableInputTypes || (exports.editableInputTypes = editableInputTypes = {}));
+
+function isEditableInput(element) {
+  return (0, isElementType_1.isElementType)(element, 'input', {
+    readOnly: false
+  }) && Boolean(editableInputTypes[element.type]);
+}
+});
+
+var getSpaceUntilMaxLength_1 = getSpaceUntilMaxLength;
+
+
+
+
+
+var maxLengthSupportedTypes;
+
+(function (maxLengthSupportedTypes) {
+  maxLengthSupportedTypes["email"] = "email";
+  maxLengthSupportedTypes["password"] = "password";
+  maxLengthSupportedTypes["search"] = "search";
+  maxLengthSupportedTypes["telephone"] = "telephone";
+  maxLengthSupportedTypes["text"] = "text";
+  maxLengthSupportedTypes["url"] = "url";
+})(maxLengthSupportedTypes || (maxLengthSupportedTypes = {}));
+
+function getSpaceUntilMaxLength(element) {
+  const value = (0, getValue_1.getValue)(element);
+  /* istanbul ignore if */
+
+  if (value === null) {
+    return undefined;
+  }
+
+  const maxLength = getSanitizedMaxLength(element);
+  return maxLength ? maxLength - value.length : undefined;
+} // can't use .maxLength property because of a jsdom bug:
+// https://github.com/jsdom/jsdom/issues/2927
+
+
+function getSanitizedMaxLength(element) {
+  var _element$getAttribute;
+
+  if (!supportsMaxLength(element)) {
+    return undefined;
+  }
+
+  const attr = (_element$getAttribute = element.getAttribute('maxlength')) != null ? _element$getAttribute : '';
+  return /^\d+$/.test(attr) && Number(attr) >= 0 ? Number(attr) : undefined;
+}
+
+function supportsMaxLength(element) {
+  return (0, isElementType_1.isElementType)(element, 'textarea') || (0, isElementType_1.isElementType)(element, 'input') && Boolean(maxLengthSupportedTypes[element.type]);
+}
+
+var maxLength = /*#__PURE__*/Object.defineProperty({
+	getSpaceUntilMaxLength: getSpaceUntilMaxLength_1
+}, '__esModule', {value: true});
+
+var isDisabled_2 = isDisabled;
+
+// This should probably be extended with checking the element type
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled
+function isDisabled(element) {
+  return Boolean(element && element.disabled);
+}
+
+var isDisabled_1 = /*#__PURE__*/Object.defineProperty({
+	isDisabled: isDisabled_2
+}, '__esModule', {value: true});
+
+var getActiveElement_2 = getActiveElement;
+
+
+
+function getActiveElement(document) {
+  const activeElement = document.activeElement;
+
+  if (activeElement != null && activeElement.shadowRoot) {
+    return getActiveElement(activeElement.shadowRoot);
+  } else {
+    // Browser does not yield disabled elements as document.activeElement - jsdom does
+    if ((0, isDisabled_1.isDisabled)(activeElement)) {
+      return document.ownerDocument ? // TODO: verify behavior in ShadowRoot
+
+      /* istanbul ignore next */
+      document.ownerDocument.body : document.body;
+    }
+
+    return activeElement;
+  }
+}
+
+var getActiveElement_1 = /*#__PURE__*/Object.defineProperty({
+	getActiveElement: getActiveElement_2
+}, '__esModule', {value: true});
+
+var isLabelWithInternallyDisabledControl_2 = isLabelWithInternallyDisabledControl;
+
+
+
+
+
+// Absolutely NO events fire on label elements that contain their control
+// if that control is disabled. NUTS!
+// no joke. There are NO events for: <label><input disabled /><label>
+function isLabelWithInternallyDisabledControl(element) {
+  if (!(0, isElementType_1.isElementType)(element, 'label')) {
+    return false;
+  }
+
+  const control = element.control;
+  return Boolean(control && element.contains(control) && (0, isDisabled_1.isDisabled)(control));
+}
+
+var isLabelWithInternallyDisabledControl_1 = /*#__PURE__*/Object.defineProperty({
+	isLabelWithInternallyDisabledControl: isLabelWithInternallyDisabledControl_2
+}, '__esModule', {value: true});
+
+var selector = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.FOCUSABLE_SELECTOR = void 0;
+const FOCUSABLE_SELECTOR = ['input:not([type=hidden]):not([disabled])', 'button:not([disabled])', 'select:not([disabled])', 'textarea:not([disabled])', '[contenteditable=""]', '[contenteditable="true"]', 'a[href]', '[tabindex]:not([disabled])'].join(', ');
+exports.FOCUSABLE_SELECTOR = FOCUSABLE_SELECTOR;
+});
+
+var isFocusable_2 = isFocusable;
+
+
+
+
+
+function isFocusable(element) {
+  return !(0, isLabelWithInternallyDisabledControl_1.isLabelWithInternallyDisabledControl)(element) && element.matches(selector.FOCUSABLE_SELECTOR);
+}
+
+var isFocusable_1 = /*#__PURE__*/Object.defineProperty({
+	isFocusable: isFocusable_2
+}, '__esModule', {value: true});
+
+var _dom = /*@__PURE__*/getAugmentedNamespace(dom_esm);
+
+var eventWrapper_2 = eventWrapper;
+
+
+
+function eventWrapper(cb) {
+  let result;
+  (0, _dom.getConfig)().eventWrapper(() => {
+    result = cb();
+  });
+  return result;
+}
+
+var eventWrapper_1 = /*#__PURE__*/Object.defineProperty({
+	eventWrapper: eventWrapper_2
+}, '__esModule', {value: true});
+
+var helpers = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.getWindowFromNode = getWindowFromNode;
+exports.getDocument = getDocument;
+exports.runWithRealTimers = runWithRealTimers;
+exports.checkContainerType = checkContainerType;
+exports.jestFakeTimersAreEnabled = jestFakeTimersAreEnabled;
+exports.TEXT_NODE = exports.setTimeout = exports.setImmediate = exports.clearTimeout = void 0;
+const globalObj = typeof window === 'undefined' ? global$1 : window; // Constant node.nodeType for text nodes, see:
+// https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#Node_type_constants
+
+const TEXT_NODE = 3; // Currently this fn only supports jest timers, but it could support other test runners in the future.
+
+exports.TEXT_NODE = TEXT_NODE;
+
+function runWithRealTimers(callback) {
+  return hasJestTimers() ? runWithJestRealTimers(callback).callbackReturnValue : // istanbul ignore next
+  callback();
+}
+
+function hasJestTimers() {
+  return typeof jest !== 'undefined' && jest !== null && typeof jest.useRealTimers === 'function';
+}
+
+function runWithJestRealTimers(callback) {
+  const timerAPI = {
+    clearInterval,
+    clearTimeout,
+    setInterval,
+    setTimeout
+  }; // For more on why we have the check here,
+  // checkout https://github.com/testing-library/dom-testing-library/issues/914
+
+  if (typeof setImmediate === 'function') {
+    timerAPI.setImmediate = setImmediate;
+  }
+
+  if (typeof clearImmediate === 'function') {
+    timerAPI.clearImmediate = clearImmediate;
+  }
+
+  jest.useRealTimers();
+  const callbackReturnValue = callback();
+  const usedFakeTimers = Object.entries(timerAPI).some(([name, func]) => func !== globalObj[name]);
+
+  if (usedFakeTimers) {
+    var _timerAPI$setTimeout;
+
+    jest.useFakeTimers((_timerAPI$setTimeout = timerAPI.setTimeout) != null && _timerAPI$setTimeout.clock ? 'modern' : 'legacy');
+  }
+
+  return {
+    callbackReturnValue,
+    usedFakeTimers
+  };
+}
+
+function jestFakeTimersAreEnabled() {
+  return hasJestTimers() ? runWithJestRealTimers(() => {}).usedFakeTimers : // istanbul ignore next
+  false;
+} // we only run our tests in node, and setImmediate is supported in node.
+// istanbul ignore next
+
+
+function setImmediatePolyfill(fn) {
+  return globalObj.setTimeout(fn, 0);
+}
+
+function getTimeFunctions() {
+  // istanbul ignore next
+  return {
+    clearTimeoutFn: globalObj.clearTimeout,
+    setImmediateFn: globalObj.setImmediate || setImmediatePolyfill,
+    setTimeoutFn: globalObj.setTimeout
+  };
+}
+
+const {
+  clearTimeoutFn,
+  setImmediateFn,
+  setTimeoutFn
+} = runWithRealTimers(getTimeFunctions);
+exports.setTimeout = setTimeoutFn;
+exports.setImmediate = setImmediateFn;
+exports.clearTimeout = clearTimeoutFn;
+
+function getDocument() {
+  /* istanbul ignore if */
+  if (typeof window === 'undefined') {
+    throw new Error('Could not find default container');
+  }
+
+  return window.document;
+}
+
+function getWindowFromNode(node) {
+  if (node.defaultView) {
+    // node is document
+    return node.defaultView;
+  } else if (node.ownerDocument && node.ownerDocument.defaultView) {
+    // node is a DOM node
+    return node.ownerDocument.defaultView;
+  } else if (node.window) {
+    // node is window
+    return node.window;
+  } else if (node.then instanceof Function) {
+    throw new Error(`It looks like you passed a Promise object instead of a DOM node. Did you do something like \`fireEvent.click(screen.findBy...\` when you meant to use a \`getBy\` query \`fireEvent.click(screen.getBy...\`, or await the findBy query \`fireEvent.click(await screen.findBy...\`?`);
+  } else if (Array.isArray(node)) {
+    throw new Error(`It looks like you passed an Array instead of a DOM node. Did you do something like \`fireEvent.click(screen.getAllBy...\` when you meant to use a \`getBy\` query \`fireEvent.click(screen.getBy...\`?`);
+  } else if (typeof node.debug === 'function' && typeof node.logTestingPlaygroundURL === 'function') {
+    throw new Error(`It looks like you passed a \`screen\` object. Did you do something like \`fireEvent.click(screen, ...\` when you meant to use a query, e.g. \`fireEvent.click(screen.getBy..., \`?`);
+  } else {
+    // The user passed something unusual to a calling function
+    throw new Error(`Unable to find the "window" object for the given node. Please file an issue with the code that's causing you to see this error: https://github.com/testing-library/dom-testing-library/issues/new`);
+  }
+}
+
+function checkContainerType(container) {
+  if (!container || !(typeof container.querySelector === 'function') || !(typeof container.querySelectorAll === 'function')) {
+    throw new TypeError(`Expected container to be an Element, a Document or a DocumentFragment but got ${getTypeName(container)}.`);
+  }
+
+  function getTypeName(object) {
+    if (typeof object === 'object') {
+      return object === null ? 'null' : object.constructor.name;
+    }
+
+    return typeof object;
+  }
+}
+});
+
+var isVisible_2 = isVisible;
+
+
+
+function isVisible(element) {
+  const window = (0, helpers.getWindowFromNode)(element);
+
+  for (let el = element; (_el = el) != null && _el.ownerDocument; el = el.parentElement) {
+    var _el;
+
+    const display = window.getComputedStyle(el).display;
+
+    if (display === 'none') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+var isVisible_1 = /*#__PURE__*/Object.defineProperty({
+	isVisible: isVisible_2
+}, '__esModule', {value: true});
+
+var isDocument_2 = isDocument;
+
+function isDocument(el) {
+  return el.nodeType === el.DOCUMENT_NODE;
+}
+
+var isDocument_1 = /*#__PURE__*/Object.defineProperty({
+	isDocument: isDocument_2
+}, '__esModule', {value: true});
+
+var wait_2 = wait;
+
+function wait(time) {
+  return new Promise(resolve => setTimeout(() => resolve(), time));
+}
+
+var wait_1 = /*#__PURE__*/Object.defineProperty({
+	wait: wait_2
+}, '__esModule', {value: true});
+
+var hasPointerEvents_2 = hasPointerEvents;
+
+
+
+function hasPointerEvents(element) {
+  const window = (0, helpers.getWindowFromNode)(element);
+
+  for (let el = element; (_el = el) != null && _el.ownerDocument; el = el.parentElement) {
+    var _el;
+
+    const pointerEvents = window.getComputedStyle(el).pointerEvents;
+
+    if (pointerEvents && !['inherit', 'unset'].includes(pointerEvents)) {
+      return pointerEvents !== 'none';
+    }
+  }
+
+  return true;
+}
+
+var hasPointerEvents_1 = /*#__PURE__*/Object.defineProperty({
+	hasPointerEvents: hasPointerEvents_2
+}, '__esModule', {value: true});
+
+var hasFormSubmit_1 = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.hasFormSubmit = void 0;
+
+const hasFormSubmit = form => !!(form && (form.querySelector('input[type="submit"]') || form.querySelector('button[type="submit"]')));
+
+exports.hasFormSubmit = hasFormSubmit;
+});
+
+var utils = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+
+
+Object.keys(getMouseEventOptions_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === getMouseEventOptions_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return getMouseEventOptions_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(isClickableInput_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === isClickableInput_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return isClickableInput_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(buildTimeValue_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === buildTimeValue_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return buildTimeValue_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(calculateNewValue_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === calculateNewValue_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return calculateNewValue_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(cursorPosition).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === cursorPosition[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return cursorPosition[key];
+    }
+  });
+});
+
+
+
+Object.keys(getValue_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === getValue_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return getValue_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(hasUnreliableEmptyValue_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === hasUnreliableEmptyValue_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return hasUnreliableEmptyValue_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(isContentEditable_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === isContentEditable_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return isContentEditable_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(isEditable_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === isEditable_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return isEditable_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(isValidDateValue_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === isValidDateValue_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return isValidDateValue_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(isValidInputTimeValue_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === isValidInputTimeValue_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return isValidInputTimeValue_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(maxLength).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === maxLength[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return maxLength[key];
+    }
+  });
+});
+
+
+
+Object.keys(selectionRange).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === selectionRange[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return selectionRange[key];
+    }
+  });
+});
+
+
+
+Object.keys(getActiveElement_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === getActiveElement_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return getActiveElement_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(isFocusable_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === isFocusable_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return isFocusable_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(selector).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === selector[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return selector[key];
+    }
+  });
+});
+
+
+
+Object.keys(eventWrapper_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === eventWrapper_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return eventWrapper_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(isElementType_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === isElementType_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return isElementType_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(isLabelWithInternallyDisabledControl_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === isLabelWithInternallyDisabledControl_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return isLabelWithInternallyDisabledControl_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(isVisible_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === isVisible_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return isVisible_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(isDisabled_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === isDisabled_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return isDisabled_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(isDocument_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === isDocument_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return isDocument_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(wait_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === wait_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return wait_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(hasPointerEvents_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === hasPointerEvents_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return hasPointerEvents_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(hasFormSubmit_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === hasFormSubmit_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return hasFormSubmit_1[key];
+    }
+  });
+});
+});
+
+var hover_2 = hover;
+var unhover_1 = unhover;
+
+
+
+
+
+// includes `element`
+function getParentElements(element) {
+  const parentElements = [element];
+  let currentElement = element;
+
+  while ((currentElement = currentElement.parentElement) != null) {
+    parentElements.push(currentElement);
+  }
+
+  return parentElements;
+}
+
+function hover(element, init, {
+  skipPointerEventsCheck = false
+} = {}) {
+  if (!skipPointerEventsCheck && !(0, utils.hasPointerEvents)(element)) {
+    throw new Error('unable to hover element as it has or inherits pointer-events set to "none".');
+  }
+
+  if ((0, utils.isLabelWithInternallyDisabledControl)(element)) return;
+  const parentElements = getParentElements(element).reverse();
+
+  _dom.fireEvent.pointerOver(element, init);
+
+  for (const el of parentElements) {
+    _dom.fireEvent.pointerEnter(el, init);
+  }
+
+  if (!(0, utils.isDisabled)(element)) {
+    _dom.fireEvent.mouseOver(element, (0, utils.getMouseEventOptions)('mouseover', init));
+
+    for (const el of parentElements) {
+      _dom.fireEvent.mouseEnter(el, (0, utils.getMouseEventOptions)('mouseenter', init));
+    }
+  }
+
+  _dom.fireEvent.pointerMove(element, init);
+
+  if (!(0, utils.isDisabled)(element)) {
+    _dom.fireEvent.mouseMove(element, (0, utils.getMouseEventOptions)('mousemove', init));
+  }
+}
+
+function unhover(element, init, {
+  skipPointerEventsCheck = false
+} = {}) {
+  if (!skipPointerEventsCheck && !(0, utils.hasPointerEvents)(element)) {
+    throw new Error('unable to unhover element as it has or inherits pointer-events set to "none".');
+  }
+
+  if ((0, utils.isLabelWithInternallyDisabledControl)(element)) return;
+  const parentElements = getParentElements(element);
+
+  _dom.fireEvent.pointerMove(element, init);
+
+  if (!(0, utils.isDisabled)(element)) {
+    _dom.fireEvent.mouseMove(element, (0, utils.getMouseEventOptions)('mousemove', init));
+  }
+
+  _dom.fireEvent.pointerOut(element, init);
+
+  for (const el of parentElements) {
+    _dom.fireEvent.pointerLeave(el, init);
+  }
+
+  if (!(0, utils.isDisabled)(element)) {
+    _dom.fireEvent.mouseOut(element, (0, utils.getMouseEventOptions)('mouseout', init));
+
+    for (const el of parentElements) {
+      _dom.fireEvent.mouseLeave(el, (0, utils.getMouseEventOptions)('mouseleave', init));
+    }
+  }
+}
+
+var hover_1 = /*#__PURE__*/Object.defineProperty({
+	hover: hover_2,
+	unhover: unhover_1
+}, '__esModule', {value: true});
+
+var blur_2 = blur;
+
+
+
+function blur(element) {
+  if (!(0, utils.isFocusable)(element)) return;
+  const wasActive = (0, utils.getActiveElement)(element.ownerDocument) === element;
+  if (!wasActive) return;
+  (0, utils.eventWrapper)(() => element.blur());
+}
+
+var blur_1 = /*#__PURE__*/Object.defineProperty({
+	blur: blur_2
+}, '__esModule', {value: true});
+
+var focus_2 = focus;
+
+
+
+function focus(element) {
+  if (!(0, utils.isFocusable)(element)) return;
+  const isAlreadyActive = (0, utils.getActiveElement)(element.ownerDocument) === element;
+  if (isAlreadyActive) return;
+  (0, utils.eventWrapper)(() => element.focus());
+}
+
+var focus_1 = /*#__PURE__*/Object.defineProperty({
+	focus: focus_2
+}, '__esModule', {value: true});
+
+var click_2 = click;
+var dblClick_1 = dblClick;
+
+
+
+
+
+
+
+
+
+
+
+function getPreviouslyFocusedElement(element) {
+  const focusedElement = element.ownerDocument.activeElement;
+  const wasAnotherElementFocused = focusedElement && focusedElement !== element.ownerDocument.body && focusedElement !== element;
+  return wasAnotherElementFocused ? focusedElement : null;
+}
+
+function clickLabel(label, init, {
+  clickCount
+}) {
+  if ((0, utils.isLabelWithInternallyDisabledControl)(label)) return;
+
+  _dom.fireEvent.pointerDown(label, init);
+
+  _dom.fireEvent.mouseDown(label, (0, utils.getMouseEventOptions)('mousedown', init, clickCount));
+
+  _dom.fireEvent.pointerUp(label, init);
+
+  _dom.fireEvent.mouseUp(label, (0, utils.getMouseEventOptions)('mouseup', init, clickCount));
+
+  fireClick(label, (0, utils.getMouseEventOptions)('click', init, clickCount)); // clicking the label will trigger a click of the label.control
+  // however, it will not focus the label.control so we have to do it
+  // ourselves.
+
+  if (label.control) (0, focus_1.focus)(label.control);
+}
+
+function clickBooleanElement(element, init, {
+  clickCount
+}) {
+  _dom.fireEvent.pointerDown(element, init);
+
+  if (!element.disabled) {
+    _dom.fireEvent.mouseDown(element, (0, utils.getMouseEventOptions)('mousedown', init, clickCount));
+  }
+
+  (0, focus_1.focus)(element);
+
+  _dom.fireEvent.pointerUp(element, init);
+
+  if (!element.disabled) {
+    _dom.fireEvent.mouseUp(element, (0, utils.getMouseEventOptions)('mouseup', init, clickCount));
+
+    fireClick(element, (0, utils.getMouseEventOptions)('click', init, clickCount));
+  }
+}
+
+function clickElement(element, init, {
+  clickCount
+}) {
+  const previousElement = getPreviouslyFocusedElement(element);
+
+  _dom.fireEvent.pointerDown(element, init);
+
+  if (!(0, utils.isDisabled)(element)) {
+    const continueDefaultHandling = _dom.fireEvent.mouseDown(element, (0, utils.getMouseEventOptions)('mousedown', init, clickCount));
+
+    if (continueDefaultHandling) {
+      const closestFocusable = findClosest(element, utils.isFocusable);
+
+      if (previousElement && !closestFocusable) {
+        (0, blur_1.blur)(previousElement);
+      } else if (closestFocusable) {
+        (0, focus_1.focus)(closestFocusable);
+      }
+    }
+  }
+
+  _dom.fireEvent.pointerUp(element, init);
+
+  if (!(0, utils.isDisabled)(element)) {
+    _dom.fireEvent.mouseUp(element, (0, utils.getMouseEventOptions)('mouseup', init, clickCount));
+
+    fireClick(element, (0, utils.getMouseEventOptions)('click', init, clickCount));
+    const parentLabel = element.closest('label');
+    if (parentLabel != null && parentLabel.control) (0, focus_1.focus)(parentLabel.control);
+  }
+}
+
+function findClosest(element, callback) {
+  let el = element;
+
+  do {
+    if (callback(el)) {
+      return el;
+    }
+
+    el = el.parentElement;
+  } while (el && el !== element.ownerDocument.body);
+
+  return undefined;
+}
+
+function click(element, init, {
+  skipHover = false,
+  clickCount = 0,
+  skipPointerEventsCheck = false
+} = {}) {
+  if (!skipPointerEventsCheck && !(0, utils.hasPointerEvents)(element)) {
+    throw new Error('unable to click element as it has or inherits pointer-events set to "none".');
+  } // We just checked for `pointerEvents`. We can always skip this one in `hover`.
+
+
+  if (!skipHover) (0, hover_1.hover)(element, init, {
+    skipPointerEventsCheck: true
+  });
+
+  if ((0, utils.isElementType)(element, 'label')) {
+    clickLabel(element, init, {
+      clickCount
+    });
+  } else if ((0, utils.isElementType)(element, 'input')) {
+    if (element.type === 'checkbox' || element.type === 'radio') {
+      clickBooleanElement(element, init, {
+        clickCount
+      });
+    } else {
+      clickElement(element, init, {
+        clickCount
+      });
+    }
+  } else {
+    clickElement(element, init, {
+      clickCount
+    });
+  }
+}
+
+function fireClick(element, mouseEventOptions) {
+  if (mouseEventOptions.button === 2) {
+    _dom.fireEvent.contextMenu(element, mouseEventOptions);
+  } else {
+    _dom.fireEvent.click(element, mouseEventOptions);
+  }
+}
+
+function dblClick(element, init, {
+  skipPointerEventsCheck = false
+} = {}) {
+  if (!skipPointerEventsCheck && !(0, utils.hasPointerEvents)(element)) {
+    throw new Error('unable to double-click element as it has or inherits pointer-events set to "none".');
+  }
+
+  (0, hover_1.hover)(element, init, {
+    skipPointerEventsCheck
+  });
+  click(element, init, {
+    skipHover: true,
+    clickCount: 0,
+    skipPointerEventsCheck
+  });
+  click(element, init, {
+    skipHover: true,
+    clickCount: 1,
+    skipPointerEventsCheck
+  });
+
+  _dom.fireEvent.dblClick(element, (0, utils.getMouseEventOptions)('dblclick', init, 2));
+}
+
+var click_1 = /*#__PURE__*/Object.defineProperty({
+	click: click_2,
+	dblClick: dblClick_1
+}, '__esModule', {value: true});
+
+var getNextKeyDef_2 = getNextKeyDef;
+var bracketDict;
+
+(function (bracketDict) {
+  bracketDict["{"] = "}";
+  bracketDict["["] = "]";
+})(bracketDict || (bracketDict = {}));
+
+var legacyModifiers;
+
+(function (legacyModifiers) {
+  legacyModifiers["alt"] = "alt";
+  legacyModifiers["ctrl"] = "ctrl";
+  legacyModifiers["meta"] = "meta";
+  legacyModifiers["shift"] = "shift";
+})(legacyModifiers || (legacyModifiers = {}));
+
+var legacyKeyMap;
+/**
+ * Get the next key from keyMap
+ *
+ * Keys can be referenced by `{key}` or `{special}` as well as physical locations per `[code]`.
+ * Everything else will be interpreted as a typed character - e.g. `a`.
+ * Brackets `{` and `[` can be escaped by doubling - e.g. `foo[[bar` translates to `foo[bar`.
+ * Keeping the key pressed can be written as `{key>}`.
+ * When keeping the key pressed you can choose how long (how many keydown and keypress) the key is pressed `{key>3}`.
+ * You can then release the key per `{key>3/}` or keep it pressed and continue with the next key.
+ * Modifiers like `{shift}` imply being kept pressed. This can be turned of per `{shift/}`.
+ */
+
+(function (legacyKeyMap) {
+  legacyKeyMap["ctrl"] = "Control";
+  legacyKeyMap["del"] = "Delete";
+  legacyKeyMap["esc"] = "Escape";
+  legacyKeyMap["space"] = " ";
+})(legacyKeyMap || (legacyKeyMap = {}));
+
+function getNextKeyDef(text, options) {
+  var _options$keyboardMap$;
+
+  const {
+    type,
+    descriptor,
+    consumedLength,
+    releasePrevious,
+    releaseSelf,
+    repeat
+  } = readNextDescriptor(text);
+  const keyDef = (_options$keyboardMap$ = options.keyboardMap.find(def => {
+    if (type === '[') {
+      var _def$code;
+
+      return ((_def$code = def.code) == null ? void 0 : _def$code.toLowerCase()) === descriptor.toLowerCase();
+    } else if (type === '{') {
+      var _def$key;
+
+      const key = mapLegacyKey(descriptor);
+      return ((_def$key = def.key) == null ? void 0 : _def$key.toLowerCase()) === key.toLowerCase();
+    }
+
+    return def.key === descriptor;
+  })) != null ? _options$keyboardMap$ : {
+    key: 'Unknown',
+    code: 'Unknown',
+    [type === '[' ? 'code' : 'key']: descriptor
+  };
+  return {
+    keyDef,
+    consumedLength,
+    releasePrevious,
+    releaseSelf,
+    repeat
+  };
+}
+
+function readNextDescriptor(text) {
+  let pos = 0;
+  const startBracket = text[pos] in bracketDict ? text[pos] : '';
+  pos += startBracket.length; // `foo{{bar` is an escaped char at position 3,
+  // but `foo{{{>5}bar` should be treated as `{` pressed down for 5 keydowns.
+
+  const startBracketRepeated = startBracket ? text.match(new RegExp(`^\\${startBracket}+`))[0].length : 0;
+  const isEscapedChar = startBracketRepeated === 2 || startBracket === '{' && startBracketRepeated > 3;
+  const type = isEscapedChar ? '' : startBracket;
+  return {
+    type,
+    ...(type === '' ? readPrintableChar(text, pos) : readTag(text, pos, type))
+  };
+}
+
+function readPrintableChar(text, pos) {
+  const descriptor = text[pos];
+  assertDescriptor(descriptor, text, pos);
+  pos += descriptor.length;
+  return {
+    consumedLength: pos,
+    descriptor,
+    releasePrevious: false,
+    releaseSelf: true,
+    repeat: 1
+  };
+}
+
+function readTag(text, pos, startBracket) {
+  var _text$slice$match, _text$slice$match$, _text$slice$match2;
+
+  const releasePreviousModifier = text[pos] === '/' ? '/' : '';
+  pos += releasePreviousModifier.length;
+  const descriptor = (_text$slice$match = text.slice(pos).match(/^\w+/)) == null ? void 0 : _text$slice$match[0];
+  assertDescriptor(descriptor, text, pos);
+  pos += descriptor.length;
+  const repeatModifier = (_text$slice$match$ = (_text$slice$match2 = text.slice(pos).match(/^>\d+/)) == null ? void 0 : _text$slice$match2[0]) != null ? _text$slice$match$ : '';
+  pos += repeatModifier.length;
+  const releaseSelfModifier = text[pos] === '/' || !repeatModifier && text[pos] === '>' ? text[pos] : '';
+  pos += releaseSelfModifier.length;
+  const expectedEndBracket = bracketDict[startBracket];
+  const endBracket = text[pos] === expectedEndBracket ? expectedEndBracket : '';
+
+  if (!endBracket) {
+    throw new Error(getErrorMessage([!repeatModifier && 'repeat modifier', !releaseSelfModifier && 'release modifier', `"${expectedEndBracket}"`].filter(Boolean).join(' or '), text[pos], text));
+  }
+
+  pos += endBracket.length;
+  return {
+    consumedLength: pos,
+    descriptor,
+    releasePrevious: !!releasePreviousModifier,
+    repeat: repeatModifier ? Math.max(Number(repeatModifier.substr(1)), 1) : 1,
+    releaseSelf: hasReleaseSelf(startBracket, descriptor, releaseSelfModifier, repeatModifier)
+  };
+}
+
+function assertDescriptor(descriptor, text, pos) {
+  if (!descriptor) {
+    throw new Error(getErrorMessage('key descriptor', text[pos], text));
+  }
+}
+
+function getEnumValue(f, key) {
+  return f[key];
+}
+
+function hasReleaseSelf(startBracket, descriptor, releaseSelfModifier, repeatModifier) {
+  if (releaseSelfModifier) {
+    return releaseSelfModifier === '/';
+  }
+
+  if (repeatModifier) {
+    return false;
+  }
+
+  if (startBracket === '{' && getEnumValue(legacyModifiers, descriptor.toLowerCase())) {
+    return false;
+  }
+
+  return true;
+}
+
+function mapLegacyKey(descriptor) {
+  var _getEnumValue;
+
+  return (_getEnumValue = getEnumValue(legacyKeyMap, descriptor)) != null ? _getEnumValue : descriptor;
+}
+
+function getErrorMessage(expected, found, text) {
+  return `Expected ${expected} but found "${found != null ? found : ''}" in "${text}"
+    See https://github.com/testing-library/user-event/blob/main/README.md#keyboardtext-options
+    for more information about how userEvent parses your input.`;
+}
+
+var getNextKeyDef_1 = /*#__PURE__*/Object.defineProperty({
+	getNextKeyDef: getNextKeyDef_2
+}, '__esModule', {value: true});
+
+var arrow = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.keydownBehavior = void 0;
+
+
+
+/**
+ * This file should contain behavior for arrow keys as described here:
+ * https://w3c.github.io/uievents-code/#key-arrowpad-section
+ */
+const keydownBehavior = [{
+  // TODO: implement for contentEditable
+  matches: (keyDef, element) => (keyDef.key === 'ArrowLeft' || keyDef.key === 'ArrowRight') && (0, utils.isElementType)(element, ['input', 'textarea']),
+  handle: (keyDef, element) => {
+    var _ref;
+
+    const {
+      selectionStart,
+      selectionEnd
+    } = (0, utils.getSelectionRange)(element);
+    const direction = keyDef.key === 'ArrowLeft' ? -1 : 1;
+    const newPos = (_ref = selectionStart === selectionEnd ? (selectionStart != null ? selectionStart :
+    /* istanbul ignore next */
+    0) + direction : direction < 0 ? selectionStart : selectionEnd) != null ? _ref :
+    /* istanbul ignore next */
+    0;
+    (0, utils.setSelectionRange)(element, newPos, newPos);
+  }
+}];
+exports.keydownBehavior = keydownBehavior;
+});
+
+var carryValue_2 = carryValue;
+
+
+
+function carryValue(element, state, newValue) {
+  const value = (0, utils.getValue)(element);
+  state.carryValue = value !== newValue && value === '' && (0, utils.hasUnreliableEmptyValue)(element) ? newValue : undefined;
+}
+
+var carryValue_1 = /*#__PURE__*/Object.defineProperty({
+	carryValue: carryValue_2
+}, '__esModule', {value: true});
+
+var fireChangeForInputTimeIfValid_2 = fireChangeForInputTimeIfValid;
+
+
+
+
+
+function fireChangeForInputTimeIfValid(el, prevValue, timeNewEntry) {
+  if ((0, utils.isValidInputTimeValue)(el, timeNewEntry) && prevValue !== timeNewEntry) {
+    _dom.fireEvent.change(el, {
+      target: {
+        value: timeNewEntry
+      }
+    });
+  }
+}
+
+var fireChangeForInputTimeIfValid_1 = /*#__PURE__*/Object.defineProperty({
+	fireChangeForInputTimeIfValid: fireChangeForInputTimeIfValid_2
+}, '__esModule', {value: true});
+
+var fireInputEvent_2 = fireInputEvent;
+
+
+
+
+
+function fireInputEvent(element, {
+  newValue,
+  newSelectionStart,
+  eventOverrides
+}) {
+  // apply the changes before firing the input event, so that input handlers can access the altered dom and selection
+  if ((0, utils.isContentEditable)(element)) {
+    applyNative(element, 'textContent', newValue);
+  } else
+    /* istanbul ignore else */
+    if ((0, utils.isElementType)(element, ['input', 'textarea'])) {
+      applyNative(element, 'value', newValue);
+    } else {
+      // TODO: properly type guard
+      throw new Error('Invalid Element');
+    }
+
+  setSelectionRangeAfterInput(element, newSelectionStart);
+
+  _dom.fireEvent.input(element, { ...eventOverrides
+  });
+
+  setSelectionRangeAfterInputHandler(element, newValue, newSelectionStart);
+}
+
+function setSelectionRangeAfterInput(element, newSelectionStart) {
+  (0, utils.setSelectionRange)(element, newSelectionStart, newSelectionStart);
+}
+
+function setSelectionRangeAfterInputHandler(element, newValue, newSelectionStart) {
+  const value = (0, utils.getValue)(element); // don't apply this workaround on elements that don't necessarily report the visible value - e.g. number
+  // TODO: this could probably be only applied when there is keyboardState.carryValue
+
+  const isUnreliableValue = value === '' && (0, utils.hasUnreliableEmptyValue)(element);
+
+  if (!isUnreliableValue && value === newValue) {
+    const {
+      selectionStart
+    } = (0, utils.getSelectionRange)(element);
+
+    if (selectionStart === value.length) {
+      // The value was changed as expected, but the cursor was moved to the end
+      // TODO: this could probably be only applied when we work around a framework setter on the element in applyNative
+      (0, utils.setSelectionRange)(element, newSelectionStart, newSelectionStart);
+    }
+  }
+}
+
+const initial = Symbol('initial input value/textContent');
+const onBlur = Symbol('onBlur');
+
+/**
+ * React tracks the changes on element properties.
+ * This workaround tries to alter the DOM element without React noticing,
+ * so that it later picks up the change.
+ *
+ * @see https://github.com/facebook/react/blob/148f8e497c7d37a3c7ab99f01dec2692427272b1/packages/react-dom/src/client/inputValueTracking.js#L51-L104
+ */
+function applyNative(element, propName, propValue) {
+  const descriptor = Object.getOwnPropertyDescriptor(element, propName);
+  const nativeDescriptor = Object.getOwnPropertyDescriptor(element.constructor.prototype, propName);
+
+  if (descriptor && nativeDescriptor) {
+    Object.defineProperty(element, propName, nativeDescriptor);
+  } // Keep track of the initial value to determine if a change event should be dispatched.
+  // CONSTRAINT: We can not determine what happened between focus event and our first API call.
+
+
+  if (element[initial] === undefined) {
+    element[initial] = String(element[propName]);
+  }
+
+  element[propName] = propValue; // Add an event listener for the blur event to the capture phase on the window.
+  // CONSTRAINT: Currently there is no cross-platform solution to unshift the event handler stack.
+  // Our change event might occur after other event handlers on the blur event have been processed.
+
+  if (!element[onBlur]) {
+    var _element$ownerDocumen;
+
+    (_element$ownerDocumen = element.ownerDocument.defaultView) == null ? void 0 : _element$ownerDocumen.addEventListener('blur', element[onBlur] = () => {
+      const initV = element[initial]; // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+
+      delete element[onBlur]; // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+
+      delete element[initial];
+
+      if (String(element[propName]) !== initV) {
+        _dom.fireEvent.change(element);
+      }
+    }, {
+      capture: true,
+      once: true
+    });
+  }
+
+  if (descriptor) {
+    Object.defineProperty(element, propName, descriptor);
+  }
+}
+
+var fireInputEvent_1 = /*#__PURE__*/Object.defineProperty({
+	fireInputEvent: fireInputEvent_2
+}, '__esModule', {value: true});
+
+var shared = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+
+
+Object.keys(carryValue_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === carryValue_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return carryValue_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(fireChangeForInputTimeIfValid_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === fireChangeForInputTimeIfValid_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return fireChangeForInputTimeIfValid_1[key];
+    }
+  });
+});
+
+
+
+Object.keys(fireInputEvent_1).forEach(function (key) {
+  if (key === "default" || key === "__esModule") return;
+  if (key in exports && exports[key] === fireInputEvent_1[key]) return;
+  Object.defineProperty(exports, key, {
+    enumerable: true,
+    get: function () {
+      return fireInputEvent_1[key];
+    }
+  });
+});
+});
+
+var control = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.keydownBehavior = void 0;
+
+
+
+
+
+/**
+ * This file should contain behavior for arrow keys as described here:
+ * https://w3c.github.io/uievents-code/#key-controlpad-section
+ */
+const keydownBehavior = [{
+  matches: (keyDef, element) => (keyDef.key === 'Home' || keyDef.key === 'End') && ((0, utils.isElementType)(element, ['input', 'textarea']) || (0, utils.isContentEditable)(element)),
+  handle: (keyDef, element) => {
+    // This could probably been improved by collapsing a selection range
+    if (keyDef.key === 'Home') {
+      (0, utils.setSelectionRange)(element, 0, 0);
+    } else {
+      var _getValue$length, _getValue;
+
+      const newPos = (_getValue$length = (_getValue = (0, utils.getValue)(element)) == null ? void 0 : _getValue.length) != null ? _getValue$length :
+      /* istanbul ignore next */
+      0;
+      (0, utils.setSelectionRange)(element, newPos, newPos);
+    }
+  }
+}, {
+  matches: (keyDef, element) => (keyDef.key === 'PageUp' || keyDef.key === 'PageDown') && (0, utils.isElementType)(element, ['input']),
+  handle: (keyDef, element) => {
+    // This could probably been improved by collapsing a selection range
+    if (keyDef.key === 'PageUp') {
+      (0, utils.setSelectionRange)(element, 0, 0);
+    } else {
+      var _getValue$length2, _getValue2;
+
+      const newPos = (_getValue$length2 = (_getValue2 = (0, utils.getValue)(element)) == null ? void 0 : _getValue2.length) != null ? _getValue$length2 :
+      /* istanbul ignore next */
+      0;
+      (0, utils.setSelectionRange)(element, newPos, newPos);
+    }
+  }
+}, {
+  matches: (keyDef, element) => keyDef.key === 'Delete' && (0, utils.isEditable)(element) && !(0, utils.isCursorAtEnd)(element),
+  handle: (keDef, element, options, state) => {
+    const {
+      newValue,
+      newSelectionStart
+    } = (0, utils.calculateNewValue)('', element, state.carryValue, undefined, 'forward');
+    (0, shared.fireInputEvent)(element, {
+      newValue,
+      newSelectionStart,
+      eventOverrides: {
+        inputType: 'deleteContentForward'
+      }
+    });
+    (0, shared.carryValue)(element, state, newValue);
+  }
+}];
+exports.keydownBehavior = keydownBehavior;
+});
+
+var character = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.keypressBehavior = void 0;
+
+
+
+
+
+
+
+/**
+ * This file should cover the behavior for keys that produce character input
+ */
+const keypressBehavior = [{
+  matches: (keyDef, element) => {
+    var _keyDef$key;
+
+    return ((_keyDef$key = keyDef.key) == null ? void 0 : _keyDef$key.length) === 1 && (0, utils.isElementType)(element, 'input', {
+      type: 'time',
+      readOnly: false
+    });
+  },
+  handle: (keyDef, element, options, state) => {
+    var _state$carryValue;
+
+    let newEntry = keyDef.key;
+    const textToBeTyped = ((_state$carryValue = state.carryValue) != null ? _state$carryValue : '') + newEntry;
+    const timeNewEntry = (0, utils.buildTimeValue)(textToBeTyped);
+
+    if ((0, utils.isValidInputTimeValue)(element, timeNewEntry)) {
+      newEntry = timeNewEntry;
+    }
+
+    const {
+      newValue,
+      newSelectionStart
+    } = (0, utils.calculateNewValue)(newEntry, element);
+    const prevValue = (0, utils.getValue)(element); // this check was provided by fireInputEventIfNeeded
+    // TODO: verify if it is even needed by this handler
+
+    if (prevValue !== newValue) {
+      (0, shared.fireInputEvent)(element, {
+        newValue,
+        newSelectionStart,
+        eventOverrides: {
+          data: keyDef.key,
+          inputType: 'insertText'
+        }
+      });
+    }
+
+    (0, shared.fireChangeForInputTimeIfValid)(element, prevValue, timeNewEntry);
+    state.carryValue = textToBeTyped;
+  }
+}, {
+  matches: (keyDef, element) => {
+    var _keyDef$key2;
+
+    return ((_keyDef$key2 = keyDef.key) == null ? void 0 : _keyDef$key2.length) === 1 && (0, utils.isElementType)(element, 'input', {
+      type: 'date',
+      readOnly: false
+    });
+  },
+  handle: (keyDef, element, options, state) => {
+    var _state$carryValue2;
+
+    let newEntry = keyDef.key;
+    const textToBeTyped = ((_state$carryValue2 = state.carryValue) != null ? _state$carryValue2 : '') + newEntry;
+    const isValidToBeTyped = (0, utils.isValidDateValue)(element, textToBeTyped);
+
+    if (isValidToBeTyped) {
+      newEntry = textToBeTyped;
+    }
+
+    const {
+      newValue,
+      newSelectionStart
+    } = (0, utils.calculateNewValue)(newEntry, element);
+    const prevValue = (0, utils.getValue)(element); // this check was provided by fireInputEventIfNeeded
+    // TODO: verify if it is even needed by this handler
+
+    if (prevValue !== newValue) {
+      (0, shared.fireInputEvent)(element, {
+        newValue,
+        newSelectionStart,
+        eventOverrides: {
+          data: keyDef.key,
+          inputType: 'insertText'
+        }
+      });
+    }
+
+    if (isValidToBeTyped) {
+      _dom.fireEvent.change(element, {
+        target: {
+          value: textToBeTyped
+        }
+      });
+    }
+
+    state.carryValue = textToBeTyped;
+  }
+}, {
+  matches: (keyDef, element) => {
+    var _keyDef$key3;
+
+    return ((_keyDef$key3 = keyDef.key) == null ? void 0 : _keyDef$key3.length) === 1 && (0, utils.isElementType)(element, 'input', {
+      type: 'number',
+      readOnly: false
+    });
+  },
+  handle: (keyDef, element, options, state) => {
+    var _ref, _state$carryValue3, _newValue$match, _newValue$match2;
+
+    if (!/[\d.\-e]/.test(keyDef.key)) {
+      return;
+    }
+
+    const oldValue = (_ref = (_state$carryValue3 = state.carryValue) != null ? _state$carryValue3 : (0, utils.getValue)(element)) != null ? _ref :
+    /* istanbul ignore next */
+    '';
+    const {
+      newValue,
+      newSelectionStart
+    } = (0, utils.calculateNewValue)(keyDef.key, element, oldValue); // the browser allows some invalid input but not others
+    // it allows up to two '-' at any place before any 'e' or one directly following 'e'
+    // it allows one '.' at any place before e
+
+    const valueParts = newValue.split('e', 2);
+
+    if (Number((_newValue$match = newValue.match(/-/g)) == null ? void 0 : _newValue$match.length) > 2 || Number((_newValue$match2 = newValue.match(/\./g)) == null ? void 0 : _newValue$match2.length) > 1 || valueParts[1] && !/^-?\d*$/.test(valueParts[1])) {
+      return;
+    }
+
+    (0, shared.fireInputEvent)(element, {
+      newValue,
+      newSelectionStart,
+      eventOverrides: {
+        data: keyDef.key,
+        inputType: 'insertText'
+      }
+    });
+    const appliedValue = (0, utils.getValue)(element);
+
+    if (appliedValue === newValue) {
+      state.carryValue = undefined;
+    } else {
+      state.carryValue = newValue;
+    }
+  }
+}, {
+  matches: (keyDef, element) => {
+    var _keyDef$key4;
+
+    return ((_keyDef$key4 = keyDef.key) == null ? void 0 : _keyDef$key4.length) === 1 && ((0, utils.isElementType)(element, ['input', 'textarea'], {
+      readOnly: false
+    }) && !(0, utils.isClickableInput)(element) || (0, utils.isContentEditable)(element)) && (0, utils.getSpaceUntilMaxLength)(element) !== 0;
+  },
+  handle: (keyDef, element) => {
+    const {
+      newValue,
+      newSelectionStart
+    } = (0, utils.calculateNewValue)(keyDef.key, element);
+    (0, shared.fireInputEvent)(element, {
+      newValue,
+      newSelectionStart,
+      eventOverrides: {
+        data: keyDef.key,
+        inputType: 'insertText'
+      }
+    });
+  }
+}, {
+  matches: (keyDef, element) => keyDef.key === 'Enter' && ((0, utils.isElementType)(element, 'textarea', {
+    readOnly: false
+  }) || (0, utils.isContentEditable)(element)) && (0, utils.getSpaceUntilMaxLength)(element) !== 0,
+  handle: (keyDef, element, options, state) => {
+    const {
+      newValue,
+      newSelectionStart
+    } = (0, utils.calculateNewValue)('\n', element);
+    const inputType = (0, utils.isContentEditable)(element) && !state.modifiers.shift ? 'insertParagraph' : 'insertLineBreak';
+    (0, shared.fireInputEvent)(element, {
+      newValue,
+      newSelectionStart,
+      eventOverrides: {
+        inputType
+      }
+    });
+  }
+}];
+exports.keypressBehavior = keypressBehavior;
+});
+
+var getKeyEventProps_1 = getKeyEventProps;
+var getMouseEventProps_1 = getMouseEventProps;
+
+function getKeyEventProps(keyDef, state) {
+  var _keyDef$keyCode, _keyDef$key;
+
+  return {
+    key: keyDef.key,
+    code: keyDef.code,
+    altKey: state.modifiers.alt,
+    ctrlKey: state.modifiers.ctrl,
+    metaKey: state.modifiers.meta,
+    shiftKey: state.modifiers.shift,
+
+    /** @deprecated use code instead */
+    keyCode: (_keyDef$keyCode = keyDef.keyCode) != null ? _keyDef$keyCode : // istanbul ignore next
+    ((_keyDef$key = keyDef.key) == null ? void 0 : _keyDef$key.length) === 1 ? keyDef.key.charCodeAt(0) : undefined
+  };
+}
+
+function getMouseEventProps(state) {
+  return {
+    altKey: state.modifiers.alt,
+    ctrlKey: state.modifiers.ctrl,
+    metaKey: state.modifiers.meta,
+    shiftKey: state.modifiers.shift
+  };
+}
+
+var getEventProps = /*#__PURE__*/Object.defineProperty({
+	getKeyEventProps: getKeyEventProps_1,
+	getMouseEventProps: getMouseEventProps_1
+}, '__esModule', {value: true});
+
+var functional = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.preKeyupBehavior = exports.preKeydownBehavior = exports.postKeyupBehavior = exports.keyupBehavior = exports.keypressBehavior = exports.keydownBehavior = void 0;
+
+
+
+
+
+
+
+
+
+/**
+ * This file should contain behavior for functional keys as described here:
+ * https://w3c.github.io/uievents-code/#key-alphanumeric-functional
+ */
+const modifierKeys = {
+  Alt: 'alt',
+  Control: 'ctrl',
+  Shift: 'shift',
+  Meta: 'meta'
+};
+const preKeydownBehavior = [// modifierKeys switch on the modifier BEFORE the keydown event
+...Object.entries(modifierKeys).map(([key, modKey]) => ({
+  matches: keyDef => keyDef.key === key,
+  handle: (keyDef, element, options, state) => {
+    state.modifiers[modKey] = true;
+  }
+})), // AltGraph produces an extra keydown for Control
+// The modifier does not change
+{
+  matches: keyDef => keyDef.key === 'AltGraph',
+  handle: (keyDef, element, options, state) => {
+    var _options$keyboardMap$;
+
+    const ctrlKeyDef = (_options$keyboardMap$ = options.keyboardMap.find(k => k.key === 'Control')) != null ? _options$keyboardMap$ :
+    /* istanbul ignore next */
+    {
+      key: 'Control',
+      code: 'Control'
+    };
+
+    _dom.fireEvent.keyDown(element, (0, getEventProps.getKeyEventProps)(ctrlKeyDef, state));
+  }
+}];
+exports.preKeydownBehavior = preKeydownBehavior;
+const keydownBehavior = [{
+  matches: keyDef => keyDef.key === 'CapsLock',
+  handle: (keyDef, element, options, state) => {
+    state.modifiers.caps = !state.modifiers.caps;
+  }
+}, {
+  matches: (keyDef, element) => keyDef.key === 'Backspace' && (0, utils.isEditable)(element) && !(0, utils.isCursorAtStart)(element),
+  handle: (keyDef, element, options, state) => {
+    const {
+      newValue,
+      newSelectionStart
+    } = (0, utils.calculateNewValue)('', element, state.carryValue, undefined, 'backward');
+    (0, shared.fireInputEvent)(element, {
+      newValue,
+      newSelectionStart,
+      eventOverrides: {
+        inputType: 'deleteContentBackward'
+      }
+    });
+    (0, shared.carryValue)(element, state, newValue);
+  }
+}];
+exports.keydownBehavior = keydownBehavior;
+const keypressBehavior = [{
+  matches: (keyDef, element) => keyDef.key === 'Enter' && (0, utils.isElementType)(element, 'input') && ['checkbox', 'radio'].includes(element.type),
+  handle: (keyDef, element) => {
+    const form = element.form;
+
+    if ((0, utils.hasFormSubmit)(form)) {
+      _dom.fireEvent.submit(form);
+    }
+  }
+}, {
+  matches: (keyDef, element) => keyDef.key === 'Enter' && ((0, utils.isClickableInput)(element) || // Links with href defined should handle Enter the same as a click
+  (0, utils.isElementType)(element, 'a') && Boolean(element.href)),
+  handle: (keyDef, element, options, state) => {
+    _dom.fireEvent.click(element, (0, getEventProps.getMouseEventProps)(state));
+  }
+}, {
+  matches: (keyDef, element) => keyDef.key === 'Enter' && (0, utils.isElementType)(element, 'input'),
+  handle: (keyDef, element) => {
+    const form = element.form;
+
+    if (form && (form.querySelectorAll('input').length === 1 || (0, utils.hasFormSubmit)(form))) {
+      _dom.fireEvent.submit(form);
+    }
+  }
+}];
+exports.keypressBehavior = keypressBehavior;
+const preKeyupBehavior = [// modifierKeys switch off the modifier BEFORE the keyup event
+...Object.entries(modifierKeys).map(([key, modKey]) => ({
+  matches: keyDef => keyDef.key === key,
+  handle: (keyDef, element, options, state) => {
+    state.modifiers[modKey] = false;
+  }
+}))];
+exports.preKeyupBehavior = preKeyupBehavior;
+const keyupBehavior = [{
+  matches: (keyDef, element) => keyDef.key === ' ' && (0, utils.isClickableInput)(element),
+  handle: (keyDef, element, options, state) => {
+    _dom.fireEvent.click(element, (0, getEventProps.getMouseEventProps)(state));
+  }
+}];
+exports.keyupBehavior = keyupBehavior;
+const postKeyupBehavior = [// AltGraph produces an extra keyup for Control
+// The modifier does not change
+{
+  matches: keyDef => keyDef.key === 'AltGraph',
+  handle: (keyDef, element, options, state) => {
+    var _options$keyboardMap$2;
+
+    const ctrlKeyDef = (_options$keyboardMap$2 = options.keyboardMap.find(k => k.key === 'Control')) != null ? _options$keyboardMap$2 :
+    /* istanbul ignore next */
+    {
+      key: 'Control',
+      code: 'Control'
+    };
+
+    _dom.fireEvent.keyUp(element, (0, getEventProps.getKeyEventProps)(ctrlKeyDef, state));
+  }
+}];
+exports.postKeyupBehavior = postKeyupBehavior;
+});
+
+var plugins$1 = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.replaceBehavior = exports.preKeyupBehavior = exports.preKeydownBehavior = exports.postKeyupBehavior = exports.keyupBehavior = exports.keypressBehavior = exports.keydownBehavior = void 0;
+
+
+
+var arrowKeys = _interopRequireWildcard(arrow);
+
+var controlKeys = _interopRequireWildcard(control);
+
+var characterKeys = _interopRequireWildcard(character);
+
+var functionalKeys = _interopRequireWildcard(functional);
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
+const replaceBehavior = [{
+  matches: (keyDef, element) => keyDef.key === 'selectall' && (0, utils.isElementType)(element, ['input', 'textarea']),
+  handle: (keyDef, element, options, state) => {
+    var _state$carryValue;
+
+    (0, utils.setSelectionRange)(element, 0, ((_state$carryValue = state.carryValue) != null ? _state$carryValue : element.value).length);
+  }
+}];
+exports.replaceBehavior = replaceBehavior;
+const preKeydownBehavior = [...functionalKeys.preKeydownBehavior];
+exports.preKeydownBehavior = preKeydownBehavior;
+const keydownBehavior = [...arrowKeys.keydownBehavior, ...controlKeys.keydownBehavior, ...functionalKeys.keydownBehavior];
+exports.keydownBehavior = keydownBehavior;
+const keypressBehavior = [...functionalKeys.keypressBehavior, ...characterKeys.keypressBehavior];
+exports.keypressBehavior = keypressBehavior;
+const preKeyupBehavior = [...functionalKeys.preKeyupBehavior];
+exports.preKeyupBehavior = preKeyupBehavior;
+const keyupBehavior = [...functionalKeys.keyupBehavior];
+exports.keyupBehavior = keyupBehavior;
+const postKeyupBehavior = [...functionalKeys.postKeyupBehavior];
+exports.postKeyupBehavior = postKeyupBehavior;
+});
+
+var keyboardImplementation_2 = keyboardImplementation;
+var releaseAllKeys_1 = releaseAllKeys;
+
+
+
+
+
+
+
+var plugins = _interopRequireWildcard(plugins$1);
+
+
+
+function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
+
+function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
+async function keyboardImplementation(text, options, state) {
+  var _state$repeatKey;
+
+  const {
+    document
+  } = options;
+
+  const getCurrentElement = () => getActive(document);
+
+  const {
+    keyDef,
+    consumedLength,
+    releasePrevious,
+    releaseSelf,
+    repeat
+  } = (_state$repeatKey = state.repeatKey) != null ? _state$repeatKey : (0, getNextKeyDef_1.getNextKeyDef)(text, options);
+  const replace = applyPlugins(plugins.replaceBehavior, keyDef, getCurrentElement(), options, state);
+
+  if (!replace) {
+    const pressed = state.pressed.find(p => p.keyDef === keyDef); // Release the key automatically if it was pressed before.
+    // Do not release the key on iterations on `state.repeatKey`.
+
+    if (pressed && !state.repeatKey) {
+      keyup(keyDef, getCurrentElement, options, state, pressed.unpreventedDefault);
+    }
+
+    if (!releasePrevious) {
+      const unpreventedDefault = keydown(keyDef, getCurrentElement, options, state);
+
+      if (unpreventedDefault && hasKeyPress(keyDef, state)) {
+        keypress(keyDef, getCurrentElement, options, state);
+      } // Release the key only on the last iteration on `state.repeatKey`.
+
+
+      if (releaseSelf && repeat <= 1) {
+        keyup(keyDef, getCurrentElement, options, state, unpreventedDefault);
+      }
+    }
+  }
+
+  if (repeat > 1) {
+    state.repeatKey = {
+      // don't consume again on the next iteration
+      consumedLength: 0,
+      keyDef,
+      releasePrevious,
+      releaseSelf,
+      repeat: repeat - 1
+    };
+  } else {
+    delete state.repeatKey;
+  }
+
+  if (text.length > consumedLength || repeat > 1) {
+    if (options.delay > 0) {
+      await (0, utils.wait)(options.delay);
+    }
+
+    return keyboardImplementation(text.slice(consumedLength), options, state);
+  }
+
+  return void undefined;
+}
+
+function getActive(document) {
+  var _getActiveElement;
+
+  return (_getActiveElement = (0, utils.getActiveElement)(document)) != null ? _getActiveElement :
+  /* istanbul ignore next */
+  document.body;
+}
+
+function releaseAllKeys(options, state) {
+  const getCurrentElement = () => getActive(options.document);
+
+  for (const k of state.pressed) {
+    keyup(k.keyDef, getCurrentElement, options, state, k.unpreventedDefault);
+  }
+}
+
+function keydown(keyDef, getCurrentElement, options, state) {
+  const element = getCurrentElement(); // clear carried characters when focus is moved
+
+  if (element !== state.activeElement) {
+    state.carryValue = undefined;
+    state.carryChar = '';
+  }
+
+  state.activeElement = element;
+  applyPlugins(plugins.preKeydownBehavior, keyDef, element, options, state);
+
+  const unpreventedDefault = _dom.fireEvent.keyDown(element, (0, getEventProps.getKeyEventProps)(keyDef, state));
+
+  state.pressed.push({
+    keyDef,
+    unpreventedDefault
+  });
+
+  if (unpreventedDefault) {
+    // all default behavior like keypress/submit etc is applied to the currentElement
+    applyPlugins(plugins.keydownBehavior, keyDef, getCurrentElement(), options, state);
+  }
+
+  return unpreventedDefault;
+}
+
+function keypress(keyDef, getCurrentElement, options, state) {
+  const element = getCurrentElement();
+
+  const unpreventedDefault = _dom.fireEvent.keyPress(element, (0, getEventProps.getKeyEventProps)(keyDef, state));
+
+  if (unpreventedDefault) {
+    applyPlugins(plugins.keypressBehavior, keyDef, getCurrentElement(), options, state);
+  }
+}
+
+function keyup(keyDef, getCurrentElement, options, state, unprevented) {
+  const element = getCurrentElement();
+  applyPlugins(plugins.preKeyupBehavior, keyDef, element, options, state);
+
+  const unpreventedDefault = _dom.fireEvent.keyUp(element, (0, getEventProps.getKeyEventProps)(keyDef, state));
+
+  if (unprevented && unpreventedDefault) {
+    applyPlugins(plugins.keyupBehavior, keyDef, getCurrentElement(), options, state);
+  }
+
+  state.pressed = state.pressed.filter(k => k.keyDef !== keyDef);
+  applyPlugins(plugins.postKeyupBehavior, keyDef, element, options, state);
+}
+
+function applyPlugins(pluginCollection, keyDef, element, options, state) {
+  const plugin = pluginCollection.find(p => p.matches(keyDef, element, options, state));
+
+  if (plugin) {
+    plugin.handle(keyDef, element, options, state);
+  }
+
+  return !!plugin;
+}
+
+function hasKeyPress(keyDef, state) {
+  var _keyDef$key;
+
+  return (((_keyDef$key = keyDef.key) == null ? void 0 : _keyDef$key.length) === 1 || keyDef.key === 'Enter') && !state.modifiers.ctrl && !state.modifiers.alt;
+}
+
+var keyboardImplementation_1 = /*#__PURE__*/Object.defineProperty({
+	keyboardImplementation: keyboardImplementation_2,
+	releaseAllKeys: releaseAllKeys_1
+}, '__esModule', {value: true});
+
+var types = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.DOM_KEY_LOCATION = void 0;
+
+/**
+ * @internal Do not create/alter this by yourself as this type might be subject to changes.
+ */
+let DOM_KEY_LOCATION;
+exports.DOM_KEY_LOCATION = DOM_KEY_LOCATION;
+
+(function (DOM_KEY_LOCATION) {
+  DOM_KEY_LOCATION[DOM_KEY_LOCATION["STANDARD"] = 0] = "STANDARD";
+  DOM_KEY_LOCATION[DOM_KEY_LOCATION["LEFT"] = 1] = "LEFT";
+  DOM_KEY_LOCATION[DOM_KEY_LOCATION["RIGHT"] = 2] = "RIGHT";
+  DOM_KEY_LOCATION[DOM_KEY_LOCATION["NUMPAD"] = 3] = "NUMPAD";
+})(DOM_KEY_LOCATION || (exports.DOM_KEY_LOCATION = DOM_KEY_LOCATION = {}));
+});
+
+var keyMap = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.defaultKeyMap = void 0;
+
+
+
+/**
+ * Mapping for a default US-104-QWERTY keyboard
+ */
+const defaultKeyMap = [// alphanumeric keys
+...'0123456789'.split('').map(c => ({
+  code: `Digit${c}`,
+  key: c
+})), ...')!@#$%^&*('.split('').map((c, i) => ({
+  code: `Digit${i}`,
+  key: c,
+  shiftKey: true
+})), ...'abcdefghijklmnopqrstuvwxyz'.split('').map(c => ({
+  code: `Key${c.toUpperCase()}`,
+  key: c
+})), ...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('').map(c => ({
+  code: `Key${c}`,
+  key: c,
+  shiftKey: true
+})), // alphanumeric block - functional
+{
+  code: 'Space',
+  key: ' '
+}, {
+  code: 'AltLeft',
+  key: 'Alt',
+  location: types.DOM_KEY_LOCATION.LEFT,
+  keyCode: 18
+}, {
+  code: 'AltRight',
+  key: 'Alt',
+  location: types.DOM_KEY_LOCATION.RIGHT,
+  keyCode: 18
+}, {
+  code: 'ShiftLeft',
+  key: 'Shift',
+  location: types.DOM_KEY_LOCATION.LEFT,
+  keyCode: 16
+}, {
+  code: 'ShiftRight',
+  key: 'Shift',
+  location: types.DOM_KEY_LOCATION.RIGHT,
+  keyCode: 16
+}, {
+  code: 'ControlLeft',
+  key: 'Control',
+  location: types.DOM_KEY_LOCATION.LEFT,
+  keyCode: 17
+}, {
+  code: 'ControlRight',
+  key: 'Control',
+  location: types.DOM_KEY_LOCATION.RIGHT,
+  keyCode: 17
+}, {
+  code: 'MetaLeft',
+  key: 'Meta',
+  location: types.DOM_KEY_LOCATION.LEFT,
+  keyCode: 93
+}, {
+  code: 'MetaRight',
+  key: 'Meta',
+  location: types.DOM_KEY_LOCATION.RIGHT,
+  keyCode: 93
+}, {
+  code: 'OSLeft',
+  key: 'OS',
+  location: types.DOM_KEY_LOCATION.LEFT,
+  keyCode: 91
+}, {
+  code: 'OSRight',
+  key: 'OS',
+  location: types.DOM_KEY_LOCATION.RIGHT,
+  keyCode: 91
+}, {
+  code: 'CapsLock',
+  key: 'CapsLock',
+  keyCode: 20
+}, {
+  code: 'Backspace',
+  key: 'Backspace',
+  keyCode: 8
+}, {
+  code: 'Enter',
+  key: 'Enter',
+  keyCode: 13
+}, // function
+{
+  code: 'Escape',
+  key: 'Escape',
+  keyCode: 27
+}, // arrows
+{
+  code: 'ArrowUp',
+  key: 'ArrowUp',
+  keyCode: 38
+}, {
+  code: 'ArrowDown',
+  key: 'ArrowDown',
+  keyCode: 40
+}, {
+  code: 'ArrowLeft',
+  key: 'ArrowLeft',
+  keyCode: 37
+}, {
+  code: 'ArrowRight',
+  key: 'ArrowRight',
+  keyCode: 39
+}, // control pad
+{
+  code: 'Home',
+  key: 'Home',
+  keyCode: 36
+}, {
+  code: 'End',
+  key: 'End',
+  keyCode: 35
+}, {
+  code: 'Delete',
+  key: 'Delete',
+  keyCode: 46
+}, {
+  code: 'PageUp',
+  key: 'PageUp',
+  keyCode: 33
+}, {
+  code: 'PageDown',
+  key: 'PageDown',
+  keyCode: 34
+} // TODO: add mappings
+];
+exports.defaultKeyMap = defaultKeyMap;
+});
+
+var specialCharMap_1 = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.specialCharMap = void 0;
+
+/**
+ * @deprecated This list of strings with special meaning is no longer necessary
+ * as we've introduced a standardized way to describe any keystroke for `userEvent`.
+ * @see https://testing-library.com/docs/ecosystem-user-event#keyboardtext-options
+ */
+const specialCharMap = {
+  arrowLeft: '{arrowleft}',
+  arrowRight: '{arrowright}',
+  arrowDown: '{arrowdown}',
+  arrowUp: '{arrowup}',
+  enter: '{enter}',
+  escape: '{esc}',
+  delete: '{del}',
+  backspace: '{backspace}',
+  home: '{home}',
+  end: '{end}',
+  selectAll: '{selectall}',
+  space: '{space}',
+  whitespace: ' ',
+  pageUp: '{pageUp}',
+  pageDown: '{pageDown}'
+};
+exports.specialCharMap = specialCharMap;
+});
+
+var keyboard_1 = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.keyboard = keyboard;
+exports.keyboardImplementationWrapper = keyboardImplementationWrapper;
+Object.defineProperty(exports, "specialCharMap", {
+  enumerable: true,
+  get: function () {
+    return specialCharMap_1.specialCharMap;
+  }
+});
+
+
+
+
+
+
+
+
+
+function keyboard(text, options) {
+  var _options$delay;
+
+  const {
+    promise,
+    state
+  } = keyboardImplementationWrapper(text, options);
+
+  if (((_options$delay = options == null ? void 0 : options.delay) != null ? _options$delay : 0) > 0) {
+    return (0, _dom.getConfig)().asyncWrapper(() => promise.then(() => state));
+  } else {
+    // prevent users from dealing with UnhandledPromiseRejectionWarning in sync call
+    promise.catch(console.error);
+    return state;
+  }
+}
+
+function keyboardImplementationWrapper(text, config = {}) {
+  const {
+    keyboardState: state = createKeyboardState(),
+    delay = 0,
+    document: doc = document,
+    autoModify = false,
+    keyboardMap = keyMap.defaultKeyMap
+  } = config;
+  const options = {
+    delay,
+    document: doc,
+    autoModify,
+    keyboardMap
+  };
+  return {
+    promise: (0, keyboardImplementation_1.keyboardImplementation)(text, options, state),
+    state,
+    releaseAllKeys: () => (0, keyboardImplementation_1.releaseAllKeys)(options, state)
+  };
+}
+
+function createKeyboardState() {
+  return {
+    activeElement: null,
+    pressed: [],
+    carryChar: '',
+    modifiers: {
+      alt: false,
+      caps: false,
+      ctrl: false,
+      meta: false,
+      shift: false
+    }
+  };
+}
+});
+
+var typeImplementation_2 = typeImplementation;
+
+
+
+
+
+
+
+async function typeImplementation(element, text, {
+  delay,
+  skipClick = false,
+  skipAutoClose = false,
+  initialSelectionStart = undefined,
+  initialSelectionEnd = undefined
+}) {
+  // TODO: properly type guard
+  // we use this workaround for now to prevent changing behavior
+  if (element.disabled) return;
+  if (!skipClick) (0, click_1.click)(element); // The focused element could change between each event, so get the currently active element each time
+
+  const currentElement = () => (0, utils.getActiveElement)(element.ownerDocument); // by default, a new element has its selection start and end at 0
+  // but most of the time when people call "type", they expect it to type
+  // at the end of the current input value. So, if the selection start
+  // and end are both the default of 0, then we'll go ahead and change
+  // them to the length of the current value.
+  // the only time it would make sense to pass the initialSelectionStart or
+  // initialSelectionEnd is if you have an input with a value and want to
+  // explicitly start typing with the cursor at 0. Not super common.
+
+
+  const value = (0, utils.getValue)(currentElement());
+  const {
+    selectionStart,
+    selectionEnd
+  } = (0, utils.getSelectionRange)(element);
+
+  if (value != null && (selectionStart === null || selectionStart === 0) && (selectionEnd === null || selectionEnd === 0)) {
+    (0, utils.setSelectionRange)(currentElement(), initialSelectionStart != null ? initialSelectionStart : value.length, initialSelectionEnd != null ? initialSelectionEnd : value.length);
+  }
+
+  const {
+    promise,
+    releaseAllKeys
+  } = (0, keyboard_1.keyboardImplementationWrapper)(text, {
+    delay,
+    document: element.ownerDocument
+  });
+
+  if (delay > 0) {
+    await promise;
+  }
+
+  if (!skipAutoClose) {
+    releaseAllKeys();
+  } // eslint-disable-next-line consistent-return -- we need to return the internal Promise so that it is catchable if we don't await
+
+
+  return promise;
+}
+
+var typeImplementation_1 = /*#__PURE__*/Object.defineProperty({
+	typeImplementation: typeImplementation_2
+}, '__esModule', {value: true});
+
+var type_2 = type;
+
+
+
+
+
+// this needs to be wrapped in the event/asyncWrapper for React's act and angular's change detection
+// depending on whether it will be async.
+function type(element, text, {
+  delay = 0,
+  ...options
+} = {}) {
+  // we do not want to wrap in the asyncWrapper if we're not
+  // going to actually be doing anything async, so we only wrap
+  // if the delay is greater than 0
+  if (delay > 0) {
+    return (0, _dom.getConfig)().asyncWrapper(() => (0, typeImplementation_1.typeImplementation)(element, text, {
+      delay,
+      ...options
+    }));
+  } else {
+    return void (0, typeImplementation_1.typeImplementation)(element, text, {
+      delay,
+      ...options
+    }) // prevents users from dealing with UnhandledPromiseRejectionWarning
+    .catch(console.error);
+  }
+}
+
+var type_1 = /*#__PURE__*/Object.defineProperty({
+	type: type_2
+}, '__esModule', {value: true});
+
+var clear_2 = clear;
+
+
+
+
+
+function clear(element) {
+  var _element$selectionSta, _element$selectionEnd;
+
+  if (!(0, utils.isElementType)(element, ['input', 'textarea'])) {
+    // TODO: support contenteditable
+    throw new Error('clear currently only supports input and textarea elements.');
+  }
+
+  if ((0, utils.isDisabled)(element)) {
+    return;
+  } // TODO: track the selection range ourselves so we don't have to do this input "type" trickery
+  // just like cypress does: https://github.com/cypress-io/cypress/blob/8d7f1a0bedc3c45a2ebf1ff50324b34129fdc683/packages/driver/src/dom/selection.ts#L16-L37
+
+
+  const elementType = element.type;
+
+  if (elementType !== 'textarea') {
+    element.type = 'text';
+  }
+
+  (0, type_1.type)(element, '{selectall}{del}', {
+    delay: 0,
+    initialSelectionStart: (_element$selectionSta = element.selectionStart) != null ? _element$selectionSta :
+    /* istanbul ignore next */
+    undefined,
+    initialSelectionEnd: (_element$selectionEnd = element.selectionEnd) != null ? _element$selectionEnd :
+    /* istanbul ignore next */
+    undefined
+  });
+
+  if (elementType !== 'textarea') {
+    element.type = elementType;
+  }
+}
+
+var clear_1 = /*#__PURE__*/Object.defineProperty({
+	clear: clear_2
+}, '__esModule', {value: true});
+
+var tab_2 = tab;
+
+
+
+
+
+
+
+
+
+function getNextElement(currentIndex, shift, elements, focusTrap) {
+  if ((0, utils.isDocument)(focusTrap) && (currentIndex === 0 && shift || currentIndex === elements.length - 1 && !shift)) {
+    return focusTrap.body;
+  }
+
+  const nextIndex = shift ? currentIndex - 1 : currentIndex + 1;
+  const defaultIndex = shift ? elements.length - 1 : 0;
+  return elements[nextIndex] || elements[defaultIndex];
+}
+
+function tab({
+  shift = false,
+  focusTrap
+} = {}) {
+  var _focusTrap$ownerDocum, _focusTrap;
+
+  const doc = (_focusTrap$ownerDocum = (_focusTrap = focusTrap) == null ? void 0 : _focusTrap.ownerDocument) != null ? _focusTrap$ownerDocum : document;
+  const previousElement = (0, utils.getActiveElement)(doc);
+
+  if (!focusTrap) {
+    focusTrap = doc;
+  }
+
+  const focusableElements = focusTrap.querySelectorAll(utils.FOCUSABLE_SELECTOR);
+  const enabledElements = Array.from(focusableElements).filter(el => el === previousElement || el.getAttribute('tabindex') !== '-1' && !(0, utils.isDisabled)(el) && // Hidden elements are not tabable
+  (0, utils.isVisible)(el));
+  if (enabledElements.length === 0) return;
+  const orderedElements = enabledElements.map((el, idx) => ({
+    el,
+    idx
+  })).sort((a, b) => {
+    // tabindex has no effect if the active element has tabindex="-1"
+    if (previousElement && previousElement.getAttribute('tabindex') === '-1') {
+      return a.idx - b.idx;
+    }
+
+    const tabIndexA = Number(a.el.getAttribute('tabindex'));
+    const tabIndexB = Number(b.el.getAttribute('tabindex'));
+    const diff = tabIndexA - tabIndexB;
+    return diff === 0 ? a.idx - b.idx : diff;
+  }).map(({
+    el
+  }) => el); // TODO: verify/remove type casts
+
+  const checkedRadio = {};
+  let prunedElements = [];
+  orderedElements.forEach(currentElement => {
+    // For radio groups keep only the active radio
+    // If there is no active radio, keep only the checked radio
+    // If there is no checked radio, treat like everything else
+    const el = currentElement;
+
+    if (el.type === 'radio' && el.name) {
+      // If the active element is part of the group, add only that
+      const prev = previousElement;
+
+      if (prev && prev.type === el.type && prev.name === el.name) {
+        if (el === prev) {
+          prunedElements.push(el);
+        }
+
+        return;
+      } // If we stumble upon a checked radio, remove the others
+
+
+      if (el.checked) {
+        prunedElements = prunedElements.filter(e => e.type !== el.type || e.name !== el.name);
+        prunedElements.push(el);
+        checkedRadio[el.name] = el;
+        return;
+      } // If we already found the checked one, skip
+
+
+      if (typeof checkedRadio[el.name] !== 'undefined') {
+        return;
+      }
+    }
+
+    prunedElements.push(el);
+  });
+  const index = prunedElements.findIndex(el => el === previousElement);
+  const nextElement = getNextElement(index, shift, prunedElements, focusTrap);
+  const shiftKeyInit = {
+    key: 'Shift',
+    keyCode: 16,
+    shiftKey: true
+  };
+  const tabKeyInit = {
+    key: 'Tab',
+    keyCode: 9,
+    shiftKey: shift
+  };
+  let continueToTab = true; // not sure how to make it so there's no previous element...
+  // istanbul ignore else
+
+  if (previousElement) {
+    // preventDefault on the shift key makes no difference
+    if (shift) _dom.fireEvent.keyDown(previousElement, { ...shiftKeyInit
+    });
+    continueToTab = _dom.fireEvent.keyDown(previousElement, { ...tabKeyInit
+    });
+  }
+
+  const keyUpTarget = !continueToTab && previousElement ? previousElement : nextElement;
+
+  if (continueToTab) {
+    if (nextElement === doc.body) {
+      /* istanbul ignore else */
+      if (previousElement) {
+        (0, blur_1.blur)(previousElement);
+      }
+    } else {
+      (0, focus_1.focus)(nextElement);
+    }
+  }
+
+  _dom.fireEvent.keyUp(keyUpTarget, { ...tabKeyInit
+  });
+
+  if (shift) {
+    _dom.fireEvent.keyUp(keyUpTarget, { ...shiftKeyInit,
+      shiftKey: false
+    });
+  }
+}
+/*
+eslint
+  complexity: "off",
+  max-statements: "off",
+*/
+
+var tab_1 = /*#__PURE__*/Object.defineProperty({
+	tab: tab_2
+}, '__esModule', {value: true});
+
+var upload_2 = upload;
+
+
+
+
+
+
+
+
+
+
+
+function upload(element, fileOrFiles, init, {
+  applyAccept = false
+} = {}) {
+  var _input$files;
+
+  const input = (0, utils.isElementType)(element, 'label') ? element.control : element;
+
+  if (!input || !(0, utils.isElementType)(input, 'input', {
+    type: 'file'
+  })) {
+    throw new TypeError(`The ${input === element ? 'given' : 'associated'} ${input == null ? void 0 : input.tagName} element does not accept file uploads`);
+  }
+
+  if ((0, utils.isDisabled)(element)) return;
+  (0, click_1.click)(element, init == null ? void 0 : init.clickInit);
+  const files = (Array.isArray(fileOrFiles) ? fileOrFiles : [fileOrFiles]).filter(file => !applyAccept || isAcceptableFile(file, input.accept)).slice(0, input.multiple ? undefined : 1); // blur fires when the file selector pops up
+
+  (0, blur_1.blur)(element); // focus fires when they make their selection
+
+  (0, focus_1.focus)(element); // do not fire an input event if the file selection does not change
+
+  if (files.length === ((_input$files = input.files) == null ? void 0 : _input$files.length) && files.every((f, i) => {
+    var _input$files2;
+
+    return f === ((_input$files2 = input.files) == null ? void 0 : _input$files2.item(i));
+  })) {
+    return;
+  } // the event fired in the browser isn't actually an "input" or "change" event
+  // but a new Event with a type set to "input" and "change"
+  // Kinda odd...
+
+
+  const inputFiles = { ...files,
+    length: files.length,
+    item: index => files[index],
+
+    [Symbol.iterator]() {
+      let i = 0;
+      return {
+        next: () => ({
+          done: i >= files.length,
+          value: files[i++]
+        })
+      };
+    }
+
+  };
+  (0, _dom.fireEvent)(input, (0, _dom.createEvent)('input', input, {
+    target: {
+      files: inputFiles
+    },
+    bubbles: true,
+    cancelable: false,
+    composed: true
+  }));
+
+  _dom.fireEvent.change(input, {
+    target: {
+      files: inputFiles
+    },
+    ...(init == null ? void 0 : init.changeInit)
+  });
+}
+
+function isAcceptableFile(file, accept) {
+  if (!accept) {
+    return true;
+  }
+
+  const wildcards = ['audio/*', 'image/*', 'video/*'];
+  return accept.split(',').some(acceptToken => {
+    if (acceptToken.startsWith('.')) {
+      // tokens starting with a dot represent a file extension
+      return file.name.endsWith(acceptToken);
+    } else if (wildcards.includes(acceptToken)) {
+      return file.type.startsWith(acceptToken.substr(0, acceptToken.length - 1));
+    }
+
+    return file.type === acceptToken;
+  });
+}
+
+var upload_1 = /*#__PURE__*/Object.defineProperty({
+	upload: upload_2
+}, '__esModule', {value: true});
+
+var selectOptions_1 = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.selectOptions = exports.deselectOptions = void 0;
+
+
+
+
+
+
+
+
+
+
+
+function selectOptionsBase(newValue, select, values, init, {
+  skipPointerEventsCheck = false
+} = {}) {
+  if (!newValue && !select.multiple) {
+    throw (0, _dom.getConfig)().getElementError(`Unable to deselect an option in a non-multiple select. Use selectOptions to change the selection instead.`, select);
+  }
+
+  const valArray = Array.isArray(values) ? values : [values];
+  const allOptions = Array.from(select.querySelectorAll('option, [role="option"]'));
+  const selectedOptions = valArray.map(val => {
+    if (typeof val !== 'string' && allOptions.includes(val)) {
+      return val;
+    } else {
+      const matchingOption = allOptions.find(o => o.value === val || o.innerHTML === val);
+
+      if (matchingOption) {
+        return matchingOption;
+      } else {
+        throw (0, _dom.getConfig)().getElementError(`Value "${String(val)}" not found in options`, select);
+      }
+    }
+  }).filter(option => !(0, utils.isDisabled)(option));
+  if ((0, utils.isDisabled)(select) || !selectedOptions.length) return;
+
+  if ((0, utils.isElementType)(select, 'select')) {
+    if (select.multiple) {
+      for (const option of selectedOptions) {
+        const withPointerEvents = skipPointerEventsCheck ? true : (0, utils.hasPointerEvents)(option); // events fired for multiple select are weird. Can't use hover...
+
+        if (withPointerEvents) {
+          _dom.fireEvent.pointerOver(option, init);
+
+          _dom.fireEvent.pointerEnter(select, init);
+
+          _dom.fireEvent.mouseOver(option);
+
+          _dom.fireEvent.mouseEnter(select);
+
+          _dom.fireEvent.pointerMove(option, init);
+
+          _dom.fireEvent.mouseMove(option, init);
+
+          _dom.fireEvent.pointerDown(option, init);
+
+          _dom.fireEvent.mouseDown(option, init);
+        }
+
+        (0, focus_1.focus)(select);
+
+        if (withPointerEvents) {
+          _dom.fireEvent.pointerUp(option, init);
+
+          _dom.fireEvent.mouseUp(option, init);
+        }
+
+        selectOption(option);
+
+        if (withPointerEvents) {
+          _dom.fireEvent.click(option, init);
+        }
+      }
+    } else if (selectedOptions.length === 1) {
+      const withPointerEvents = skipPointerEventsCheck ? true : (0, utils.hasPointerEvents)(select); // the click to open the select options
+
+      if (withPointerEvents) {
+        (0, click_1.click)(select, init, {
+          skipPointerEventsCheck
+        });
+      } else {
+        (0, focus_1.focus)(select);
+      }
+
+      selectOption(selectedOptions[0]);
+
+      if (withPointerEvents) {
+        // the browser triggers another click event on the select for the click on the option
+        // this second click has no 'down' phase
+        _dom.fireEvent.pointerOver(select, init);
+
+        _dom.fireEvent.pointerEnter(select, init);
+
+        _dom.fireEvent.mouseOver(select);
+
+        _dom.fireEvent.mouseEnter(select);
+
+        _dom.fireEvent.pointerUp(select, init);
+
+        _dom.fireEvent.mouseUp(select, init);
+
+        _dom.fireEvent.click(select, init);
+      }
+    } else {
+      throw (0, _dom.getConfig)().getElementError(`Cannot select multiple options on a non-multiple select`, select);
+    }
+  } else if (select.getAttribute('role') === 'listbox') {
+    selectedOptions.forEach(option => {
+      (0, hover_1.hover)(option, init, {
+        skipPointerEventsCheck
+      });
+      (0, click_1.click)(option, init, {
+        skipPointerEventsCheck
+      });
+      (0, hover_1.unhover)(option, init, {
+        skipPointerEventsCheck
+      });
+    });
+  } else {
+    throw (0, _dom.getConfig)().getElementError(`Cannot select options on elements that are neither select nor listbox elements`, select);
+  }
+
+  function selectOption(option) {
+    option.selected = newValue;
+    (0, _dom.fireEvent)(select, (0, _dom.createEvent)('input', select, {
+      bubbles: true,
+      cancelable: false,
+      composed: true,
+      ...init
+    }));
+
+    _dom.fireEvent.change(select, init);
+  }
+}
+
+const selectOptions = selectOptionsBase.bind(null, true);
+exports.selectOptions = selectOptions;
+const deselectOptions = selectOptionsBase.bind(null, false);
+exports.deselectOptions = deselectOptions;
+});
+
+var paste_2 = paste;
+
+
+
+
+
+function isSupportedElement(element) {
+  return (0, utils.isElementType)(element, 'input') && Boolean(utils.editableInputTypes[element.type]) || (0, utils.isElementType)(element, 'textarea');
+}
+
+function paste(element, text, init, {
+  initialSelectionStart,
+  initialSelectionEnd
+} = {}) {
+  // TODO: implement for contenteditable
+  if (!isSupportedElement(element)) {
+    throw new TypeError(`The given ${element.tagName} element is currently unsupported.
+      A PR extending this implementation would be very much welcome at https://github.com/testing-library/user-event`);
+  }
+
+  if ((0, utils.isDisabled)(element)) {
+    return;
+  }
+
+  (0, utils.eventWrapper)(() => element.focus()); // by default, a new element has it's selection start and end at 0
+  // but most of the time when people call "paste", they expect it to paste
+  // at the end of the current input value. So, if the selection start
+  // and end are both the default of 0, then we'll go ahead and change
+  // them to the length of the current value.
+  // the only time it would make sense to pass the initialSelectionStart or
+  // initialSelectionEnd is if you have an input with a value and want to
+  // explicitely start typing with the cursor at 0. Not super common.
+
+  if (element.selectionStart === 0 && element.selectionEnd === 0) {
+    (0, utils.setSelectionRange)(element, initialSelectionStart != null ? initialSelectionStart : element.value.length, initialSelectionEnd != null ? initialSelectionEnd : element.value.length);
+  }
+
+  _dom.fireEvent.paste(element, init);
+
+  if (element.readOnly) {
+    return;
+  }
+
+  text = text.substr(0, (0, utils.getSpaceUntilMaxLength)(element));
+  const {
+    newValue,
+    newSelectionStart
+  } = (0, utils.calculateNewValue)(text, element);
+
+  _dom.fireEvent.input(element, {
+    inputType: 'insertFromPaste',
+    target: {
+      value: newValue
+    }
+  });
+
+  (0, utils.setSelectionRange)(element, // TODO: investigate why the selection caused by invalid parameters was expected
+  {
+    newSelectionStart,
+    selectionEnd: newSelectionStart
+  }, {});
+}
+
+var paste_1 = /*#__PURE__*/Object.defineProperty({
+	paste: paste_2
+}, '__esModule', {value: true});
+
+var dist = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+Object.defineProperty(exports, "specialChars", {
+  enumerable: true,
+  get: function () {
+    return keyboard_1.specialCharMap;
+  }
+});
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+const userEvent = {
+  click: click_1.click,
+  dblClick: click_1.dblClick,
+  type: type_1.type,
+  clear: clear_1.clear,
+  tab: tab_1.tab,
+  hover: hover_1.hover,
+  unhover: hover_1.unhover,
+  upload: upload_1.upload,
+  selectOptions: selectOptions_1.selectOptions,
+  deselectOptions: selectOptions_1.deselectOptions,
+  paste: paste_1.paste,
+  keyboard: keyboard_1.keyboard
+};
+var _default = userEvent;
+exports.default = _default;
+});
+
+var index = /*@__PURE__*/getDefaultExportFromCjs(dist);
+
+var eventMap_1 = createCommonjsModule(function (module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.eventAliasMap = exports.eventMap = void 0;
+const eventMap = {
+  // Clipboard Events
+  copy: {
+    EventType: 'ClipboardEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  cut: {
+    EventType: 'ClipboardEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  paste: {
+    EventType: 'ClipboardEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  // Composition Events
+  compositionEnd: {
+    EventType: 'CompositionEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  compositionStart: {
+    EventType: 'CompositionEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  compositionUpdate: {
+    EventType: 'CompositionEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  // Keyboard Events
+  keyDown: {
+    EventType: 'KeyboardEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      charCode: 0,
+      composed: true
+    }
+  },
+  keyPress: {
+    EventType: 'KeyboardEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      charCode: 0,
+      composed: true
+    }
+  },
+  keyUp: {
+    EventType: 'KeyboardEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      charCode: 0,
+      composed: true
+    }
+  },
+  // Focus Events
+  focus: {
+    EventType: 'FocusEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false,
+      composed: true
+    }
+  },
+  blur: {
+    EventType: 'FocusEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false,
+      composed: true
+    }
+  },
+  focusIn: {
+    EventType: 'FocusEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  focusOut: {
+    EventType: 'FocusEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  // Form Events
+  change: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false
+    }
+  },
+  input: {
+    EventType: 'InputEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  invalid: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: true
+    }
+  },
+  submit: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true
+    }
+  },
+  reset: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true
+    }
+  },
+  // Mouse Events
+  click: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      composed: true
+    }
+  },
+  contextMenu: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  dblClick: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  drag: {
+    EventType: 'DragEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  dragEnd: {
+    EventType: 'DragEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  dragEnter: {
+    EventType: 'DragEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  dragExit: {
+    EventType: 'DragEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  dragLeave: {
+    EventType: 'DragEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  dragOver: {
+    EventType: 'DragEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  dragStart: {
+    EventType: 'DragEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  drop: {
+    EventType: 'DragEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  mouseDown: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  mouseEnter: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false,
+      composed: true
+    }
+  },
+  mouseLeave: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false,
+      composed: true
+    }
+  },
+  mouseMove: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  mouseOut: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  mouseOver: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  mouseUp: {
+    EventType: 'MouseEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  // Selection Events
+  select: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false
+    }
+  },
+  // Touch Events
+  touchCancel: {
+    EventType: 'TouchEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  touchEnd: {
+    EventType: 'TouchEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  touchMove: {
+    EventType: 'TouchEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  touchStart: {
+    EventType: 'TouchEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  // UI Events
+  scroll: {
+    EventType: 'UIEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  // Wheel Events
+  wheel: {
+    EventType: 'WheelEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  // Media Events
+  abort: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  canPlay: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  canPlayThrough: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  durationChange: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  emptied: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  encrypted: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  ended: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  loadedData: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  loadedMetadata: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  loadStart: {
+    EventType: 'ProgressEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  pause: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  play: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  playing: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  progress: {
+    EventType: 'ProgressEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  rateChange: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  seeked: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  seeking: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  stalled: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  suspend: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  timeUpdate: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  volumeChange: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  waiting: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  // Image Events
+  load: {
+    EventType: 'UIEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  error: {
+    EventType: 'Event',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  // Animation Events
+  animationStart: {
+    EventType: 'AnimationEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false
+    }
+  },
+  animationEnd: {
+    EventType: 'AnimationEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false
+    }
+  },
+  animationIteration: {
+    EventType: 'AnimationEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false
+    }
+  },
+  // Transition Events
+  transitionEnd: {
+    EventType: 'TransitionEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true
+    }
+  },
+  // pointer events
+  pointerOver: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  pointerEnter: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  pointerDown: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  pointerMove: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  pointerUp: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  pointerCancel: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  pointerOut: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: true,
+      composed: true
+    }
+  },
+  pointerLeave: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: false,
+      cancelable: false
+    }
+  },
+  gotPointerCapture: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  lostPointerCapture: {
+    EventType: 'PointerEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }
+  },
+  // history events
+  popState: {
+    EventType: 'PopStateEvent',
+    defaultInit: {
+      bubbles: true,
+      cancelable: false
+    }
+  }
+};
+exports.eventMap = eventMap;
+const eventAliasMap = {
+  doubleClick: 'dblClick'
+};
+exports.eventAliasMap = eventAliasMap;
+});
+
+// Copyright 2021 Workiva Inc.
+
+// Configure the test id to match what the OverReact ecosystem defaults to.
+configure({
+  testIdAttribute: 'data-test-id',
+  getElementError: buildJsGetElementError
+});
+
+// In order to allow us to interop `fireEvent` as both a function, and an object with function values,
+// we need two vars exported so we can `@JS()` annotate each one separately with the type Dart expects.
+var fireEventObj = fireEvent;
+
+var eventMap$1 = eventMap_1.eventMap;
+export { act, buildJsGetElementError, buildQueries, cleanup, configure, createEvent, eventMap$1 as eventMap, findAllByAltText, findAllByDisplayValue, findAllByLabelText, findAllByPlaceholderText, findAllByRole, findAllByTestId, findAllByText, findAllByTitle, findByAltText, findByDisplayValue, findByLabelText, findByPlaceholderText, findByRole, findByTestId, findByText, findByTitle, fireEvent, fireEventObj, getAllByAltText, getAllByDisplayValue, getAllByLabelTextWithSuggestions as getAllByLabelText, getAllByPlaceholderText, getAllByRole, getAllByTestId, getAllByText, getAllByTitle, getByAltText, getByDisplayValue, getByLabelTextWithSuggestions as getByLabelText, getByPlaceholderText, getByRole, getByTestId, getByText, getByTitle, getConfig, getDefaultNormalizer, getElementError, getMultipleElementsFoundError, getNodeText, getQueriesForElement, getRoles, getSuggestedQuery, isInaccessible, logDOM, logRoles, makeFindQuery, makeGetAllQuery, makeSingleQuery, prettyDOM, build$1 as prettyFormat, queries, queryAllByAltTextWithSuggestions as queryAllByAltText, queryAllByAttribute, queryAllByDisplayValueWithSuggestions as queryAllByDisplayValue, queryAllByLabelTextWithSuggestions as queryAllByLabelText, queryAllByPlaceholderTextWithSuggestions as queryAllByPlaceholderText, queryAllByRoleWithSuggestions as queryAllByRole, queryAllByTestIdWithSuggestions as queryAllByTestId, queryAllByTextWithSuggestions as queryAllByText, queryAllByTitleWithSuggestions as queryAllByTitle, queryByAltText, queryByAttribute, queryByDisplayValue, queryByLabelText, queryByPlaceholderText, queryByRole, queryByTestId, queryByText, queryByTitle, queryHelpers, render, screen, index as userEvent, wait$1 as wait, waitForWrapper as waitFor, waitForDomChangeWrapper as waitForDomChange, waitForElement, waitForElementToBeRemoved, getQueriesForElement as within, wrapAllByQueryWithSuggestion, wrapSingleQueryWithSuggestion };

--- a/js_src/vite.config.mjs
+++ b/js_src/vite.config.mjs
@@ -2,7 +2,7 @@ import { resolve, dirname, parse } from 'path';
 import { defineConfig } from 'vite';
 import pkg from './package.json' assert { type: 'json' };
 
-const input = 'src/_react-testing-library.js';
+const input = 'src/index.js';
 const jsPackageName = 'rtl';
 
 const globals = {

--- a/lib/js/react-testing-library.js
+++ b/lib/js/react-testing-library.js
@@ -1942,9 +1942,9 @@
       return plugins_1;
     }
   }, [build$1]);
-  var toStr$6 = Object.prototype.toString;
+  var toStr$7 = Object.prototype.toString;
   function isCallable$2(fn2) {
-    return typeof fn2 === "function" || toStr$6.call(fn2) === "[object Function]";
+    return typeof fn2 === "function" || toStr$7.call(fn2) === "[object Function]";
   }
   function toInteger(value) {
     var number = Number(value);
@@ -8364,20 +8364,20 @@
   var _default$2 = (0, _iterationDecorator$2.default)(rolesMap, rolesMap.entries());
   rolesMap$1.default = _default$2;
   var elementRoleMap$1 = {};
-  var toStr$5 = Object.prototype.toString;
+  var toStr$6 = Object.prototype.toString;
   var isArguments$3 = function isArguments2(value) {
-    var str = toStr$5.call(value);
+    var str = toStr$6.call(value);
     var isArgs2 = str === "[object Arguments]";
     if (!isArgs2) {
-      isArgs2 = str !== "[object Array]" && value !== null && typeof value === "object" && typeof value.length === "number" && value.length >= 0 && toStr$5.call(value.callee) === "[object Function]";
+      isArgs2 = str !== "[object Array]" && value !== null && typeof value === "object" && typeof value.length === "number" && value.length >= 0 && toStr$6.call(value.callee) === "[object Function]";
     }
     return isArgs2;
   };
-  var implementation$a;
-  var hasRequiredImplementation$1;
-  function requireImplementation$1() {
-    if (hasRequiredImplementation$1) return implementation$a;
-    hasRequiredImplementation$1 = 1;
+  var implementation$b;
+  var hasRequiredImplementation;
+  function requireImplementation() {
+    if (hasRequiredImplementation) return implementation$b;
+    hasRequiredImplementation = 1;
     var keysShim2;
     if (!Object.keys) {
       var has2 = Object.prototype.hasOwnProperty;
@@ -8491,15 +8491,15 @@
         return theKeys;
       };
     }
-    implementation$a = keysShim2;
-    return implementation$a;
+    implementation$b = keysShim2;
+    return implementation$b;
   }
   var slice = Array.prototype.slice;
   var isArgs = isArguments$3;
   var origKeys = Object.keys;
   var keysShim = origKeys ? function keys2(o) {
     return origKeys(o);
-  } : requireImplementation$1();
+  } : requireImplementation();
   var originalKeys = Object.keys;
   keysShim.shim = function shimObjectKeys() {
     if (Object.keys) {
@@ -8600,11 +8600,11 @@
   var hasPropertyDescriptors_1 = hasPropertyDescriptors;
   var keys$2 = objectKeys$2;
   var hasSymbols$5 = typeof Symbol === "function" && typeof Symbol("foo") === "symbol";
-  var toStr$4 = Object.prototype.toString;
+  var toStr$5 = Object.prototype.toString;
   var concat = Array.prototype.concat;
   var defineDataProperty = defineDataProperty$1;
   var isFunction = function(fn2) {
-    return typeof fn2 === "function" && toStr$4.call(fn2) === "[object Function]";
+    return typeof fn2 === "function" && toStr$5.call(fn2) === "[object Function]";
   };
   var supportsDescriptors$2 = hasPropertyDescriptors_1();
   var defineProperty$1 = function(object, name, value, predicate) {
@@ -8644,7 +8644,7 @@
   var uri = URIError;
   var abs$1 = Math.abs;
   var floor$1 = Math.floor;
-  var max$1 = Math.max;
+  var max$2 = Math.max;
   var min$1 = Math.min;
   var pow$1 = Math.pow;
   var shams$1 = function hasSymbols2() {
@@ -8712,91 +8712,77 @@
     }
     return hasSymbolSham();
   };
-  var implementation$9;
-  var hasRequiredImplementation;
-  function requireImplementation() {
-    if (hasRequiredImplementation) return implementation$9;
-    hasRequiredImplementation = 1;
-    var ERROR_MESSAGE = "Function.prototype.bind called on incompatible ";
-    var toStr2 = Object.prototype.toString;
-    var max2 = Math.max;
-    var funcType = "[object Function]";
-    var concatty = function concatty2(a, b2) {
-      var arr = [];
-      for (var i2 = 0; i2 < a.length; i2 += 1) {
-        arr[i2] = a[i2];
+  var ERROR_MESSAGE = "Function.prototype.bind called on incompatible ";
+  var toStr$4 = Object.prototype.toString;
+  var max$1 = Math.max;
+  var funcType = "[object Function]";
+  var concatty = function concatty2(a, b2) {
+    var arr = [];
+    for (var i2 = 0; i2 < a.length; i2 += 1) {
+      arr[i2] = a[i2];
+    }
+    for (var j = 0; j < b2.length; j += 1) {
+      arr[j + a.length] = b2[j];
+    }
+    return arr;
+  };
+  var slicy = function slicy2(arrLike, offset) {
+    var arr = [];
+    for (var i2 = offset, j = 0; i2 < arrLike.length; i2 += 1, j += 1) {
+      arr[j] = arrLike[i2];
+    }
+    return arr;
+  };
+  var joiny = function(arr, joiner) {
+    var str = "";
+    for (var i2 = 0; i2 < arr.length; i2 += 1) {
+      str += arr[i2];
+      if (i2 + 1 < arr.length) {
+        str += joiner;
       }
-      for (var j = 0; j < b2.length; j += 1) {
-        arr[j + a.length] = b2[j];
-      }
-      return arr;
-    };
-    var slicy = function slicy2(arrLike, offset) {
-      var arr = [];
-      for (var i2 = offset, j = 0; i2 < arrLike.length; i2 += 1, j += 1) {
-        arr[j] = arrLike[i2];
-      }
-      return arr;
-    };
-    var joiny = function(arr, joiner) {
-      var str = "";
-      for (var i2 = 0; i2 < arr.length; i2 += 1) {
-        str += arr[i2];
-        if (i2 + 1 < arr.length) {
-          str += joiner;
-        }
-      }
-      return str;
-    };
-    implementation$9 = function bind2(that) {
-      var target = this;
-      if (typeof target !== "function" || toStr2.apply(target) !== funcType) {
-        throw new TypeError(ERROR_MESSAGE + target);
-      }
-      var args = slicy(arguments, 1);
-      var bound2;
-      var binder = function() {
-        if (this instanceof bound2) {
-          var result = target.apply(
-            this,
-            concatty(args, arguments)
-          );
-          if (Object(result) === result) {
-            return result;
-          }
-          return this;
-        }
-        return target.apply(
-          that,
+    }
+    return str;
+  };
+  var implementation$a = function bind2(that) {
+    var target = this;
+    if (typeof target !== "function" || toStr$4.apply(target) !== funcType) {
+      throw new TypeError(ERROR_MESSAGE + target);
+    }
+    var args = slicy(arguments, 1);
+    var bound2;
+    var binder = function() {
+      if (this instanceof bound2) {
+        var result = target.apply(
+          this,
           concatty(args, arguments)
         );
-      };
-      var boundLength = max2(0, target.length - args.length);
-      var boundArgs = [];
-      for (var i2 = 0; i2 < boundLength; i2++) {
-        boundArgs[i2] = "$" + i2;
+        if (Object(result) === result) {
+          return result;
+        }
+        return this;
       }
-      bound2 = Function("binder", "return function (" + joiny(boundArgs, ",") + "){ return binder.apply(this,arguments); }")(binder);
-      if (target.prototype) {
-        var Empty = function Empty2() {
-        };
-        Empty.prototype = target.prototype;
-        bound2.prototype = new Empty();
-        Empty.prototype = null;
-      }
-      return bound2;
+      return target.apply(
+        that,
+        concatty(args, arguments)
+      );
     };
-    return implementation$9;
-  }
-  var functionBind;
-  var hasRequiredFunctionBind;
-  function requireFunctionBind() {
-    if (hasRequiredFunctionBind) return functionBind;
-    hasRequiredFunctionBind = 1;
-    var implementation2 = requireImplementation();
-    functionBind = Function.prototype.bind || implementation2;
-    return functionBind;
-  }
+    var boundLength = max$1(0, target.length - args.length);
+    var boundArgs = [];
+    for (var i2 = 0; i2 < boundLength; i2++) {
+      boundArgs[i2] = "$" + i2;
+    }
+    bound2 = Function("binder", "return function (" + joiny(boundArgs, ",") + "){ return binder.apply(this,arguments); }")(binder);
+    if (target.prototype) {
+      var Empty = function Empty2() {
+      };
+      Empty.prototype = target.prototype;
+      bound2.prototype = new Empty();
+      Empty.prototype = null;
+    }
+    return bound2;
+  };
+  var implementation$9 = implementation$a;
+  var functionBind = Function.prototype.bind || implementation$9;
   var functionCall;
   var hasRequiredFunctionCall;
   function requireFunctionCall() {
@@ -8814,12 +8800,12 @@
     return functionApply;
   }
   var reflectApply$1 = typeof Reflect !== "undefined" && Reflect && Reflect.apply;
-  var bind$4 = requireFunctionBind();
+  var bind$4 = functionBind;
   var $apply$2 = requireFunctionApply();
   var $call$2 = requireFunctionCall();
   var $reflectApply = reflectApply$1;
   var actualApply$1 = $reflectApply || bind$4.call($call$2, $apply$2);
-  var bind$3 = requireFunctionBind();
+  var bind$3 = functionBind;
   var $TypeError$9 = type$2;
   var $call$1 = requireFunctionCall();
   var $actualApply = actualApply$1;
@@ -8862,7 +8848,7 @@
   }
   var call = Function.prototype.call;
   var $hasOwn = Object.prototype.hasOwnProperty;
-  var bind$2 = requireFunctionBind();
+  var bind$2 = functionBind;
   var hasown = bind$2.call(call, $hasOwn);
   var undefined$1;
   var $Object$2 = esObjectAtoms;
@@ -8875,7 +8861,7 @@
   var $URIError = uri;
   var abs = abs$1;
   var floor = floor$1;
-  var max = max$1;
+  var max = max$2;
   var min = min$1;
   var pow = pow$1;
   var $Function = Function;
@@ -9072,7 +9058,7 @@
     "%WeakMapPrototype%": ["WeakMap", "prototype"],
     "%WeakSetPrototype%": ["WeakSet", "prototype"]
   };
-  var bind$1 = requireFunctionBind();
+  var bind$1 = functionBind;
   var hasOwn$3 = hasown;
   var $concat$1 = bind$1.call($call, Array.prototype.concat);
   var $spliceApply = bind$1.call($apply$1, Array.prototype.splice);
@@ -9225,7 +9211,7 @@
     }
     return fn2;
   };
-  var bind = requireFunctionBind();
+  var bind = functionBind;
   var $apply = requireFunctionApply();
   var actualApply = actualApply$1;
   var applyBind = function applyBind2() {

--- a/lib/js/react-testing-library.js
+++ b/lib/js/react-testing-library.js
@@ -1,7 +1,8 @@
 (function(global2, factory) {
-  typeof exports === "object" && typeof module !== "undefined" ? factory(exports, require("react"), require("react-dom")) : typeof define === "function" && define.amd ? define(["exports", "react", "react-dom"], factory) : (global2 = typeof globalThis !== "undefined" ? globalThis : global2 || self, factory(global2.rtl = {}, global2.React, global2.ReactDOM));
-})(this, function(exports2, React, ReactDOM) {
+  typeof exports === "object" && typeof module !== "undefined" ? module.exports = factory(require("react"), require("react-dom")) : typeof define === "function" && define.amd ? define(["react", "react-dom"], factory) : (global2 = typeof globalThis !== "undefined" ? globalThis : global2 || self, global2.rtl = factory(global2.React, global2.ReactDOM));
+})(this, function(l__default, m$1$1) {
   "use strict";
+  var _a;
   function _interopNamespaceDefault(e2) {
     const n2 = Object.create(null, { [Symbol.toStringTag]: { value: "Module" } });
     if (e2) {
@@ -37,7 +38,21348 @@
     }
     return Object.freeze(Object.defineProperty(n2, Symbol.toStringTag, { value: "Module" }));
   }
-  const React__namespace = /* @__PURE__ */ _interopNamespaceDefault(React);
+  const l__default__namespace = /* @__PURE__ */ _interopNamespaceDefault(l__default);
+  var global$1$1 = typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {};
+  function defaultSetTimout() {
+    throw new Error("setTimeout has not been defined");
+  }
+  function defaultClearTimeout() {
+    throw new Error("clearTimeout has not been defined");
+  }
+  var cachedSetTimeout = defaultSetTimout;
+  var cachedClearTimeout = defaultClearTimeout;
+  if (typeof global$1$1.setTimeout === "function") {
+    cachedSetTimeout = setTimeout;
+  }
+  if (typeof global$1$1.clearTimeout === "function") {
+    cachedClearTimeout = clearTimeout;
+  }
+  function runTimeout(fun) {
+    if (cachedSetTimeout === setTimeout) {
+      return setTimeout(fun, 0);
+    }
+    if ((cachedSetTimeout === defaultSetTimout || !cachedSetTimeout) && setTimeout) {
+      cachedSetTimeout = setTimeout;
+      return setTimeout(fun, 0);
+    }
+    try {
+      return cachedSetTimeout(fun, 0);
+    } catch (e2) {
+      try {
+        return cachedSetTimeout.call(null, fun, 0);
+      } catch (e3) {
+        return cachedSetTimeout.call(this, fun, 0);
+      }
+    }
+  }
+  function runClearTimeout(marker) {
+    if (cachedClearTimeout === clearTimeout) {
+      return clearTimeout(marker);
+    }
+    if ((cachedClearTimeout === defaultClearTimeout || !cachedClearTimeout) && clearTimeout) {
+      cachedClearTimeout = clearTimeout;
+      return clearTimeout(marker);
+    }
+    try {
+      return cachedClearTimeout(marker);
+    } catch (e2) {
+      try {
+        return cachedClearTimeout.call(null, marker);
+      } catch (e3) {
+        return cachedClearTimeout.call(this, marker);
+      }
+    }
+  }
+  var queue = [];
+  var draining = false;
+  var currentQueue;
+  var queueIndex = -1;
+  function cleanUpNextTick() {
+    if (!draining || !currentQueue) {
+      return;
+    }
+    draining = false;
+    if (currentQueue.length) {
+      queue = currentQueue.concat(queue);
+    } else {
+      queueIndex = -1;
+    }
+    if (queue.length) {
+      drainQueue();
+    }
+  }
+  function drainQueue() {
+    if (draining) {
+      return;
+    }
+    var timeout = runTimeout(cleanUpNextTick);
+    draining = true;
+    var len = queue.length;
+    while (len) {
+      currentQueue = queue;
+      queue = [];
+      while (++queueIndex < len) {
+        if (currentQueue) {
+          currentQueue[queueIndex].run();
+        }
+      }
+      queueIndex = -1;
+      len = queue.length;
+    }
+    currentQueue = null;
+    draining = false;
+    runClearTimeout(timeout);
+  }
+  function nextTick(fun) {
+    var args = new Array(arguments.length - 1);
+    if (arguments.length > 1) {
+      for (var i2 = 1; i2 < arguments.length; i2++) {
+        args[i2 - 1] = arguments[i2];
+      }
+    }
+    queue.push(new Item(fun, args));
+    if (queue.length === 1 && !draining) {
+      runTimeout(drainQueue);
+    }
+  }
+  function Item(fun, array) {
+    this.fun = fun;
+    this.array = array;
+  }
+  Item.prototype.run = function() {
+    this.fun.apply(null, this.array);
+  };
+  var title = "browser";
+  var platform = "browser";
+  var browser = true;
+  var env = {};
+  var argv = [];
+  var version$1 = "";
+  var versions$1 = {};
+  var release = {};
+  var config$1 = {};
+  function noop$1() {
+  }
+  var on = noop$1;
+  var addListener = noop$1;
+  var once = noop$1;
+  var off = noop$1;
+  var removeListener = noop$1;
+  var removeAllListeners = noop$1;
+  var emit = noop$1;
+  function binding(name) {
+    throw new Error("process.binding is not supported");
+  }
+  function cwd() {
+    return "/";
+  }
+  function chdir(dir) {
+    throw new Error("process.chdir is not supported");
+  }
+  function umask() {
+    return 0;
+  }
+  var performance$1 = global$1$1.performance || {};
+  var performanceNow = performance$1.now || performance$1.mozNow || performance$1.msNow || performance$1.oNow || performance$1.webkitNow || function() {
+    return (/* @__PURE__ */ new Date()).getTime();
+  };
+  function hrtime(previousTimestamp) {
+    var clocktime = performanceNow.call(performance$1) * 1e-3;
+    var seconds = Math.floor(clocktime);
+    var nanoseconds = Math.floor(clocktime % 1 * 1e9);
+    if (previousTimestamp) {
+      seconds = seconds - previousTimestamp[0];
+      nanoseconds = nanoseconds - previousTimestamp[1];
+      if (nanoseconds < 0) {
+        seconds--;
+        nanoseconds += 1e9;
+      }
+    }
+    return [seconds, nanoseconds];
+  }
+  var startTime = /* @__PURE__ */ new Date();
+  function uptime() {
+    var currentTime = /* @__PURE__ */ new Date();
+    var dif = currentTime - startTime;
+    return dif / 1e3;
+  }
+  var process$1 = {
+    nextTick,
+    title,
+    browser,
+    env,
+    argv,
+    version: version$1,
+    versions: versions$1,
+    on,
+    addListener,
+    once,
+    off,
+    removeListener,
+    removeAllListeners,
+    emit,
+    binding,
+    cwd,
+    chdir,
+    umask,
+    hrtime,
+    platform,
+    release,
+    config: config$1,
+    uptime
+  };
+  function _extends() {
+    return _extends = Object.assign ? Object.assign.bind() : function(n2) {
+      for (var e2 = 1; e2 < arguments.length; e2++) {
+        var t2 = arguments[e2];
+        for (var r2 in t2) ({}).hasOwnProperty.call(t2, r2) && (n2[r2] = t2[r2]);
+      }
+      return n2;
+    }, _extends.apply(null, arguments);
+  }
+  function asyncGeneratorStep(n2, t2, e2, r2, o, a, c2) {
+    try {
+      var i2 = n2[a](c2), u2 = i2.value;
+    } catch (n3) {
+      return void e2(n3);
+    }
+    i2.done ? t2(u2) : Promise.resolve(u2).then(r2, o);
+  }
+  function _asyncToGenerator(n2) {
+    return function() {
+      var t2 = this, e2 = arguments;
+      return new Promise(function(r2, o) {
+        var a = n2.apply(t2, e2);
+        function _next(n3) {
+          asyncGeneratorStep(a, r2, o, _next, _throw, "next", n3);
+        }
+        function _throw(n3) {
+          asyncGeneratorStep(a, r2, o, _next, _throw, "throw", n3);
+        }
+        _next(void 0);
+      });
+    };
+  }
+  function getDefaultExportFromCjs$1(x2) {
+    return x2 && x2.__esModule && Object.prototype.hasOwnProperty.call(x2, "default") ? x2["default"] : x2;
+  }
+  function getAugmentedNamespace$1(n2) {
+    if (n2.__esModule) return n2;
+    var a = Object.defineProperty({}, "__esModule", { value: true });
+    Object.keys(n2).forEach(function(k2) {
+      var d2 = Object.getOwnPropertyDescriptor(n2, k2);
+      Object.defineProperty(a, k2, d2.get ? d2 : {
+        enumerable: true,
+        get: function() {
+          return n2[k2];
+        }
+      });
+    });
+    return a;
+  }
+  function createCommonjsModule(fn2) {
+    var module2 = { exports: {} };
+    return fn2(module2, module2.exports), module2.exports;
+  }
+  var _typeof_1$1 = createCommonjsModule(function(module2) {
+    function _typeof2(o) {
+      "@babel/helpers - typeof";
+      return module2.exports = _typeof2 = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function(o2) {
+        return typeof o2;
+      } : function(o2) {
+        return o2 && "function" == typeof Symbol && o2.constructor === Symbol && o2 !== Symbol.prototype ? "symbol" : typeof o2;
+      }, module2.exports.__esModule = true, module2.exports["default"] = module2.exports, _typeof2(o);
+    }
+    module2.exports = _typeof2, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+  });
+  var regeneratorRuntime$1 = createCommonjsModule(function(module2) {
+    var _typeof2 = _typeof_1$1["default"];
+    function _regeneratorRuntime() {
+      module2.exports = _regeneratorRuntime = function _regeneratorRuntime2() {
+        return e2;
+      }, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+      var t2, e2 = {}, r2 = Object.prototype, n2 = r2.hasOwnProperty, o = Object.defineProperty || function(t3, e3, r3) {
+        t3[e3] = r3.value;
+      }, i2 = "function" == typeof Symbol ? Symbol : {}, a = i2.iterator || "@@iterator", c2 = i2.asyncIterator || "@@asyncIterator", u2 = i2.toStringTag || "@@toStringTag";
+      function define3(t3, e3, r3) {
+        return Object.defineProperty(t3, e3, {
+          value: r3,
+          enumerable: true,
+          configurable: true,
+          writable: true
+        }), t3[e3];
+      }
+      try {
+        define3({}, "");
+      } catch (t3) {
+        define3 = function define4(t4, e3, r3) {
+          return t4[e3] = r3;
+        };
+      }
+      function wrap2(t3, e3, r3, n3) {
+        var i3 = e3 && e3.prototype instanceof Generator ? e3 : Generator, a2 = Object.create(i3.prototype), c3 = new Context(n3 || []);
+        return o(a2, "_invoke", {
+          value: makeInvokeMethod(t3, r3, c3)
+        }), a2;
+      }
+      function tryCatch(t3, e3, r3) {
+        try {
+          return {
+            type: "normal",
+            arg: t3.call(e3, r3)
+          };
+        } catch (t4) {
+          return {
+            type: "throw",
+            arg: t4
+          };
+        }
+      }
+      e2.wrap = wrap2;
+      var h2 = "suspendedStart", l2 = "suspendedYield", f2 = "executing", s = "completed", y2 = {};
+      function Generator() {
+      }
+      function GeneratorFunction() {
+      }
+      function GeneratorFunctionPrototype() {
+      }
+      var p2 = {};
+      define3(p2, a, function() {
+        return this;
+      });
+      var d2 = Object.getPrototypeOf, v2 = d2 && d2(d2(values([])));
+      v2 && v2 !== r2 && n2.call(v2, a) && (p2 = v2);
+      var g2 = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(p2);
+      function defineIteratorMethods(t3) {
+        ["next", "throw", "return"].forEach(function(e3) {
+          define3(t3, e3, function(t4) {
+            return this._invoke(e3, t4);
+          });
+        });
+      }
+      function AsyncIterator(t3, e3) {
+        function invoke(r4, o2, i3, a2) {
+          var c3 = tryCatch(t3[r4], t3, o2);
+          if ("throw" !== c3.type) {
+            var u3 = c3.arg, h3 = u3.value;
+            return h3 && "object" == _typeof2(h3) && n2.call(h3, "__await") ? e3.resolve(h3.__await).then(function(t4) {
+              invoke("next", t4, i3, a2);
+            }, function(t4) {
+              invoke("throw", t4, i3, a2);
+            }) : e3.resolve(h3).then(function(t4) {
+              u3.value = t4, i3(u3);
+            }, function(t4) {
+              return invoke("throw", t4, i3, a2);
+            });
+          }
+          a2(c3.arg);
+        }
+        var r3;
+        o(this, "_invoke", {
+          value: function value(t4, n3) {
+            function callInvokeWithMethodAndArg() {
+              return new e3(function(e4, r4) {
+                invoke(t4, n3, e4, r4);
+              });
+            }
+            return r3 = r3 ? r3.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg();
+          }
+        });
+      }
+      function makeInvokeMethod(e3, r3, n3) {
+        var o2 = h2;
+        return function(i3, a2) {
+          if (o2 === f2) throw Error("Generator is already running");
+          if (o2 === s) {
+            if ("throw" === i3) throw a2;
+            return {
+              value: t2,
+              done: true
+            };
+          }
+          for (n3.method = i3, n3.arg = a2; ; ) {
+            var c3 = n3.delegate;
+            if (c3) {
+              var u3 = maybeInvokeDelegate(c3, n3);
+              if (u3) {
+                if (u3 === y2) continue;
+                return u3;
+              }
+            }
+            if ("next" === n3.method) n3.sent = n3._sent = n3.arg;
+            else if ("throw" === n3.method) {
+              if (o2 === h2) throw o2 = s, n3.arg;
+              n3.dispatchException(n3.arg);
+            } else "return" === n3.method && n3.abrupt("return", n3.arg);
+            o2 = f2;
+            var p3 = tryCatch(e3, r3, n3);
+            if ("normal" === p3.type) {
+              if (o2 = n3.done ? s : l2, p3.arg === y2) continue;
+              return {
+                value: p3.arg,
+                done: n3.done
+              };
+            }
+            "throw" === p3.type && (o2 = s, n3.method = "throw", n3.arg = p3.arg);
+          }
+        };
+      }
+      function maybeInvokeDelegate(e3, r3) {
+        var n3 = r3.method, o2 = e3.iterator[n3];
+        if (o2 === t2) return r3.delegate = null, "throw" === n3 && e3.iterator["return"] && (r3.method = "return", r3.arg = t2, maybeInvokeDelegate(e3, r3), "throw" === r3.method) || "return" !== n3 && (r3.method = "throw", r3.arg = new TypeError("The iterator does not provide a '" + n3 + "' method")), y2;
+        var i3 = tryCatch(o2, e3.iterator, r3.arg);
+        if ("throw" === i3.type) return r3.method = "throw", r3.arg = i3.arg, r3.delegate = null, y2;
+        var a2 = i3.arg;
+        return a2 ? a2.done ? (r3[e3.resultName] = a2.value, r3.next = e3.nextLoc, "return" !== r3.method && (r3.method = "next", r3.arg = t2), r3.delegate = null, y2) : a2 : (r3.method = "throw", r3.arg = new TypeError("iterator result is not an object"), r3.delegate = null, y2);
+      }
+      function pushTryEntry(t3) {
+        var e3 = {
+          tryLoc: t3[0]
+        };
+        1 in t3 && (e3.catchLoc = t3[1]), 2 in t3 && (e3.finallyLoc = t3[2], e3.afterLoc = t3[3]), this.tryEntries.push(e3);
+      }
+      function resetTryEntry(t3) {
+        var e3 = t3.completion || {};
+        e3.type = "normal", delete e3.arg, t3.completion = e3;
+      }
+      function Context(t3) {
+        this.tryEntries = [{
+          tryLoc: "root"
+        }], t3.forEach(pushTryEntry, this), this.reset(true);
+      }
+      function values(e3) {
+        if (e3 || "" === e3) {
+          var r3 = e3[a];
+          if (r3) return r3.call(e3);
+          if ("function" == typeof e3.next) return e3;
+          if (!isNaN(e3.length)) {
+            var o2 = -1, i3 = function next() {
+              for (; ++o2 < e3.length; ) if (n2.call(e3, o2)) return next.value = e3[o2], next.done = false, next;
+              return next.value = t2, next.done = true, next;
+            };
+            return i3.next = i3;
+          }
+        }
+        throw new TypeError(_typeof2(e3) + " is not iterable");
+      }
+      return GeneratorFunction.prototype = GeneratorFunctionPrototype, o(g2, "constructor", {
+        value: GeneratorFunctionPrototype,
+        configurable: true
+      }), o(GeneratorFunctionPrototype, "constructor", {
+        value: GeneratorFunction,
+        configurable: true
+      }), GeneratorFunction.displayName = define3(GeneratorFunctionPrototype, u2, "GeneratorFunction"), e2.isGeneratorFunction = function(t3) {
+        var e3 = "function" == typeof t3 && t3.constructor;
+        return !!e3 && (e3 === GeneratorFunction || "GeneratorFunction" === (e3.displayName || e3.name));
+      }, e2.mark = function(t3) {
+        return Object.setPrototypeOf ? Object.setPrototypeOf(t3, GeneratorFunctionPrototype) : (t3.__proto__ = GeneratorFunctionPrototype, define3(t3, u2, "GeneratorFunction")), t3.prototype = Object.create(g2), t3;
+      }, e2.awrap = function(t3) {
+        return {
+          __await: t3
+        };
+      }, defineIteratorMethods(AsyncIterator.prototype), define3(AsyncIterator.prototype, c2, function() {
+        return this;
+      }), e2.AsyncIterator = AsyncIterator, e2.async = function(t3, r3, n3, o2, i3) {
+        void 0 === i3 && (i3 = Promise);
+        var a2 = new AsyncIterator(wrap2(t3, r3, n3, o2), i3);
+        return e2.isGeneratorFunction(r3) ? a2 : a2.next().then(function(t4) {
+          return t4.done ? t4.value : a2.next();
+        });
+      }, defineIteratorMethods(g2), define3(g2, u2, "Generator"), define3(g2, a, function() {
+        return this;
+      }), define3(g2, "toString", function() {
+        return "[object Generator]";
+      }), e2.keys = function(t3) {
+        var e3 = Object(t3), r3 = [];
+        for (var n3 in e3) r3.push(n3);
+        return r3.reverse(), function next() {
+          for (; r3.length; ) {
+            var t4 = r3.pop();
+            if (t4 in e3) return next.value = t4, next.done = false, next;
+          }
+          return next.done = true, next;
+        };
+      }, e2.values = values, Context.prototype = {
+        constructor: Context,
+        reset: function reset(e3) {
+          if (this.prev = 0, this.next = 0, this.sent = this._sent = t2, this.done = false, this.delegate = null, this.method = "next", this.arg = t2, this.tryEntries.forEach(resetTryEntry), !e3) for (var r3 in this) "t" === r3.charAt(0) && n2.call(this, r3) && !isNaN(+r3.slice(1)) && (this[r3] = t2);
+        },
+        stop: function stop() {
+          this.done = true;
+          var t3 = this.tryEntries[0].completion;
+          if ("throw" === t3.type) throw t3.arg;
+          return this.rval;
+        },
+        dispatchException: function dispatchException(e3) {
+          if (this.done) throw e3;
+          var r3 = this;
+          function handle(n3, o3) {
+            return a2.type = "throw", a2.arg = e3, r3.next = n3, o3 && (r3.method = "next", r3.arg = t2), !!o3;
+          }
+          for (var o2 = this.tryEntries.length - 1; o2 >= 0; --o2) {
+            var i3 = this.tryEntries[o2], a2 = i3.completion;
+            if ("root" === i3.tryLoc) return handle("end");
+            if (i3.tryLoc <= this.prev) {
+              var c3 = n2.call(i3, "catchLoc"), u3 = n2.call(i3, "finallyLoc");
+              if (c3 && u3) {
+                if (this.prev < i3.catchLoc) return handle(i3.catchLoc, true);
+                if (this.prev < i3.finallyLoc) return handle(i3.finallyLoc);
+              } else if (c3) {
+                if (this.prev < i3.catchLoc) return handle(i3.catchLoc, true);
+              } else {
+                if (!u3) throw Error("try statement without catch or finally");
+                if (this.prev < i3.finallyLoc) return handle(i3.finallyLoc);
+              }
+            }
+          }
+        },
+        abrupt: function abrupt(t3, e3) {
+          for (var r3 = this.tryEntries.length - 1; r3 >= 0; --r3) {
+            var o2 = this.tryEntries[r3];
+            if (o2.tryLoc <= this.prev && n2.call(o2, "finallyLoc") && this.prev < o2.finallyLoc) {
+              var i3 = o2;
+              break;
+            }
+          }
+          i3 && ("break" === t3 || "continue" === t3) && i3.tryLoc <= e3 && e3 <= i3.finallyLoc && (i3 = null);
+          var a2 = i3 ? i3.completion : {};
+          return a2.type = t3, a2.arg = e3, i3 ? (this.method = "next", this.next = i3.finallyLoc, y2) : this.complete(a2);
+        },
+        complete: function complete(t3, e3) {
+          if ("throw" === t3.type) throw t3.arg;
+          return "break" === t3.type || "continue" === t3.type ? this.next = t3.arg : "return" === t3.type ? (this.rval = this.arg = t3.arg, this.method = "return", this.next = "end") : "normal" === t3.type && e3 && (this.next = e3), y2;
+        },
+        finish: function finish(t3) {
+          for (var e3 = this.tryEntries.length - 1; e3 >= 0; --e3) {
+            var r3 = this.tryEntries[e3];
+            if (r3.finallyLoc === t3) return this.complete(r3.completion, r3.afterLoc), resetTryEntry(r3), y2;
+          }
+        },
+        "catch": function _catch(t3) {
+          for (var e3 = this.tryEntries.length - 1; e3 >= 0; --e3) {
+            var r3 = this.tryEntries[e3];
+            if (r3.tryLoc === t3) {
+              var n3 = r3.completion;
+              if ("throw" === n3.type) {
+                var o2 = n3.arg;
+                resetTryEntry(r3);
+              }
+              return o2;
+            }
+          }
+          throw Error("illegal catch attempt");
+        },
+        delegateYield: function delegateYield(e3, r3, n3) {
+          return this.delegate = {
+            iterator: values(e3),
+            resultName: r3,
+            nextLoc: n3
+          }, "next" === this.method && (this.arg = t2), y2;
+        }
+      }, e2;
+    }
+    module2.exports = _regeneratorRuntime, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+  });
+  var runtime = regeneratorRuntime$1();
+  var regenerator = runtime;
+  try {
+    regeneratorRuntime = runtime;
+  } catch (accidentalStrictMode) {
+    if (typeof globalThis === "object") {
+      globalThis.regeneratorRuntime = runtime;
+    } else {
+      Function("r", "regeneratorRuntime = r")(runtime);
+    }
+  }
+  var colorName = {
+    "aliceblue": [240, 248, 255],
+    "antiquewhite": [250, 235, 215],
+    "aqua": [0, 255, 255],
+    "aquamarine": [127, 255, 212],
+    "azure": [240, 255, 255],
+    "beige": [245, 245, 220],
+    "bisque": [255, 228, 196],
+    "black": [0, 0, 0],
+    "blanchedalmond": [255, 235, 205],
+    "blue": [0, 0, 255],
+    "blueviolet": [138, 43, 226],
+    "brown": [165, 42, 42],
+    "burlywood": [222, 184, 135],
+    "cadetblue": [95, 158, 160],
+    "chartreuse": [127, 255, 0],
+    "chocolate": [210, 105, 30],
+    "coral": [255, 127, 80],
+    "cornflowerblue": [100, 149, 237],
+    "cornsilk": [255, 248, 220],
+    "crimson": [220, 20, 60],
+    "cyan": [0, 255, 255],
+    "darkblue": [0, 0, 139],
+    "darkcyan": [0, 139, 139],
+    "darkgoldenrod": [184, 134, 11],
+    "darkgray": [169, 169, 169],
+    "darkgreen": [0, 100, 0],
+    "darkgrey": [169, 169, 169],
+    "darkkhaki": [189, 183, 107],
+    "darkmagenta": [139, 0, 139],
+    "darkolivegreen": [85, 107, 47],
+    "darkorange": [255, 140, 0],
+    "darkorchid": [153, 50, 204],
+    "darkred": [139, 0, 0],
+    "darksalmon": [233, 150, 122],
+    "darkseagreen": [143, 188, 143],
+    "darkslateblue": [72, 61, 139],
+    "darkslategray": [47, 79, 79],
+    "darkslategrey": [47, 79, 79],
+    "darkturquoise": [0, 206, 209],
+    "darkviolet": [148, 0, 211],
+    "deeppink": [255, 20, 147],
+    "deepskyblue": [0, 191, 255],
+    "dimgray": [105, 105, 105],
+    "dimgrey": [105, 105, 105],
+    "dodgerblue": [30, 144, 255],
+    "firebrick": [178, 34, 34],
+    "floralwhite": [255, 250, 240],
+    "forestgreen": [34, 139, 34],
+    "fuchsia": [255, 0, 255],
+    "gainsboro": [220, 220, 220],
+    "ghostwhite": [248, 248, 255],
+    "gold": [255, 215, 0],
+    "goldenrod": [218, 165, 32],
+    "gray": [128, 128, 128],
+    "green": [0, 128, 0],
+    "greenyellow": [173, 255, 47],
+    "grey": [128, 128, 128],
+    "honeydew": [240, 255, 240],
+    "hotpink": [255, 105, 180],
+    "indianred": [205, 92, 92],
+    "indigo": [75, 0, 130],
+    "ivory": [255, 255, 240],
+    "khaki": [240, 230, 140],
+    "lavender": [230, 230, 250],
+    "lavenderblush": [255, 240, 245],
+    "lawngreen": [124, 252, 0],
+    "lemonchiffon": [255, 250, 205],
+    "lightblue": [173, 216, 230],
+    "lightcoral": [240, 128, 128],
+    "lightcyan": [224, 255, 255],
+    "lightgoldenrodyellow": [250, 250, 210],
+    "lightgray": [211, 211, 211],
+    "lightgreen": [144, 238, 144],
+    "lightgrey": [211, 211, 211],
+    "lightpink": [255, 182, 193],
+    "lightsalmon": [255, 160, 122],
+    "lightseagreen": [32, 178, 170],
+    "lightskyblue": [135, 206, 250],
+    "lightslategray": [119, 136, 153],
+    "lightslategrey": [119, 136, 153],
+    "lightsteelblue": [176, 196, 222],
+    "lightyellow": [255, 255, 224],
+    "lime": [0, 255, 0],
+    "limegreen": [50, 205, 50],
+    "linen": [250, 240, 230],
+    "magenta": [255, 0, 255],
+    "maroon": [128, 0, 0],
+    "mediumaquamarine": [102, 205, 170],
+    "mediumblue": [0, 0, 205],
+    "mediumorchid": [186, 85, 211],
+    "mediumpurple": [147, 112, 219],
+    "mediumseagreen": [60, 179, 113],
+    "mediumslateblue": [123, 104, 238],
+    "mediumspringgreen": [0, 250, 154],
+    "mediumturquoise": [72, 209, 204],
+    "mediumvioletred": [199, 21, 133],
+    "midnightblue": [25, 25, 112],
+    "mintcream": [245, 255, 250],
+    "mistyrose": [255, 228, 225],
+    "moccasin": [255, 228, 181],
+    "navajowhite": [255, 222, 173],
+    "navy": [0, 0, 128],
+    "oldlace": [253, 245, 230],
+    "olive": [128, 128, 0],
+    "olivedrab": [107, 142, 35],
+    "orange": [255, 165, 0],
+    "orangered": [255, 69, 0],
+    "orchid": [218, 112, 214],
+    "palegoldenrod": [238, 232, 170],
+    "palegreen": [152, 251, 152],
+    "paleturquoise": [175, 238, 238],
+    "palevioletred": [219, 112, 147],
+    "papayawhip": [255, 239, 213],
+    "peachpuff": [255, 218, 185],
+    "peru": [205, 133, 63],
+    "pink": [255, 192, 203],
+    "plum": [221, 160, 221],
+    "powderblue": [176, 224, 230],
+    "purple": [128, 0, 128],
+    "rebeccapurple": [102, 51, 153],
+    "red": [255, 0, 0],
+    "rosybrown": [188, 143, 143],
+    "royalblue": [65, 105, 225],
+    "saddlebrown": [139, 69, 19],
+    "salmon": [250, 128, 114],
+    "sandybrown": [244, 164, 96],
+    "seagreen": [46, 139, 87],
+    "seashell": [255, 245, 238],
+    "sienna": [160, 82, 45],
+    "silver": [192, 192, 192],
+    "skyblue": [135, 206, 235],
+    "slateblue": [106, 90, 205],
+    "slategray": [112, 128, 144],
+    "slategrey": [112, 128, 144],
+    "snow": [255, 250, 250],
+    "springgreen": [0, 255, 127],
+    "steelblue": [70, 130, 180],
+    "tan": [210, 180, 140],
+    "teal": [0, 128, 128],
+    "thistle": [216, 191, 216],
+    "tomato": [255, 99, 71],
+    "turquoise": [64, 224, 208],
+    "violet": [238, 130, 238],
+    "wheat": [245, 222, 179],
+    "white": [255, 255, 255],
+    "whitesmoke": [245, 245, 245],
+    "yellow": [255, 255, 0],
+    "yellowgreen": [154, 205, 50]
+  };
+  const reverseKeywords = {};
+  for (const key2 of Object.keys(colorName)) {
+    reverseKeywords[colorName[key2]] = key2;
+  }
+  const convert$1 = {
+    rgb: { channels: 3, labels: "rgb" },
+    hsl: { channels: 3, labels: "hsl" },
+    hsv: { channels: 3, labels: "hsv" },
+    hwb: { channels: 3, labels: "hwb" },
+    cmyk: { channels: 4, labels: "cmyk" },
+    xyz: { channels: 3, labels: "xyz" },
+    lab: { channels: 3, labels: "lab" },
+    lch: { channels: 3, labels: "lch" },
+    hex: { channels: 1, labels: ["hex"] },
+    keyword: { channels: 1, labels: ["keyword"] },
+    ansi16: { channels: 1, labels: ["ansi16"] },
+    ansi256: { channels: 1, labels: ["ansi256"] },
+    hcg: { channels: 3, labels: ["h", "c", "g"] },
+    apple: { channels: 3, labels: ["r16", "g16", "b16"] },
+    gray: { channels: 1, labels: ["gray"] }
+  };
+  var conversions = convert$1;
+  for (const model of Object.keys(convert$1)) {
+    if (!("channels" in convert$1[model])) {
+      throw new Error("missing channels property: " + model);
+    }
+    if (!("labels" in convert$1[model])) {
+      throw new Error("missing channel labels property: " + model);
+    }
+    if (convert$1[model].labels.length !== convert$1[model].channels) {
+      throw new Error("channel and label counts mismatch: " + model);
+    }
+    const { channels, labels } = convert$1[model];
+    delete convert$1[model].channels;
+    delete convert$1[model].labels;
+    Object.defineProperty(convert$1[model], "channels", { value: channels });
+    Object.defineProperty(convert$1[model], "labels", { value: labels });
+  }
+  convert$1.rgb.hsl = function(rgb) {
+    const r2 = rgb[0] / 255;
+    const g2 = rgb[1] / 255;
+    const b2 = rgb[2] / 255;
+    const min2 = Math.min(r2, g2, b2);
+    const max2 = Math.max(r2, g2, b2);
+    const delta = max2 - min2;
+    let h2;
+    let s;
+    if (max2 === min2) {
+      h2 = 0;
+    } else if (r2 === max2) {
+      h2 = (g2 - b2) / delta;
+    } else if (g2 === max2) {
+      h2 = 2 + (b2 - r2) / delta;
+    } else if (b2 === max2) {
+      h2 = 4 + (r2 - g2) / delta;
+    }
+    h2 = Math.min(h2 * 60, 360);
+    if (h2 < 0) {
+      h2 += 360;
+    }
+    const l2 = (min2 + max2) / 2;
+    if (max2 === min2) {
+      s = 0;
+    } else if (l2 <= 0.5) {
+      s = delta / (max2 + min2);
+    } else {
+      s = delta / (2 - max2 - min2);
+    }
+    return [h2, s * 100, l2 * 100];
+  };
+  convert$1.rgb.hsv = function(rgb) {
+    let rdif;
+    let gdif;
+    let bdif;
+    let h2;
+    let s;
+    const r2 = rgb[0] / 255;
+    const g2 = rgb[1] / 255;
+    const b2 = rgb[2] / 255;
+    const v2 = Math.max(r2, g2, b2);
+    const diff = v2 - Math.min(r2, g2, b2);
+    const diffc = function(c2) {
+      return (v2 - c2) / 6 / diff + 1 / 2;
+    };
+    if (diff === 0) {
+      h2 = 0;
+      s = 0;
+    } else {
+      s = diff / v2;
+      rdif = diffc(r2);
+      gdif = diffc(g2);
+      bdif = diffc(b2);
+      if (r2 === v2) {
+        h2 = bdif - gdif;
+      } else if (g2 === v2) {
+        h2 = 1 / 3 + rdif - bdif;
+      } else if (b2 === v2) {
+        h2 = 2 / 3 + gdif - rdif;
+      }
+      if (h2 < 0) {
+        h2 += 1;
+      } else if (h2 > 1) {
+        h2 -= 1;
+      }
+    }
+    return [
+      h2 * 360,
+      s * 100,
+      v2 * 100
+    ];
+  };
+  convert$1.rgb.hwb = function(rgb) {
+    const r2 = rgb[0];
+    const g2 = rgb[1];
+    let b2 = rgb[2];
+    const h2 = convert$1.rgb.hsl(rgb)[0];
+    const w2 = 1 / 255 * Math.min(r2, Math.min(g2, b2));
+    b2 = 1 - 1 / 255 * Math.max(r2, Math.max(g2, b2));
+    return [h2, w2 * 100, b2 * 100];
+  };
+  convert$1.rgb.cmyk = function(rgb) {
+    const r2 = rgb[0] / 255;
+    const g2 = rgb[1] / 255;
+    const b2 = rgb[2] / 255;
+    const k2 = Math.min(1 - r2, 1 - g2, 1 - b2);
+    const c2 = (1 - r2 - k2) / (1 - k2) || 0;
+    const m2 = (1 - g2 - k2) / (1 - k2) || 0;
+    const y2 = (1 - b2 - k2) / (1 - k2) || 0;
+    return [c2 * 100, m2 * 100, y2 * 100, k2 * 100];
+  };
+  function comparativeDistance(x2, y2) {
+    return (x2[0] - y2[0]) ** 2 + (x2[1] - y2[1]) ** 2 + (x2[2] - y2[2]) ** 2;
+  }
+  convert$1.rgb.keyword = function(rgb) {
+    const reversed = reverseKeywords[rgb];
+    if (reversed) {
+      return reversed;
+    }
+    let currentClosestDistance = Infinity;
+    let currentClosestKeyword;
+    for (const keyword of Object.keys(colorName)) {
+      const value = colorName[keyword];
+      const distance = comparativeDistance(rgb, value);
+      if (distance < currentClosestDistance) {
+        currentClosestDistance = distance;
+        currentClosestKeyword = keyword;
+      }
+    }
+    return currentClosestKeyword;
+  };
+  convert$1.keyword.rgb = function(keyword) {
+    return colorName[keyword];
+  };
+  convert$1.rgb.xyz = function(rgb) {
+    let r2 = rgb[0] / 255;
+    let g2 = rgb[1] / 255;
+    let b2 = rgb[2] / 255;
+    r2 = r2 > 0.04045 ? ((r2 + 0.055) / 1.055) ** 2.4 : r2 / 12.92;
+    g2 = g2 > 0.04045 ? ((g2 + 0.055) / 1.055) ** 2.4 : g2 / 12.92;
+    b2 = b2 > 0.04045 ? ((b2 + 0.055) / 1.055) ** 2.4 : b2 / 12.92;
+    const x2 = r2 * 0.4124 + g2 * 0.3576 + b2 * 0.1805;
+    const y2 = r2 * 0.2126 + g2 * 0.7152 + b2 * 0.0722;
+    const z2 = r2 * 0.0193 + g2 * 0.1192 + b2 * 0.9505;
+    return [x2 * 100, y2 * 100, z2 * 100];
+  };
+  convert$1.rgb.lab = function(rgb) {
+    const xyz = convert$1.rgb.xyz(rgb);
+    let x2 = xyz[0];
+    let y2 = xyz[1];
+    let z2 = xyz[2];
+    x2 /= 95.047;
+    y2 /= 100;
+    z2 /= 108.883;
+    x2 = x2 > 8856e-6 ? x2 ** (1 / 3) : 7.787 * x2 + 16 / 116;
+    y2 = y2 > 8856e-6 ? y2 ** (1 / 3) : 7.787 * y2 + 16 / 116;
+    z2 = z2 > 8856e-6 ? z2 ** (1 / 3) : 7.787 * z2 + 16 / 116;
+    const l2 = 116 * y2 - 16;
+    const a = 500 * (x2 - y2);
+    const b2 = 200 * (y2 - z2);
+    return [l2, a, b2];
+  };
+  convert$1.hsl.rgb = function(hsl) {
+    const h2 = hsl[0] / 360;
+    const s = hsl[1] / 100;
+    const l2 = hsl[2] / 100;
+    let t2;
+    let t3;
+    let val;
+    if (s === 0) {
+      val = l2 * 255;
+      return [val, val, val];
+    }
+    if (l2 < 0.5) {
+      t2 = l2 * (1 + s);
+    } else {
+      t2 = l2 + s - l2 * s;
+    }
+    const t1 = 2 * l2 - t2;
+    const rgb = [0, 0, 0];
+    for (let i2 = 0; i2 < 3; i2++) {
+      t3 = h2 + 1 / 3 * -(i2 - 1);
+      if (t3 < 0) {
+        t3++;
+      }
+      if (t3 > 1) {
+        t3--;
+      }
+      if (6 * t3 < 1) {
+        val = t1 + (t2 - t1) * 6 * t3;
+      } else if (2 * t3 < 1) {
+        val = t2;
+      } else if (3 * t3 < 2) {
+        val = t1 + (t2 - t1) * (2 / 3 - t3) * 6;
+      } else {
+        val = t1;
+      }
+      rgb[i2] = val * 255;
+    }
+    return rgb;
+  };
+  convert$1.hsl.hsv = function(hsl) {
+    const h2 = hsl[0];
+    let s = hsl[1] / 100;
+    let l2 = hsl[2] / 100;
+    let smin = s;
+    const lmin = Math.max(l2, 0.01);
+    l2 *= 2;
+    s *= l2 <= 1 ? l2 : 2 - l2;
+    smin *= lmin <= 1 ? lmin : 2 - lmin;
+    const v2 = (l2 + s) / 2;
+    const sv = l2 === 0 ? 2 * smin / (lmin + smin) : 2 * s / (l2 + s);
+    return [h2, sv * 100, v2 * 100];
+  };
+  convert$1.hsv.rgb = function(hsv) {
+    const h2 = hsv[0] / 60;
+    const s = hsv[1] / 100;
+    let v2 = hsv[2] / 100;
+    const hi2 = Math.floor(h2) % 6;
+    const f2 = h2 - Math.floor(h2);
+    const p2 = 255 * v2 * (1 - s);
+    const q2 = 255 * v2 * (1 - s * f2);
+    const t2 = 255 * v2 * (1 - s * (1 - f2));
+    v2 *= 255;
+    switch (hi2) {
+      case 0:
+        return [v2, t2, p2];
+      case 1:
+        return [q2, v2, p2];
+      case 2:
+        return [p2, v2, t2];
+      case 3:
+        return [p2, q2, v2];
+      case 4:
+        return [t2, p2, v2];
+      case 5:
+        return [v2, p2, q2];
+    }
+  };
+  convert$1.hsv.hsl = function(hsv) {
+    const h2 = hsv[0];
+    const s = hsv[1] / 100;
+    const v2 = hsv[2] / 100;
+    const vmin = Math.max(v2, 0.01);
+    let sl;
+    let l2;
+    l2 = (2 - s) * v2;
+    const lmin = (2 - s) * vmin;
+    sl = s * vmin;
+    sl /= lmin <= 1 ? lmin : 2 - lmin;
+    sl = sl || 0;
+    l2 /= 2;
+    return [h2, sl * 100, l2 * 100];
+  };
+  convert$1.hwb.rgb = function(hwb) {
+    const h2 = hwb[0] / 360;
+    let wh = hwb[1] / 100;
+    let bl = hwb[2] / 100;
+    const ratio = wh + bl;
+    let f2;
+    if (ratio > 1) {
+      wh /= ratio;
+      bl /= ratio;
+    }
+    const i2 = Math.floor(6 * h2);
+    const v2 = 1 - bl;
+    f2 = 6 * h2 - i2;
+    if ((i2 & 1) !== 0) {
+      f2 = 1 - f2;
+    }
+    const n2 = wh + f2 * (v2 - wh);
+    let r2;
+    let g2;
+    let b2;
+    switch (i2) {
+      default:
+      case 6:
+      case 0:
+        r2 = v2;
+        g2 = n2;
+        b2 = wh;
+        break;
+      case 1:
+        r2 = n2;
+        g2 = v2;
+        b2 = wh;
+        break;
+      case 2:
+        r2 = wh;
+        g2 = v2;
+        b2 = n2;
+        break;
+      case 3:
+        r2 = wh;
+        g2 = n2;
+        b2 = v2;
+        break;
+      case 4:
+        r2 = n2;
+        g2 = wh;
+        b2 = v2;
+        break;
+      case 5:
+        r2 = v2;
+        g2 = wh;
+        b2 = n2;
+        break;
+    }
+    return [r2 * 255, g2 * 255, b2 * 255];
+  };
+  convert$1.cmyk.rgb = function(cmyk) {
+    const c2 = cmyk[0] / 100;
+    const m2 = cmyk[1] / 100;
+    const y2 = cmyk[2] / 100;
+    const k2 = cmyk[3] / 100;
+    const r2 = 1 - Math.min(1, c2 * (1 - k2) + k2);
+    const g2 = 1 - Math.min(1, m2 * (1 - k2) + k2);
+    const b2 = 1 - Math.min(1, y2 * (1 - k2) + k2);
+    return [r2 * 255, g2 * 255, b2 * 255];
+  };
+  convert$1.xyz.rgb = function(xyz) {
+    const x2 = xyz[0] / 100;
+    const y2 = xyz[1] / 100;
+    const z2 = xyz[2] / 100;
+    let r2;
+    let g2;
+    let b2;
+    r2 = x2 * 3.2406 + y2 * -1.5372 + z2 * -0.4986;
+    g2 = x2 * -0.9689 + y2 * 1.8758 + z2 * 0.0415;
+    b2 = x2 * 0.0557 + y2 * -0.204 + z2 * 1.057;
+    r2 = r2 > 31308e-7 ? 1.055 * r2 ** (1 / 2.4) - 0.055 : r2 * 12.92;
+    g2 = g2 > 31308e-7 ? 1.055 * g2 ** (1 / 2.4) - 0.055 : g2 * 12.92;
+    b2 = b2 > 31308e-7 ? 1.055 * b2 ** (1 / 2.4) - 0.055 : b2 * 12.92;
+    r2 = Math.min(Math.max(0, r2), 1);
+    g2 = Math.min(Math.max(0, g2), 1);
+    b2 = Math.min(Math.max(0, b2), 1);
+    return [r2 * 255, g2 * 255, b2 * 255];
+  };
+  convert$1.xyz.lab = function(xyz) {
+    let x2 = xyz[0];
+    let y2 = xyz[1];
+    let z2 = xyz[2];
+    x2 /= 95.047;
+    y2 /= 100;
+    z2 /= 108.883;
+    x2 = x2 > 8856e-6 ? x2 ** (1 / 3) : 7.787 * x2 + 16 / 116;
+    y2 = y2 > 8856e-6 ? y2 ** (1 / 3) : 7.787 * y2 + 16 / 116;
+    z2 = z2 > 8856e-6 ? z2 ** (1 / 3) : 7.787 * z2 + 16 / 116;
+    const l2 = 116 * y2 - 16;
+    const a = 500 * (x2 - y2);
+    const b2 = 200 * (y2 - z2);
+    return [l2, a, b2];
+  };
+  convert$1.lab.xyz = function(lab) {
+    const l2 = lab[0];
+    const a = lab[1];
+    const b2 = lab[2];
+    let x2;
+    let y2;
+    let z2;
+    y2 = (l2 + 16) / 116;
+    x2 = a / 500 + y2;
+    z2 = y2 - b2 / 200;
+    const y22 = y2 ** 3;
+    const x22 = x2 ** 3;
+    const z22 = z2 ** 3;
+    y2 = y22 > 8856e-6 ? y22 : (y2 - 16 / 116) / 7.787;
+    x2 = x22 > 8856e-6 ? x22 : (x2 - 16 / 116) / 7.787;
+    z2 = z22 > 8856e-6 ? z22 : (z2 - 16 / 116) / 7.787;
+    x2 *= 95.047;
+    y2 *= 100;
+    z2 *= 108.883;
+    return [x2, y2, z2];
+  };
+  convert$1.lab.lch = function(lab) {
+    const l2 = lab[0];
+    const a = lab[1];
+    const b2 = lab[2];
+    let h2;
+    const hr = Math.atan2(b2, a);
+    h2 = hr * 360 / 2 / Math.PI;
+    if (h2 < 0) {
+      h2 += 360;
+    }
+    const c2 = Math.sqrt(a * a + b2 * b2);
+    return [l2, c2, h2];
+  };
+  convert$1.lch.lab = function(lch) {
+    const l2 = lch[0];
+    const c2 = lch[1];
+    const h2 = lch[2];
+    const hr = h2 / 360 * 2 * Math.PI;
+    const a = c2 * Math.cos(hr);
+    const b2 = c2 * Math.sin(hr);
+    return [l2, a, b2];
+  };
+  convert$1.rgb.ansi16 = function(args, saturation = null) {
+    const [r2, g2, b2] = args;
+    let value = saturation === null ? convert$1.rgb.hsv(args)[2] : saturation;
+    value = Math.round(value / 50);
+    if (value === 0) {
+      return 30;
+    }
+    let ansi = 30 + (Math.round(b2 / 255) << 2 | Math.round(g2 / 255) << 1 | Math.round(r2 / 255));
+    if (value === 2) {
+      ansi += 60;
+    }
+    return ansi;
+  };
+  convert$1.hsv.ansi16 = function(args) {
+    return convert$1.rgb.ansi16(convert$1.hsv.rgb(args), args[2]);
+  };
+  convert$1.rgb.ansi256 = function(args) {
+    const r2 = args[0];
+    const g2 = args[1];
+    const b2 = args[2];
+    if (r2 === g2 && g2 === b2) {
+      if (r2 < 8) {
+        return 16;
+      }
+      if (r2 > 248) {
+        return 231;
+      }
+      return Math.round((r2 - 8) / 247 * 24) + 232;
+    }
+    const ansi = 16 + 36 * Math.round(r2 / 255 * 5) + 6 * Math.round(g2 / 255 * 5) + Math.round(b2 / 255 * 5);
+    return ansi;
+  };
+  convert$1.ansi16.rgb = function(args) {
+    let color = args % 10;
+    if (color === 0 || color === 7) {
+      if (args > 50) {
+        color += 3.5;
+      }
+      color = color / 10.5 * 255;
+      return [color, color, color];
+    }
+    const mult = (~~(args > 50) + 1) * 0.5;
+    const r2 = (color & 1) * mult * 255;
+    const g2 = (color >> 1 & 1) * mult * 255;
+    const b2 = (color >> 2 & 1) * mult * 255;
+    return [r2, g2, b2];
+  };
+  convert$1.ansi256.rgb = function(args) {
+    if (args >= 232) {
+      const c2 = (args - 232) * 10 + 8;
+      return [c2, c2, c2];
+    }
+    args -= 16;
+    let rem;
+    const r2 = Math.floor(args / 36) / 5 * 255;
+    const g2 = Math.floor((rem = args % 36) / 6) / 5 * 255;
+    const b2 = rem % 6 / 5 * 255;
+    return [r2, g2, b2];
+  };
+  convert$1.rgb.hex = function(args) {
+    const integer = ((Math.round(args[0]) & 255) << 16) + ((Math.round(args[1]) & 255) << 8) + (Math.round(args[2]) & 255);
+    const string = integer.toString(16).toUpperCase();
+    return "000000".substring(string.length) + string;
+  };
+  convert$1.hex.rgb = function(args) {
+    const match2 = args.toString(16).match(/[a-f0-9]{6}|[a-f0-9]{3}/i);
+    if (!match2) {
+      return [0, 0, 0];
+    }
+    let colorString = match2[0];
+    if (match2[0].length === 3) {
+      colorString = colorString.split("").map((char) => {
+        return char + char;
+      }).join("");
+    }
+    const integer = parseInt(colorString, 16);
+    const r2 = integer >> 16 & 255;
+    const g2 = integer >> 8 & 255;
+    const b2 = integer & 255;
+    return [r2, g2, b2];
+  };
+  convert$1.rgb.hcg = function(rgb) {
+    const r2 = rgb[0] / 255;
+    const g2 = rgb[1] / 255;
+    const b2 = rgb[2] / 255;
+    const max2 = Math.max(Math.max(r2, g2), b2);
+    const min2 = Math.min(Math.min(r2, g2), b2);
+    const chroma = max2 - min2;
+    let grayscale;
+    let hue;
+    if (chroma < 1) {
+      grayscale = min2 / (1 - chroma);
+    } else {
+      grayscale = 0;
+    }
+    if (chroma <= 0) {
+      hue = 0;
+    } else if (max2 === r2) {
+      hue = (g2 - b2) / chroma % 6;
+    } else if (max2 === g2) {
+      hue = 2 + (b2 - r2) / chroma;
+    } else {
+      hue = 4 + (r2 - g2) / chroma;
+    }
+    hue /= 6;
+    hue %= 1;
+    return [hue * 360, chroma * 100, grayscale * 100];
+  };
+  convert$1.hsl.hcg = function(hsl) {
+    const s = hsl[1] / 100;
+    const l2 = hsl[2] / 100;
+    const c2 = l2 < 0.5 ? 2 * s * l2 : 2 * s * (1 - l2);
+    let f2 = 0;
+    if (c2 < 1) {
+      f2 = (l2 - 0.5 * c2) / (1 - c2);
+    }
+    return [hsl[0], c2 * 100, f2 * 100];
+  };
+  convert$1.hsv.hcg = function(hsv) {
+    const s = hsv[1] / 100;
+    const v2 = hsv[2] / 100;
+    const c2 = s * v2;
+    let f2 = 0;
+    if (c2 < 1) {
+      f2 = (v2 - c2) / (1 - c2);
+    }
+    return [hsv[0], c2 * 100, f2 * 100];
+  };
+  convert$1.hcg.rgb = function(hcg) {
+    const h2 = hcg[0] / 360;
+    const c2 = hcg[1] / 100;
+    const g2 = hcg[2] / 100;
+    if (c2 === 0) {
+      return [g2 * 255, g2 * 255, g2 * 255];
+    }
+    const pure = [0, 0, 0];
+    const hi2 = h2 % 1 * 6;
+    const v2 = hi2 % 1;
+    const w2 = 1 - v2;
+    let mg = 0;
+    switch (Math.floor(hi2)) {
+      case 0:
+        pure[0] = 1;
+        pure[1] = v2;
+        pure[2] = 0;
+        break;
+      case 1:
+        pure[0] = w2;
+        pure[1] = 1;
+        pure[2] = 0;
+        break;
+      case 2:
+        pure[0] = 0;
+        pure[1] = 1;
+        pure[2] = v2;
+        break;
+      case 3:
+        pure[0] = 0;
+        pure[1] = w2;
+        pure[2] = 1;
+        break;
+      case 4:
+        pure[0] = v2;
+        pure[1] = 0;
+        pure[2] = 1;
+        break;
+      default:
+        pure[0] = 1;
+        pure[1] = 0;
+        pure[2] = w2;
+    }
+    mg = (1 - c2) * g2;
+    return [
+      (c2 * pure[0] + mg) * 255,
+      (c2 * pure[1] + mg) * 255,
+      (c2 * pure[2] + mg) * 255
+    ];
+  };
+  convert$1.hcg.hsv = function(hcg) {
+    const c2 = hcg[1] / 100;
+    const g2 = hcg[2] / 100;
+    const v2 = c2 + g2 * (1 - c2);
+    let f2 = 0;
+    if (v2 > 0) {
+      f2 = c2 / v2;
+    }
+    return [hcg[0], f2 * 100, v2 * 100];
+  };
+  convert$1.hcg.hsl = function(hcg) {
+    const c2 = hcg[1] / 100;
+    const g2 = hcg[2] / 100;
+    const l2 = g2 * (1 - c2) + 0.5 * c2;
+    let s = 0;
+    if (l2 > 0 && l2 < 0.5) {
+      s = c2 / (2 * l2);
+    } else if (l2 >= 0.5 && l2 < 1) {
+      s = c2 / (2 * (1 - l2));
+    }
+    return [hcg[0], s * 100, l2 * 100];
+  };
+  convert$1.hcg.hwb = function(hcg) {
+    const c2 = hcg[1] / 100;
+    const g2 = hcg[2] / 100;
+    const v2 = c2 + g2 * (1 - c2);
+    return [hcg[0], (v2 - c2) * 100, (1 - v2) * 100];
+  };
+  convert$1.hwb.hcg = function(hwb) {
+    const w2 = hwb[1] / 100;
+    const b2 = hwb[2] / 100;
+    const v2 = 1 - b2;
+    const c2 = v2 - w2;
+    let g2 = 0;
+    if (c2 < 1) {
+      g2 = (v2 - c2) / (1 - c2);
+    }
+    return [hwb[0], c2 * 100, g2 * 100];
+  };
+  convert$1.apple.rgb = function(apple) {
+    return [apple[0] / 65535 * 255, apple[1] / 65535 * 255, apple[2] / 65535 * 255];
+  };
+  convert$1.rgb.apple = function(rgb) {
+    return [rgb[0] / 255 * 65535, rgb[1] / 255 * 65535, rgb[2] / 255 * 65535];
+  };
+  convert$1.gray.rgb = function(args) {
+    return [args[0] / 100 * 255, args[0] / 100 * 255, args[0] / 100 * 255];
+  };
+  convert$1.gray.hsl = function(args) {
+    return [0, 0, args[0]];
+  };
+  convert$1.gray.hsv = convert$1.gray.hsl;
+  convert$1.gray.hwb = function(gray) {
+    return [0, 100, gray[0]];
+  };
+  convert$1.gray.cmyk = function(gray) {
+    return [0, 0, 0, gray[0]];
+  };
+  convert$1.gray.lab = function(gray) {
+    return [gray[0], 0, 0];
+  };
+  convert$1.gray.hex = function(gray) {
+    const val = Math.round(gray[0] / 100 * 255) & 255;
+    const integer = (val << 16) + (val << 8) + val;
+    const string = integer.toString(16).toUpperCase();
+    return "000000".substring(string.length) + string;
+  };
+  convert$1.rgb.gray = function(rgb) {
+    const val = (rgb[0] + rgb[1] + rgb[2]) / 3;
+    return [val / 255 * 100];
+  };
+  function buildGraph() {
+    const graph = {};
+    const models2 = Object.keys(conversions);
+    for (let len = models2.length, i2 = 0; i2 < len; i2++) {
+      graph[models2[i2]] = {
+        // http://jsperf.com/1-vs-infinity
+        // micro-opt, but this is simple.
+        distance: -1,
+        parent: null
+      };
+    }
+    return graph;
+  }
+  function deriveBFS(fromModel) {
+    const graph = buildGraph();
+    const queue2 = [fromModel];
+    graph[fromModel].distance = 0;
+    while (queue2.length) {
+      const current = queue2.pop();
+      const adjacents = Object.keys(conversions[current]);
+      for (let len = adjacents.length, i2 = 0; i2 < len; i2++) {
+        const adjacent = adjacents[i2];
+        const node = graph[adjacent];
+        if (node.distance === -1) {
+          node.distance = graph[current].distance + 1;
+          node.parent = current;
+          queue2.unshift(adjacent);
+        }
+      }
+    }
+    return graph;
+  }
+  function link(from2, to) {
+    return function(args) {
+      return to(from2(args));
+    };
+  }
+  function wrapConversion(toModel, graph) {
+    const path2 = [graph[toModel].parent, toModel];
+    let fn2 = conversions[graph[toModel].parent][toModel];
+    let cur = graph[toModel].parent;
+    while (graph[cur].parent) {
+      path2.unshift(graph[cur].parent);
+      fn2 = link(conversions[graph[cur].parent][cur], fn2);
+      cur = graph[cur].parent;
+    }
+    fn2.conversion = path2;
+    return fn2;
+  }
+  var route = function(fromModel) {
+    const graph = deriveBFS(fromModel);
+    const conversion = {};
+    const models2 = Object.keys(graph);
+    for (let len = models2.length, i2 = 0; i2 < len; i2++) {
+      const toModel = models2[i2];
+      const node = graph[toModel];
+      if (node.parent === null) {
+        continue;
+      }
+      conversion[toModel] = wrapConversion(toModel, graph);
+    }
+    return conversion;
+  };
+  const convert = {};
+  const models = Object.keys(conversions);
+  function wrapRaw(fn2) {
+    const wrappedFn = function(...args) {
+      const arg0 = args[0];
+      if (arg0 === void 0 || arg0 === null) {
+        return arg0;
+      }
+      if (arg0.length > 1) {
+        args = arg0;
+      }
+      return fn2(args);
+    };
+    if ("conversion" in fn2) {
+      wrappedFn.conversion = fn2.conversion;
+    }
+    return wrappedFn;
+  }
+  function wrapRounded(fn2) {
+    const wrappedFn = function(...args) {
+      const arg0 = args[0];
+      if (arg0 === void 0 || arg0 === null) {
+        return arg0;
+      }
+      if (arg0.length > 1) {
+        args = arg0;
+      }
+      const result = fn2(args);
+      if (typeof result === "object") {
+        for (let len = result.length, i2 = 0; i2 < len; i2++) {
+          result[i2] = Math.round(result[i2]);
+        }
+      }
+      return result;
+    };
+    if ("conversion" in fn2) {
+      wrappedFn.conversion = fn2.conversion;
+    }
+    return wrappedFn;
+  }
+  models.forEach((fromModel) => {
+    convert[fromModel] = {};
+    Object.defineProperty(convert[fromModel], "channels", { value: conversions[fromModel].channels });
+    Object.defineProperty(convert[fromModel], "labels", { value: conversions[fromModel].labels });
+    const routes = route(fromModel);
+    const routeModels = Object.keys(routes);
+    routeModels.forEach((toModel) => {
+      const fn2 = routes[toModel];
+      convert[fromModel][toModel] = wrapRounded(fn2);
+      convert[fromModel][toModel].raw = wrapRaw(fn2);
+    });
+  });
+  var colorConvert = convert;
+  var ansiStyles$1 = createCommonjsModule(function(module2) {
+    const wrapAnsi16 = (fn2, offset) => (...args) => {
+      const code = fn2(...args);
+      return `\x1B[${code + offset}m`;
+    };
+    const wrapAnsi256 = (fn2, offset) => (...args) => {
+      const code = fn2(...args);
+      return `\x1B[${38 + offset};5;${code}m`;
+    };
+    const wrapAnsi16m = (fn2, offset) => (...args) => {
+      const rgb = fn2(...args);
+      return `\x1B[${38 + offset};2;${rgb[0]};${rgb[1]};${rgb[2]}m`;
+    };
+    const ansi2ansi = (n2) => n2;
+    const rgb2rgb = (r2, g2, b2) => [r2, g2, b2];
+    const setLazyProperty = (object, property, get2) => {
+      Object.defineProperty(object, property, {
+        get: () => {
+          const value = get2();
+          Object.defineProperty(object, property, {
+            value,
+            enumerable: true,
+            configurable: true
+          });
+          return value;
+        },
+        enumerable: true,
+        configurable: true
+      });
+    };
+    let colorConvert$1;
+    const makeDynamicStyles = (wrap2, targetSpace, identity, isBackground) => {
+      if (colorConvert$1 === void 0) {
+        colorConvert$1 = colorConvert;
+      }
+      const offset = isBackground ? 10 : 0;
+      const styles = {};
+      for (const [sourceSpace, suite] of Object.entries(colorConvert$1)) {
+        const name = sourceSpace === "ansi16" ? "ansi" : sourceSpace;
+        if (sourceSpace === targetSpace) {
+          styles[name] = wrap2(identity, offset);
+        } else if (typeof suite === "object") {
+          styles[name] = wrap2(suite[targetSpace], offset);
+        }
+      }
+      return styles;
+    };
+    function assembleStyles() {
+      const codes = /* @__PURE__ */ new Map();
+      const styles = {
+        modifier: {
+          reset: [0, 0],
+          // 21 isn't widely supported and 22 does the same thing
+          bold: [1, 22],
+          dim: [2, 22],
+          italic: [3, 23],
+          underline: [4, 24],
+          inverse: [7, 27],
+          hidden: [8, 28],
+          strikethrough: [9, 29]
+        },
+        color: {
+          black: [30, 39],
+          red: [31, 39],
+          green: [32, 39],
+          yellow: [33, 39],
+          blue: [34, 39],
+          magenta: [35, 39],
+          cyan: [36, 39],
+          white: [37, 39],
+          // Bright color
+          blackBright: [90, 39],
+          redBright: [91, 39],
+          greenBright: [92, 39],
+          yellowBright: [93, 39],
+          blueBright: [94, 39],
+          magentaBright: [95, 39],
+          cyanBright: [96, 39],
+          whiteBright: [97, 39]
+        },
+        bgColor: {
+          bgBlack: [40, 49],
+          bgRed: [41, 49],
+          bgGreen: [42, 49],
+          bgYellow: [43, 49],
+          bgBlue: [44, 49],
+          bgMagenta: [45, 49],
+          bgCyan: [46, 49],
+          bgWhite: [47, 49],
+          // Bright color
+          bgBlackBright: [100, 49],
+          bgRedBright: [101, 49],
+          bgGreenBright: [102, 49],
+          bgYellowBright: [103, 49],
+          bgBlueBright: [104, 49],
+          bgMagentaBright: [105, 49],
+          bgCyanBright: [106, 49],
+          bgWhiteBright: [107, 49]
+        }
+      };
+      styles.color.gray = styles.color.blackBright;
+      styles.bgColor.bgGray = styles.bgColor.bgBlackBright;
+      styles.color.grey = styles.color.blackBright;
+      styles.bgColor.bgGrey = styles.bgColor.bgBlackBright;
+      for (const [groupName, group] of Object.entries(styles)) {
+        for (const [styleName, style] of Object.entries(group)) {
+          styles[styleName] = {
+            open: `\x1B[${style[0]}m`,
+            close: `\x1B[${style[1]}m`
+          };
+          group[styleName] = styles[styleName];
+          codes.set(style[0], style[1]);
+        }
+        Object.defineProperty(styles, groupName, {
+          value: group,
+          enumerable: false
+        });
+      }
+      Object.defineProperty(styles, "codes", {
+        value: codes,
+        enumerable: false
+      });
+      styles.color.close = "\x1B[39m";
+      styles.bgColor.close = "\x1B[49m";
+      setLazyProperty(styles.color, "ansi", () => makeDynamicStyles(wrapAnsi16, "ansi16", ansi2ansi, false));
+      setLazyProperty(styles.color, "ansi256", () => makeDynamicStyles(wrapAnsi256, "ansi256", ansi2ansi, false));
+      setLazyProperty(styles.color, "ansi16m", () => makeDynamicStyles(wrapAnsi16m, "rgb", rgb2rgb, false));
+      setLazyProperty(styles.bgColor, "ansi", () => makeDynamicStyles(wrapAnsi16, "ansi16", ansi2ansi, true));
+      setLazyProperty(styles.bgColor, "ansi256", () => makeDynamicStyles(wrapAnsi256, "ansi256", ansi2ansi, true));
+      setLazyProperty(styles.bgColor, "ansi16m", () => makeDynamicStyles(wrapAnsi16m, "rgb", rgb2rgb, true));
+      return styles;
+    }
+    Object.defineProperty(module2, "exports", {
+      enumerable: true,
+      get: assembleStyles
+    });
+  });
+  var printIteratorEntries_1 = printIteratorEntries$1;
+  var printIteratorValues_1 = printIteratorValues$1;
+  var printListItems_1 = printListItems$1;
+  var printObjectProperties_1 = printObjectProperties$1;
+  const getKeysOfEnumerableProperties$1 = (object) => {
+    const keys2 = Object.keys(object).sort();
+    if (Object.getOwnPropertySymbols) {
+      Object.getOwnPropertySymbols(object).forEach((symbol2) => {
+        if (Object.getOwnPropertyDescriptor(object, symbol2).enumerable) {
+          keys2.push(symbol2);
+        }
+      });
+    }
+    return keys2;
+  };
+  function printIteratorEntries$1(iterator2, config2, indentation, depth, refs, printer2, separator = ": ") {
+    let result = "";
+    let current = iterator2.next();
+    if (!current.done) {
+      result += config2.spacingOuter;
+      const indentationNext = indentation + config2.indent;
+      while (!current.done) {
+        const name = printer2(
+          current.value[0],
+          config2,
+          indentationNext,
+          depth,
+          refs
+        );
+        const value = printer2(
+          current.value[1],
+          config2,
+          indentationNext,
+          depth,
+          refs
+        );
+        result += indentationNext + name + separator + value;
+        current = iterator2.next();
+        if (!current.done) {
+          result += "," + config2.spacingInner;
+        } else if (!config2.min) {
+          result += ",";
+        }
+      }
+      result += config2.spacingOuter + indentation;
+    }
+    return result;
+  }
+  function printIteratorValues$1(iterator2, config2, indentation, depth, refs, printer2) {
+    let result = "";
+    let current = iterator2.next();
+    if (!current.done) {
+      result += config2.spacingOuter;
+      const indentationNext = indentation + config2.indent;
+      while (!current.done) {
+        result += indentationNext + printer2(current.value, config2, indentationNext, depth, refs);
+        current = iterator2.next();
+        if (!current.done) {
+          result += "," + config2.spacingInner;
+        } else if (!config2.min) {
+          result += ",";
+        }
+      }
+      result += config2.spacingOuter + indentation;
+    }
+    return result;
+  }
+  function printListItems$1(list, config2, indentation, depth, refs, printer2) {
+    let result = "";
+    if (list.length) {
+      result += config2.spacingOuter;
+      const indentationNext = indentation + config2.indent;
+      for (let i2 = 0; i2 < list.length; i2++) {
+        result += indentationNext + printer2(list[i2], config2, indentationNext, depth, refs);
+        if (i2 < list.length - 1) {
+          result += "," + config2.spacingInner;
+        } else if (!config2.min) {
+          result += ",";
+        }
+      }
+      result += config2.spacingOuter + indentation;
+    }
+    return result;
+  }
+  function printObjectProperties$1(val, config2, indentation, depth, refs, printer2) {
+    let result = "";
+    const keys2 = getKeysOfEnumerableProperties$1(val);
+    if (keys2.length) {
+      result += config2.spacingOuter;
+      const indentationNext = indentation + config2.indent;
+      for (let i2 = 0; i2 < keys2.length; i2++) {
+        const key2 = keys2[i2];
+        const name = printer2(key2, config2, indentationNext, depth, refs);
+        const value = printer2(val[key2], config2, indentationNext, depth, refs);
+        result += indentationNext + name + ": " + value;
+        if (i2 < keys2.length - 1) {
+          result += "," + config2.spacingInner;
+        } else if (!config2.min) {
+          result += ",";
+        }
+      }
+      result += config2.spacingOuter + indentation;
+    }
+    return result;
+  }
+  var collections$1 = /* @__PURE__ */ Object.defineProperty({
+    printIteratorEntries: printIteratorEntries_1,
+    printIteratorValues: printIteratorValues_1,
+    printListItems: printListItems_1,
+    printObjectProperties: printObjectProperties_1
+  }, "__esModule", { value: true });
+  var AsymmetricMatcher$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = exports2.test = exports2.serialize = void 0;
+    var Symbol2 = global$1$1["jest-symbol-do-not-touch"] || global$1$1.Symbol;
+    const asymmetricMatcher2 = typeof Symbol2 === "function" && Symbol2.for ? Symbol2.for("jest.asymmetricMatcher") : 1267621;
+    const SPACE2 = " ";
+    const serialize2 = (val, config2, indentation, depth, refs, printer2) => {
+      const stringedValue = val.toString();
+      if (stringedValue === "ArrayContaining" || stringedValue === "ArrayNotContaining") {
+        if (++depth > config2.maxDepth) {
+          return "[" + stringedValue + "]";
+        }
+        return stringedValue + SPACE2 + "[" + (0, collections$1.printListItems)(
+          val.sample,
+          config2,
+          indentation,
+          depth,
+          refs,
+          printer2
+        ) + "]";
+      }
+      if (stringedValue === "ObjectContaining" || stringedValue === "ObjectNotContaining") {
+        if (++depth > config2.maxDepth) {
+          return "[" + stringedValue + "]";
+        }
+        return stringedValue + SPACE2 + "{" + (0, collections$1.printObjectProperties)(
+          val.sample,
+          config2,
+          indentation,
+          depth,
+          refs,
+          printer2
+        ) + "}";
+      }
+      if (stringedValue === "StringMatching" || stringedValue === "StringNotMatching") {
+        return stringedValue + SPACE2 + printer2(val.sample, config2, indentation, depth, refs);
+      }
+      if (stringedValue === "StringContaining" || stringedValue === "StringNotContaining") {
+        return stringedValue + SPACE2 + printer2(val.sample, config2, indentation, depth, refs);
+      }
+      return val.toAsymmetricMatcher();
+    };
+    exports2.serialize = serialize2;
+    const test2 = (val) => val && val.$$typeof === asymmetricMatcher2;
+    exports2.test = test2;
+    const plugin2 = {
+      serialize: serialize2,
+      test: test2
+    };
+    var _default2 = plugin2;
+    exports2.default = _default2;
+  });
+  var ansiRegex$1 = ({ onlyFirst = false } = {}) => {
+    const pattern = [
+      "[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)",
+      "(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))"
+    ].join("|");
+    return new RegExp(pattern, onlyFirst ? void 0 : "g");
+  };
+  var ConvertAnsi$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = exports2.serialize = exports2.test = void 0;
+    var _ansiRegex2 = _interopRequireDefault2(ansiRegex$1);
+    var _ansiStyles2 = _interopRequireDefault2(ansiStyles$1);
+    function _interopRequireDefault2(obj) {
+      return obj && obj.__esModule ? obj : { default: obj };
+    }
+    const toHumanReadableAnsi2 = (text) => text.replace((0, _ansiRegex2.default)(), (match2) => {
+      switch (match2) {
+        case _ansiStyles2.default.red.close:
+        case _ansiStyles2.default.green.close:
+        case _ansiStyles2.default.cyan.close:
+        case _ansiStyles2.default.gray.close:
+        case _ansiStyles2.default.white.close:
+        case _ansiStyles2.default.yellow.close:
+        case _ansiStyles2.default.bgRed.close:
+        case _ansiStyles2.default.bgGreen.close:
+        case _ansiStyles2.default.bgYellow.close:
+        case _ansiStyles2.default.inverse.close:
+        case _ansiStyles2.default.dim.close:
+        case _ansiStyles2.default.bold.close:
+        case _ansiStyles2.default.reset.open:
+        case _ansiStyles2.default.reset.close:
+          return "</>";
+        case _ansiStyles2.default.red.open:
+          return "<red>";
+        case _ansiStyles2.default.green.open:
+          return "<green>";
+        case _ansiStyles2.default.cyan.open:
+          return "<cyan>";
+        case _ansiStyles2.default.gray.open:
+          return "<gray>";
+        case _ansiStyles2.default.white.open:
+          return "<white>";
+        case _ansiStyles2.default.yellow.open:
+          return "<yellow>";
+        case _ansiStyles2.default.bgRed.open:
+          return "<bgRed>";
+        case _ansiStyles2.default.bgGreen.open:
+          return "<bgGreen>";
+        case _ansiStyles2.default.bgYellow.open:
+          return "<bgYellow>";
+        case _ansiStyles2.default.inverse.open:
+          return "<inverse>";
+        case _ansiStyles2.default.dim.open:
+          return "<dim>";
+        case _ansiStyles2.default.bold.open:
+          return "<bold>";
+        default:
+          return "";
+      }
+    });
+    const test2 = (val) => typeof val === "string" && !!val.match((0, _ansiRegex2.default)());
+    exports2.test = test2;
+    const serialize2 = (val, config2, indentation, depth, refs, printer2) => printer2(toHumanReadableAnsi2(val), config2, indentation, depth, refs);
+    exports2.serialize = serialize2;
+    const plugin2 = {
+      serialize: serialize2,
+      test: test2
+    };
+    var _default2 = plugin2;
+    exports2.default = _default2;
+  });
+  var DOMCollection$1$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = exports2.serialize = exports2.test = void 0;
+    const SPACE2 = " ";
+    const OBJECT_NAMES2 = ["DOMStringMap", "NamedNodeMap"];
+    const ARRAY_REGEXP2 = /^(HTML\w*Collection|NodeList)$/;
+    const testName2 = (name) => OBJECT_NAMES2.indexOf(name) !== -1 || ARRAY_REGEXP2.test(name);
+    const test2 = (val) => val && val.constructor && !!val.constructor.name && testName2(val.constructor.name);
+    exports2.test = test2;
+    const isNamedNodeMap2 = (collection2) => collection2.constructor.name === "NamedNodeMap";
+    const serialize2 = (collection2, config2, indentation, depth, refs, printer2) => {
+      const name = collection2.constructor.name;
+      if (++depth > config2.maxDepth) {
+        return "[" + name + "]";
+      }
+      return (config2.min ? "" : name + SPACE2) + (OBJECT_NAMES2.indexOf(name) !== -1 ? "{" + (0, collections$1.printObjectProperties)(
+        isNamedNodeMap2(collection2) ? Array.from(collection2).reduce((props, attribute) => {
+          props[attribute.name] = attribute.value;
+          return props;
+        }, {}) : { ...collection2 },
+        config2,
+        indentation,
+        depth,
+        refs,
+        printer2
+      ) + "}" : "[" + (0, collections$1.printListItems)(
+        Array.from(collection2),
+        config2,
+        indentation,
+        depth,
+        refs,
+        printer2
+      ) + "]");
+    };
+    exports2.serialize = serialize2;
+    const plugin2 = {
+      serialize: serialize2,
+      test: test2
+    };
+    var _default2 = plugin2;
+    exports2.default = _default2;
+  });
+  var _default$2q = escapeHTML$3;
+  function escapeHTML$3(str) {
+    return str.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+  var escapeHTML_1 = /* @__PURE__ */ Object.defineProperty({
+    default: _default$2q
+  }, "__esModule", { value: true });
+  var markup$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.printElementAsLeaf = exports2.printElement = exports2.printComment = exports2.printText = exports2.printChildren = exports2.printProps = void 0;
+    var _escapeHTML2 = _interopRequireDefault2(escapeHTML_1);
+    function _interopRequireDefault2(obj) {
+      return obj && obj.__esModule ? obj : { default: obj };
+    }
+    const printProps2 = (keys2, props, config2, indentation, depth, refs, printer2) => {
+      const indentationNext = indentation + config2.indent;
+      const colors = config2.colors;
+      return keys2.map((key2) => {
+        const value = props[key2];
+        let printed = printer2(value, config2, indentationNext, depth, refs);
+        if (typeof value !== "string") {
+          if (printed.indexOf("\n") !== -1) {
+            printed = config2.spacingOuter + indentationNext + printed + config2.spacingOuter + indentation;
+          }
+          printed = "{" + printed + "}";
+        }
+        return config2.spacingInner + indentation + colors.prop.open + key2 + colors.prop.close + "=" + colors.value.open + printed + colors.value.close;
+      }).join("");
+    };
+    exports2.printProps = printProps2;
+    const printChildren2 = (children, config2, indentation, depth, refs, printer2) => children.map(
+      (child) => config2.spacingOuter + indentation + (typeof child === "string" ? printText2(child, config2) : printer2(child, config2, indentation, depth, refs))
+    ).join("");
+    exports2.printChildren = printChildren2;
+    const printText2 = (text, config2) => {
+      const contentColor = config2.colors.content;
+      return contentColor.open + (0, _escapeHTML2.default)(text) + contentColor.close;
+    };
+    exports2.printText = printText2;
+    const printComment2 = (comment, config2) => {
+      const commentColor = config2.colors.comment;
+      return commentColor.open + "<!--" + (0, _escapeHTML2.default)(comment) + "-->" + commentColor.close;
+    };
+    exports2.printComment = printComment2;
+    const printElement2 = (type2, printedProps, printedChildren, config2, indentation) => {
+      const tagColor = config2.colors.tag;
+      return tagColor.open + "<" + type2 + (printedProps && tagColor.close + printedProps + config2.spacingOuter + indentation + tagColor.open) + (printedChildren ? ">" + tagColor.close + printedChildren + config2.spacingOuter + indentation + tagColor.open + "</" + type2 : (printedProps && !config2.min ? "" : " ") + "/") + ">" + tagColor.close;
+    };
+    exports2.printElement = printElement2;
+    const printElementAsLeaf2 = (type2, config2) => {
+      const tagColor = config2.colors.tag;
+      return tagColor.open + "<" + type2 + tagColor.close + " …" + tagColor.open + " />" + tagColor.close;
+    };
+    exports2.printElementAsLeaf = printElementAsLeaf2;
+  });
+  var DOMElement$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = exports2.serialize = exports2.test = void 0;
+    const ELEMENT_NODE2 = 1;
+    const TEXT_NODE2 = 3;
+    const COMMENT_NODE2 = 8;
+    const FRAGMENT_NODE2 = 11;
+    const ELEMENT_REGEXP2 = /^((HTML|SVG)\w*)?Element$/;
+    const testNode2 = (val) => {
+      var _val$hasAttribute;
+      const constructorName = val.constructor.name;
+      const { nodeType, tagName } = val;
+      const isCustomElement = typeof tagName === "string" && tagName.includes("-") || ((_val$hasAttribute = val.hasAttribute) === null || _val$hasAttribute === void 0 ? void 0 : _val$hasAttribute.call(val, "is"));
+      return nodeType === ELEMENT_NODE2 && (ELEMENT_REGEXP2.test(constructorName) || isCustomElement) || nodeType === TEXT_NODE2 && constructorName === "Text" || nodeType === COMMENT_NODE2 && constructorName === "Comment" || nodeType === FRAGMENT_NODE2 && constructorName === "DocumentFragment";
+    };
+    const test2 = (val) => {
+      var _val$constructor;
+      return (val === null || val === void 0 ? void 0 : (_val$constructor = val.constructor) === null || _val$constructor === void 0 ? void 0 : _val$constructor.name) && testNode2(val);
+    };
+    exports2.test = test2;
+    function nodeIsText2(node) {
+      return node.nodeType === TEXT_NODE2;
+    }
+    function nodeIsComment2(node) {
+      return node.nodeType === COMMENT_NODE2;
+    }
+    function nodeIsFragment2(node) {
+      return node.nodeType === FRAGMENT_NODE2;
+    }
+    const serialize2 = (node, config2, indentation, depth, refs, printer2) => {
+      if (nodeIsText2(node)) {
+        return (0, markup$1.printText)(node.data, config2);
+      }
+      if (nodeIsComment2(node)) {
+        return (0, markup$1.printComment)(node.data, config2);
+      }
+      const type2 = nodeIsFragment2(node) ? `DocumentFragment` : node.tagName.toLowerCase();
+      if (++depth > config2.maxDepth) {
+        return (0, markup$1.printElementAsLeaf)(type2, config2);
+      }
+      return (0, markup$1.printElement)(
+        type2,
+        (0, markup$1.printProps)(
+          nodeIsFragment2(node) ? [] : Array.from(node.attributes).map((attr) => attr.name).sort(),
+          nodeIsFragment2(node) ? {} : Array.from(node.attributes).reduce((props, attribute) => {
+            props[attribute.name] = attribute.value;
+            return props;
+          }, {}),
+          config2,
+          indentation + config2.indent,
+          depth,
+          refs,
+          printer2
+        ),
+        (0, markup$1.printChildren)(
+          Array.prototype.slice.call(node.childNodes || node.children),
+          config2,
+          indentation + config2.indent,
+          depth,
+          refs,
+          printer2
+        ),
+        config2,
+        indentation
+      );
+    };
+    exports2.serialize = serialize2;
+    const plugin2 = {
+      serialize: serialize2,
+      test: test2
+    };
+    var _default2 = plugin2;
+    exports2.default = _default2;
+  });
+  var Immutable$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = exports2.test = exports2.serialize = void 0;
+    const IS_ITERABLE_SENTINEL2 = "@@__IMMUTABLE_ITERABLE__@@";
+    const IS_LIST_SENTINEL2 = "@@__IMMUTABLE_LIST__@@";
+    const IS_KEYED_SENTINEL2 = "@@__IMMUTABLE_KEYED__@@";
+    const IS_MAP_SENTINEL2 = "@@__IMMUTABLE_MAP__@@";
+    const IS_ORDERED_SENTINEL2 = "@@__IMMUTABLE_ORDERED__@@";
+    const IS_RECORD_SENTINEL2 = "@@__IMMUTABLE_RECORD__@@";
+    const IS_SEQ_SENTINEL2 = "@@__IMMUTABLE_SEQ__@@";
+    const IS_SET_SENTINEL2 = "@@__IMMUTABLE_SET__@@";
+    const IS_STACK_SENTINEL2 = "@@__IMMUTABLE_STACK__@@";
+    const getImmutableName2 = (name) => "Immutable." + name;
+    const printAsLeaf2 = (name) => "[" + name + "]";
+    const SPACE2 = " ";
+    const LAZY2 = "…";
+    const printImmutableEntries2 = (val, config2, indentation, depth, refs, printer2, type2) => ++depth > config2.maxDepth ? printAsLeaf2(getImmutableName2(type2)) : getImmutableName2(type2) + SPACE2 + "{" + (0, collections$1.printIteratorEntries)(
+      val.entries(),
+      config2,
+      indentation,
+      depth,
+      refs,
+      printer2
+    ) + "}";
+    function getRecordEntries2(val) {
+      let i2 = 0;
+      return {
+        next() {
+          if (i2 < val._keys.length) {
+            const key2 = val._keys[i2++];
+            return {
+              done: false,
+              value: [key2, val.get(key2)]
+            };
+          }
+          return {
+            done: true,
+            value: void 0
+          };
+        }
+      };
+    }
+    const printImmutableRecord2 = (val, config2, indentation, depth, refs, printer2) => {
+      const name = getImmutableName2(val._name || "Record");
+      return ++depth > config2.maxDepth ? printAsLeaf2(name) : name + SPACE2 + "{" + (0, collections$1.printIteratorEntries)(
+        getRecordEntries2(val),
+        config2,
+        indentation,
+        depth,
+        refs,
+        printer2
+      ) + "}";
+    };
+    const printImmutableSeq2 = (val, config2, indentation, depth, refs, printer2) => {
+      const name = getImmutableName2("Seq");
+      if (++depth > config2.maxDepth) {
+        return printAsLeaf2(name);
+      }
+      if (val[IS_KEYED_SENTINEL2]) {
+        return name + SPACE2 + "{" + // from Immutable collection of entries or from ECMAScript object
+        (val._iter || val._object ? (0, collections$1.printIteratorEntries)(
+          val.entries(),
+          config2,
+          indentation,
+          depth,
+          refs,
+          printer2
+        ) : LAZY2) + "}";
+      }
+      return name + SPACE2 + "[" + (val._iter || // from Immutable collection of values
+      val._array || // from ECMAScript array
+      val._collection || // from ECMAScript collection in immutable v4
+      val._iterable ? (0, collections$1.printIteratorValues)(
+        val.values(),
+        config2,
+        indentation,
+        depth,
+        refs,
+        printer2
+      ) : LAZY2) + "]";
+    };
+    const printImmutableValues2 = (val, config2, indentation, depth, refs, printer2, type2) => ++depth > config2.maxDepth ? printAsLeaf2(getImmutableName2(type2)) : getImmutableName2(type2) + SPACE2 + "[" + (0, collections$1.printIteratorValues)(
+      val.values(),
+      config2,
+      indentation,
+      depth,
+      refs,
+      printer2
+    ) + "]";
+    const serialize2 = (val, config2, indentation, depth, refs, printer2) => {
+      if (val[IS_MAP_SENTINEL2]) {
+        return printImmutableEntries2(
+          val,
+          config2,
+          indentation,
+          depth,
+          refs,
+          printer2,
+          val[IS_ORDERED_SENTINEL2] ? "OrderedMap" : "Map"
+        );
+      }
+      if (val[IS_LIST_SENTINEL2]) {
+        return printImmutableValues2(
+          val,
+          config2,
+          indentation,
+          depth,
+          refs,
+          printer2,
+          "List"
+        );
+      }
+      if (val[IS_SET_SENTINEL2]) {
+        return printImmutableValues2(
+          val,
+          config2,
+          indentation,
+          depth,
+          refs,
+          printer2,
+          val[IS_ORDERED_SENTINEL2] ? "OrderedSet" : "Set"
+        );
+      }
+      if (val[IS_STACK_SENTINEL2]) {
+        return printImmutableValues2(
+          val,
+          config2,
+          indentation,
+          depth,
+          refs,
+          printer2,
+          "Stack"
+        );
+      }
+      if (val[IS_SEQ_SENTINEL2]) {
+        return printImmutableSeq2(val, config2, indentation, depth, refs, printer2);
+      }
+      return printImmutableRecord2(val, config2, indentation, depth, refs, printer2);
+    };
+    exports2.serialize = serialize2;
+    const test2 = (val) => val && (val[IS_ITERABLE_SENTINEL2] === true || val[IS_RECORD_SENTINEL2] === true);
+    exports2.test = test2;
+    const plugin2 = {
+      serialize: serialize2,
+      test: test2
+    };
+    var _default2 = plugin2;
+    exports2.default = _default2;
+  });
+  /** @license React v17.0.2
+   * react-is.production.min.js
+   *
+   * Copyright (c) Facebook, Inc. and its affiliates.
+   *
+   * This source code is licensed under the MIT license found in the
+   * LICENSE file in the root directory of this source tree.
+   */
+  var b$1 = 60103, c$1 = 60106, d$1 = 60107, e$1 = 60108, f$8 = 60114, g$3 = 60109, h$1 = 60110, k$3 = 60112, l$2 = 60113, m$3 = 60120, n$2 = 60115, p$2 = 60116, q$2 = 60121, r$2 = 60122, u$2 = 60117, v$2 = 60129, w$2 = 60131;
+  if ("function" === typeof Symbol && Symbol.for) {
+    var x$2 = Symbol.for;
+    b$1 = x$2("react.element");
+    c$1 = x$2("react.portal");
+    d$1 = x$2("react.fragment");
+    e$1 = x$2("react.strict_mode");
+    f$8 = x$2("react.profiler");
+    g$3 = x$2("react.provider");
+    h$1 = x$2("react.context");
+    k$3 = x$2("react.forward_ref");
+    l$2 = x$2("react.suspense");
+    m$3 = x$2("react.suspense_list");
+    n$2 = x$2("react.memo");
+    p$2 = x$2("react.lazy");
+    q$2 = x$2("react.block");
+    r$2 = x$2("react.server.block");
+    u$2 = x$2("react.fundamental");
+    v$2 = x$2("react.debug_trace_mode");
+    w$2 = x$2("react.legacy_hidden");
+  }
+  function y$2(a) {
+    if ("object" === typeof a && null !== a) {
+      var t2 = a.$$typeof;
+      switch (t2) {
+        case b$1:
+          switch (a = a.type, a) {
+            case d$1:
+            case f$8:
+            case e$1:
+            case l$2:
+            case m$3:
+              return a;
+            default:
+              switch (a = a && a.$$typeof, a) {
+                case h$1:
+                case k$3:
+                case p$2:
+                case n$2:
+                case g$3:
+                  return a;
+                default:
+                  return t2;
+              }
+          }
+        case c$1:
+          return t2;
+      }
+    }
+  }
+  var z$2 = g$3, A$2 = b$1, B$2 = k$3, C$2 = d$1, D$2 = p$2, E$2 = n$2, F$2 = c$1, G$1 = f$8, H$2 = e$1, I$2 = l$2;
+  var ContextConsumer = h$1;
+  var ContextProvider = z$2;
+  var Element = A$2;
+  var ForwardRef = B$2;
+  var Fragment = C$2;
+  var Lazy = D$2;
+  var Memo = E$2;
+  var Portal = F$2;
+  var Profiler = G$1;
+  var StrictMode = H$2;
+  var Suspense = I$2;
+  var isAsyncMode = function() {
+    return false;
+  };
+  var isConcurrentMode = function() {
+    return false;
+  };
+  var isContextConsumer = function(a) {
+    return y$2(a) === h$1;
+  };
+  var isContextProvider = function(a) {
+    return y$2(a) === g$3;
+  };
+  var isElement$1$1 = function(a) {
+    return "object" === typeof a && null !== a && a.$$typeof === b$1;
+  };
+  var isForwardRef = function(a) {
+    return y$2(a) === k$3;
+  };
+  var isFragment = function(a) {
+    return y$2(a) === d$1;
+  };
+  var isLazy = function(a) {
+    return y$2(a) === p$2;
+  };
+  var isMemo = function(a) {
+    return y$2(a) === n$2;
+  };
+  var isPortal = function(a) {
+    return y$2(a) === c$1;
+  };
+  var isProfiler = function(a) {
+    return y$2(a) === f$8;
+  };
+  var isStrictMode = function(a) {
+    return y$2(a) === e$1;
+  };
+  var isSuspense = function(a) {
+    return y$2(a) === l$2;
+  };
+  var isValidElementType = function(a) {
+    return "string" === typeof a || "function" === typeof a || a === d$1 || a === f$8 || a === v$2 || a === e$1 || a === l$2 || a === m$3 || a === w$2 || "object" === typeof a && null !== a && (a.$$typeof === p$2 || a.$$typeof === n$2 || a.$$typeof === g$3 || a.$$typeof === h$1 || a.$$typeof === k$3 || a.$$typeof === u$2 || a.$$typeof === q$2 || a[0] === r$2) ? true : false;
+  };
+  var typeOf = y$2;
+  var reactIs_production_min$1 = {
+    ContextConsumer,
+    ContextProvider,
+    Element,
+    ForwardRef,
+    Fragment,
+    Lazy,
+    Memo,
+    Portal,
+    Profiler,
+    StrictMode,
+    Suspense,
+    isAsyncMode,
+    isConcurrentMode,
+    isContextConsumer,
+    isContextProvider,
+    isElement: isElement$1$1,
+    isForwardRef,
+    isFragment,
+    isLazy,
+    isMemo,
+    isPortal,
+    isProfiler,
+    isStrictMode,
+    isSuspense,
+    isValidElementType,
+    typeOf
+  };
+  var reactIs_development = createCommonjsModule(function(module2, exports2) {
+    if (process$1.env.NODE_ENV !== "production") {
+      (function() {
+        var REACT_ELEMENT_TYPE = 60103;
+        var REACT_PORTAL_TYPE = 60106;
+        var REACT_FRAGMENT_TYPE = 60107;
+        var REACT_STRICT_MODE_TYPE = 60108;
+        var REACT_PROFILER_TYPE = 60114;
+        var REACT_PROVIDER_TYPE = 60109;
+        var REACT_CONTEXT_TYPE = 60110;
+        var REACT_FORWARD_REF_TYPE = 60112;
+        var REACT_SUSPENSE_TYPE = 60113;
+        var REACT_SUSPENSE_LIST_TYPE = 60120;
+        var REACT_MEMO_TYPE = 60115;
+        var REACT_LAZY_TYPE = 60116;
+        var REACT_BLOCK_TYPE = 60121;
+        var REACT_SERVER_BLOCK_TYPE = 60122;
+        var REACT_FUNDAMENTAL_TYPE = 60117;
+        var REACT_DEBUG_TRACING_MODE_TYPE = 60129;
+        var REACT_LEGACY_HIDDEN_TYPE = 60131;
+        if (typeof Symbol === "function" && Symbol.for) {
+          var symbolFor = Symbol.for;
+          REACT_ELEMENT_TYPE = symbolFor("react.element");
+          REACT_PORTAL_TYPE = symbolFor("react.portal");
+          REACT_FRAGMENT_TYPE = symbolFor("react.fragment");
+          REACT_STRICT_MODE_TYPE = symbolFor("react.strict_mode");
+          REACT_PROFILER_TYPE = symbolFor("react.profiler");
+          REACT_PROVIDER_TYPE = symbolFor("react.provider");
+          REACT_CONTEXT_TYPE = symbolFor("react.context");
+          REACT_FORWARD_REF_TYPE = symbolFor("react.forward_ref");
+          REACT_SUSPENSE_TYPE = symbolFor("react.suspense");
+          REACT_SUSPENSE_LIST_TYPE = symbolFor("react.suspense_list");
+          REACT_MEMO_TYPE = symbolFor("react.memo");
+          REACT_LAZY_TYPE = symbolFor("react.lazy");
+          REACT_BLOCK_TYPE = symbolFor("react.block");
+          REACT_SERVER_BLOCK_TYPE = symbolFor("react.server.block");
+          REACT_FUNDAMENTAL_TYPE = symbolFor("react.fundamental");
+          symbolFor("react.scope");
+          symbolFor("react.opaque.id");
+          REACT_DEBUG_TRACING_MODE_TYPE = symbolFor("react.debug_trace_mode");
+          symbolFor("react.offscreen");
+          REACT_LEGACY_HIDDEN_TYPE = symbolFor("react.legacy_hidden");
+        }
+        var enableScopeAPI = false;
+        function isValidElementType2(type2) {
+          if (typeof type2 === "string" || typeof type2 === "function") {
+            return true;
+          }
+          if (type2 === REACT_FRAGMENT_TYPE || type2 === REACT_PROFILER_TYPE || type2 === REACT_DEBUG_TRACING_MODE_TYPE || type2 === REACT_STRICT_MODE_TYPE || type2 === REACT_SUSPENSE_TYPE || type2 === REACT_SUSPENSE_LIST_TYPE || type2 === REACT_LEGACY_HIDDEN_TYPE || enableScopeAPI) {
+            return true;
+          }
+          if (typeof type2 === "object" && type2 !== null) {
+            if (type2.$$typeof === REACT_LAZY_TYPE || type2.$$typeof === REACT_MEMO_TYPE || type2.$$typeof === REACT_PROVIDER_TYPE || type2.$$typeof === REACT_CONTEXT_TYPE || type2.$$typeof === REACT_FORWARD_REF_TYPE || type2.$$typeof === REACT_FUNDAMENTAL_TYPE || type2.$$typeof === REACT_BLOCK_TYPE || type2[0] === REACT_SERVER_BLOCK_TYPE) {
+              return true;
+            }
+          }
+          return false;
+        }
+        function typeOf2(object) {
+          if (typeof object === "object" && object !== null) {
+            var $$typeof = object.$$typeof;
+            switch ($$typeof) {
+              case REACT_ELEMENT_TYPE:
+                var type2 = object.type;
+                switch (type2) {
+                  case REACT_FRAGMENT_TYPE:
+                  case REACT_PROFILER_TYPE:
+                  case REACT_STRICT_MODE_TYPE:
+                  case REACT_SUSPENSE_TYPE:
+                  case REACT_SUSPENSE_LIST_TYPE:
+                    return type2;
+                  default:
+                    var $$typeofType = type2 && type2.$$typeof;
+                    switch ($$typeofType) {
+                      case REACT_CONTEXT_TYPE:
+                      case REACT_FORWARD_REF_TYPE:
+                      case REACT_LAZY_TYPE:
+                      case REACT_MEMO_TYPE:
+                      case REACT_PROVIDER_TYPE:
+                        return $$typeofType;
+                      default:
+                        return $$typeof;
+                    }
+                }
+              case REACT_PORTAL_TYPE:
+                return $$typeof;
+            }
+          }
+          return void 0;
+        }
+        var ContextConsumer2 = REACT_CONTEXT_TYPE;
+        var ContextProvider2 = REACT_PROVIDER_TYPE;
+        var Element2 = REACT_ELEMENT_TYPE;
+        var ForwardRef2 = REACT_FORWARD_REF_TYPE;
+        var Fragment2 = REACT_FRAGMENT_TYPE;
+        var Lazy2 = REACT_LAZY_TYPE;
+        var Memo2 = REACT_MEMO_TYPE;
+        var Portal2 = REACT_PORTAL_TYPE;
+        var Profiler2 = REACT_PROFILER_TYPE;
+        var StrictMode2 = REACT_STRICT_MODE_TYPE;
+        var Suspense2 = REACT_SUSPENSE_TYPE;
+        var hasWarnedAboutDeprecatedIsAsyncMode = false;
+        var hasWarnedAboutDeprecatedIsConcurrentMode = false;
+        function isAsyncMode2(object) {
+          {
+            if (!hasWarnedAboutDeprecatedIsAsyncMode) {
+              hasWarnedAboutDeprecatedIsAsyncMode = true;
+              console["warn"]("The ReactIs.isAsyncMode() alias has been deprecated, and will be removed in React 18+.");
+            }
+          }
+          return false;
+        }
+        function isConcurrentMode2(object) {
+          {
+            if (!hasWarnedAboutDeprecatedIsConcurrentMode) {
+              hasWarnedAboutDeprecatedIsConcurrentMode = true;
+              console["warn"]("The ReactIs.isConcurrentMode() alias has been deprecated, and will be removed in React 18+.");
+            }
+          }
+          return false;
+        }
+        function isContextConsumer2(object) {
+          return typeOf2(object) === REACT_CONTEXT_TYPE;
+        }
+        function isContextProvider2(object) {
+          return typeOf2(object) === REACT_PROVIDER_TYPE;
+        }
+        function isElement2(object) {
+          return typeof object === "object" && object !== null && object.$$typeof === REACT_ELEMENT_TYPE;
+        }
+        function isForwardRef2(object) {
+          return typeOf2(object) === REACT_FORWARD_REF_TYPE;
+        }
+        function isFragment2(object) {
+          return typeOf2(object) === REACT_FRAGMENT_TYPE;
+        }
+        function isLazy2(object) {
+          return typeOf2(object) === REACT_LAZY_TYPE;
+        }
+        function isMemo2(object) {
+          return typeOf2(object) === REACT_MEMO_TYPE;
+        }
+        function isPortal2(object) {
+          return typeOf2(object) === REACT_PORTAL_TYPE;
+        }
+        function isProfiler2(object) {
+          return typeOf2(object) === REACT_PROFILER_TYPE;
+        }
+        function isStrictMode2(object) {
+          return typeOf2(object) === REACT_STRICT_MODE_TYPE;
+        }
+        function isSuspense2(object) {
+          return typeOf2(object) === REACT_SUSPENSE_TYPE;
+        }
+        exports2.ContextConsumer = ContextConsumer2;
+        exports2.ContextProvider = ContextProvider2;
+        exports2.Element = Element2;
+        exports2.ForwardRef = ForwardRef2;
+        exports2.Fragment = Fragment2;
+        exports2.Lazy = Lazy2;
+        exports2.Memo = Memo2;
+        exports2.Portal = Portal2;
+        exports2.Profiler = Profiler2;
+        exports2.StrictMode = StrictMode2;
+        exports2.Suspense = Suspense2;
+        exports2.isAsyncMode = isAsyncMode2;
+        exports2.isConcurrentMode = isConcurrentMode2;
+        exports2.isContextConsumer = isContextConsumer2;
+        exports2.isContextProvider = isContextProvider2;
+        exports2.isElement = isElement2;
+        exports2.isForwardRef = isForwardRef2;
+        exports2.isFragment = isFragment2;
+        exports2.isLazy = isLazy2;
+        exports2.isMemo = isMemo2;
+        exports2.isPortal = isPortal2;
+        exports2.isProfiler = isProfiler2;
+        exports2.isStrictMode = isStrictMode2;
+        exports2.isSuspense = isSuspense2;
+        exports2.isValidElementType = isValidElementType2;
+        exports2.typeOf = typeOf2;
+      })();
+    }
+  });
+  var reactIs$1 = createCommonjsModule(function(module2) {
+    if (process$1.env.NODE_ENV === "production") {
+      module2.exports = reactIs_production_min$1;
+    } else {
+      module2.exports = reactIs_development;
+    }
+  });
+  var ReactElement$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = exports2.test = exports2.serialize = void 0;
+    var ReactIs2 = _interopRequireWildcard2(reactIs$1);
+    function _getRequireWildcardCache2() {
+      if (typeof WeakMap !== "function") return null;
+      var cache2 = /* @__PURE__ */ new WeakMap();
+      _getRequireWildcardCache2 = function() {
+        return cache2;
+      };
+      return cache2;
+    }
+    function _interopRequireWildcard2(obj) {
+      if (obj && obj.__esModule) {
+        return obj;
+      }
+      if (obj === null || typeof obj !== "object" && typeof obj !== "function") {
+        return { default: obj };
+      }
+      var cache2 = _getRequireWildcardCache2();
+      if (cache2 && cache2.has(obj)) {
+        return cache2.get(obj);
+      }
+      var newObj = {};
+      var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor;
+      for (var key2 in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key2)) {
+          var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key2) : null;
+          if (desc && (desc.get || desc.set)) {
+            Object.defineProperty(newObj, key2, desc);
+          } else {
+            newObj[key2] = obj[key2];
+          }
+        }
+      }
+      newObj.default = obj;
+      if (cache2) {
+        cache2.set(obj, newObj);
+      }
+      return newObj;
+    }
+    const getChildren2 = (arg, children = []) => {
+      if (Array.isArray(arg)) {
+        arg.forEach((item) => {
+          getChildren2(item, children);
+        });
+      } else if (arg != null && arg !== false) {
+        children.push(arg);
+      }
+      return children;
+    };
+    const getType2 = (element) => {
+      const type2 = element.type;
+      if (typeof type2 === "string") {
+        return type2;
+      }
+      if (typeof type2 === "function") {
+        return type2.displayName || type2.name || "Unknown";
+      }
+      if (ReactIs2.isFragment(element)) {
+        return "React.Fragment";
+      }
+      if (ReactIs2.isSuspense(element)) {
+        return "React.Suspense";
+      }
+      if (typeof type2 === "object" && type2 !== null) {
+        if (ReactIs2.isContextProvider(element)) {
+          return "Context.Provider";
+        }
+        if (ReactIs2.isContextConsumer(element)) {
+          return "Context.Consumer";
+        }
+        if (ReactIs2.isForwardRef(element)) {
+          if (type2.displayName) {
+            return type2.displayName;
+          }
+          const functionName2 = type2.render.displayName || type2.render.name || "";
+          return functionName2 !== "" ? "ForwardRef(" + functionName2 + ")" : "ForwardRef";
+        }
+        if (ReactIs2.isMemo(element)) {
+          const functionName2 = type2.displayName || type2.type.displayName || type2.type.name || "";
+          return functionName2 !== "" ? "Memo(" + functionName2 + ")" : "Memo";
+        }
+      }
+      return "UNDEFINED";
+    };
+    const getPropKeys2 = (element) => {
+      const { props } = element;
+      return Object.keys(props).filter((key2) => key2 !== "children" && props[key2] !== void 0).sort();
+    };
+    const serialize2 = (element, config2, indentation, depth, refs, printer2) => ++depth > config2.maxDepth ? (0, markup$1.printElementAsLeaf)(getType2(element), config2) : (0, markup$1.printElement)(
+      getType2(element),
+      (0, markup$1.printProps)(
+        getPropKeys2(element),
+        element.props,
+        config2,
+        indentation + config2.indent,
+        depth,
+        refs,
+        printer2
+      ),
+      (0, markup$1.printChildren)(
+        getChildren2(element.props.children),
+        config2,
+        indentation + config2.indent,
+        depth,
+        refs,
+        printer2
+      ),
+      config2,
+      indentation
+    );
+    exports2.serialize = serialize2;
+    const test2 = (val) => val && ReactIs2.isElement(val);
+    exports2.test = test2;
+    const plugin2 = {
+      serialize: serialize2,
+      test: test2
+    };
+    var _default2 = plugin2;
+    exports2.default = _default2;
+  });
+  var ReactTestComponent$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = exports2.test = exports2.serialize = void 0;
+    var Symbol2 = global$1$1["jest-symbol-do-not-touch"] || global$1$1.Symbol;
+    const testSymbol2 = typeof Symbol2 === "function" && Symbol2.for ? Symbol2.for("react.test.json") : 245830487;
+    const getPropKeys2 = (object) => {
+      const { props } = object;
+      return props ? Object.keys(props).filter((key2) => props[key2] !== void 0).sort() : [];
+    };
+    const serialize2 = (object, config2, indentation, depth, refs, printer2) => ++depth > config2.maxDepth ? (0, markup$1.printElementAsLeaf)(object.type, config2) : (0, markup$1.printElement)(
+      object.type,
+      object.props ? (0, markup$1.printProps)(
+        getPropKeys2(object),
+        object.props,
+        config2,
+        indentation + config2.indent,
+        depth,
+        refs,
+        printer2
+      ) : "",
+      object.children ? (0, markup$1.printChildren)(
+        object.children,
+        config2,
+        indentation + config2.indent,
+        depth,
+        refs,
+        printer2
+      ) : "",
+      config2,
+      indentation
+    );
+    exports2.serialize = serialize2;
+    const test2 = (val) => val && val.$$typeof === testSymbol2;
+    exports2.test = test2;
+    const plugin2 = {
+      serialize: serialize2,
+      test: test2
+    };
+    var _default2 = plugin2;
+    exports2.default = _default2;
+  });
+  var _ansiStyles$2 = _interopRequireDefault$e(ansiStyles$1);
+  var _AsymmetricMatcher$1 = _interopRequireDefault$e(
+    AsymmetricMatcher$1
+  );
+  var _ConvertAnsi$1 = _interopRequireDefault$e(ConvertAnsi$1);
+  var _DOMCollection$1 = _interopRequireDefault$e(DOMCollection$1$1);
+  var _DOMElement$1 = _interopRequireDefault$e(DOMElement$1);
+  var _Immutable$1 = _interopRequireDefault$e(Immutable$1);
+  var _ReactElement$1 = _interopRequireDefault$e(ReactElement$1);
+  var _ReactTestComponent$1 = _interopRequireDefault$e(
+    ReactTestComponent$1
+  );
+  function _interopRequireDefault$e(obj) {
+    return obj && obj.__esModule ? obj : { default: obj };
+  }
+  const toString$5 = Object.prototype.toString;
+  const toISOString$1 = Date.prototype.toISOString;
+  const errorToString$1 = Error.prototype.toString;
+  const regExpToString$1 = RegExp.prototype.toString;
+  const getConstructorName$1 = (val) => typeof val.constructor === "function" && val.constructor.name || "Object";
+  const isWindow$1 = (val) => typeof window !== "undefined" && val === window;
+  const SYMBOL_REGEXP$1 = /^Symbol\((.*)\)(.*)$/;
+  const NEWLINE_REGEXP$1 = /\n/gi;
+  let PrettyFormatPluginError$1 = class PrettyFormatPluginError extends Error {
+    constructor(message, stack) {
+      super(message);
+      this.stack = stack;
+      this.name = this.constructor.name;
+    }
+  };
+  function isToStringedArrayType$1(toStringed) {
+    return toStringed === "[object Array]" || toStringed === "[object ArrayBuffer]" || toStringed === "[object DataView]" || toStringed === "[object Float32Array]" || toStringed === "[object Float64Array]" || toStringed === "[object Int8Array]" || toStringed === "[object Int16Array]" || toStringed === "[object Int32Array]" || toStringed === "[object Uint8Array]" || toStringed === "[object Uint8ClampedArray]" || toStringed === "[object Uint16Array]" || toStringed === "[object Uint32Array]";
+  }
+  function printNumber$1(val) {
+    return Object.is(val, -0) ? "-0" : String(val);
+  }
+  function printBigInt$1(val) {
+    return String(`${val}n`);
+  }
+  function printFunction$1(val, printFunctionName) {
+    if (!printFunctionName) {
+      return "[Function]";
+    }
+    return "[Function " + (val.name || "anonymous") + "]";
+  }
+  function printSymbol$1(val) {
+    return String(val).replace(SYMBOL_REGEXP$1, "Symbol($1)");
+  }
+  function printError$1(val) {
+    return "[" + errorToString$1.call(val) + "]";
+  }
+  function printBasicValue$1(val, printFunctionName, escapeRegex, escapeString) {
+    if (val === true || val === false) {
+      return "" + val;
+    }
+    if (val === void 0) {
+      return "undefined";
+    }
+    if (val === null) {
+      return "null";
+    }
+    const typeOf2 = typeof val;
+    if (typeOf2 === "number") {
+      return printNumber$1(val);
+    }
+    if (typeOf2 === "bigint") {
+      return printBigInt$1(val);
+    }
+    if (typeOf2 === "string") {
+      if (escapeString) {
+        return '"' + val.replace(/"|\\/g, "\\$&") + '"';
+      }
+      return '"' + val + '"';
+    }
+    if (typeOf2 === "function") {
+      return printFunction$1(val, printFunctionName);
+    }
+    if (typeOf2 === "symbol") {
+      return printSymbol$1(val);
+    }
+    const toStringed = toString$5.call(val);
+    if (toStringed === "[object WeakMap]") {
+      return "WeakMap {}";
+    }
+    if (toStringed === "[object WeakSet]") {
+      return "WeakSet {}";
+    }
+    if (toStringed === "[object Function]" || toStringed === "[object GeneratorFunction]") {
+      return printFunction$1(val, printFunctionName);
+    }
+    if (toStringed === "[object Symbol]") {
+      return printSymbol$1(val);
+    }
+    if (toStringed === "[object Date]") {
+      return isNaN(+val) ? "Date { NaN }" : toISOString$1.call(val);
+    }
+    if (toStringed === "[object Error]") {
+      return printError$1(val);
+    }
+    if (toStringed === "[object RegExp]") {
+      if (escapeRegex) {
+        return regExpToString$1.call(val).replace(/[\\^$*+?.()|[\]{}]/g, "\\$&");
+      }
+      return regExpToString$1.call(val);
+    }
+    if (val instanceof Error) {
+      return printError$1(val);
+    }
+    return null;
+  }
+  function printComplexValue$1(val, config2, indentation, depth, refs, hasCalledToJSON) {
+    if (refs.indexOf(val) !== -1) {
+      return "[Circular]";
+    }
+    refs = refs.slice();
+    refs.push(val);
+    const hitMaxDepth = ++depth > config2.maxDepth;
+    const min2 = config2.min;
+    if (config2.callToJSON && !hitMaxDepth && val.toJSON && typeof val.toJSON === "function" && !hasCalledToJSON) {
+      return printer$1(val.toJSON(), config2, indentation, depth, refs, true);
+    }
+    const toStringed = toString$5.call(val);
+    if (toStringed === "[object Arguments]") {
+      return hitMaxDepth ? "[Arguments]" : (min2 ? "" : "Arguments ") + "[" + (0, collections$1.printListItems)(
+        val,
+        config2,
+        indentation,
+        depth,
+        refs,
+        printer$1
+      ) + "]";
+    }
+    if (isToStringedArrayType$1(toStringed)) {
+      return hitMaxDepth ? "[" + val.constructor.name + "]" : (min2 ? "" : val.constructor.name + " ") + "[" + (0, collections$1.printListItems)(
+        val,
+        config2,
+        indentation,
+        depth,
+        refs,
+        printer$1
+      ) + "]";
+    }
+    if (toStringed === "[object Map]") {
+      return hitMaxDepth ? "[Map]" : "Map {" + (0, collections$1.printIteratorEntries)(
+        val.entries(),
+        config2,
+        indentation,
+        depth,
+        refs,
+        printer$1,
+        " => "
+      ) + "}";
+    }
+    if (toStringed === "[object Set]") {
+      return hitMaxDepth ? "[Set]" : "Set {" + (0, collections$1.printIteratorValues)(
+        val.values(),
+        config2,
+        indentation,
+        depth,
+        refs,
+        printer$1
+      ) + "}";
+    }
+    return hitMaxDepth || isWindow$1(val) ? "[" + getConstructorName$1(val) + "]" : (min2 ? "" : getConstructorName$1(val) + " ") + "{" + (0, collections$1.printObjectProperties)(
+      val,
+      config2,
+      indentation,
+      depth,
+      refs,
+      printer$1
+    ) + "}";
+  }
+  function isNewPlugin$1(plugin2) {
+    return plugin2.serialize != null;
+  }
+  function printPlugin$1(plugin2, val, config2, indentation, depth, refs) {
+    let printed;
+    try {
+      printed = isNewPlugin$1(plugin2) ? plugin2.serialize(val, config2, indentation, depth, refs, printer$1) : plugin2.print(
+        val,
+        (valChild) => printer$1(valChild, config2, indentation, depth, refs),
+        (str) => {
+          const indentationNext = indentation + config2.indent;
+          return indentationNext + str.replace(NEWLINE_REGEXP$1, "\n" + indentationNext);
+        },
+        {
+          edgeSpacing: config2.spacingOuter,
+          min: config2.min,
+          spacing: config2.spacingInner
+        },
+        config2.colors
+      );
+    } catch (error) {
+      throw new PrettyFormatPluginError$1(error.message, error.stack);
+    }
+    if (typeof printed !== "string") {
+      throw new Error(
+        `pretty-format: Plugin must return type "string" but instead returned "${typeof printed}".`
+      );
+    }
+    return printed;
+  }
+  function findPlugin$1(plugins2, val) {
+    for (let p2 = 0; p2 < plugins2.length; p2++) {
+      try {
+        if (plugins2[p2].test(val)) {
+          return plugins2[p2];
+        }
+      } catch (error) {
+        throw new PrettyFormatPluginError$1(error.message, error.stack);
+      }
+    }
+    return null;
+  }
+  function printer$1(val, config2, indentation, depth, refs, hasCalledToJSON) {
+    const plugin2 = findPlugin$1(config2.plugins, val);
+    if (plugin2 !== null) {
+      return printPlugin$1(plugin2, val, config2, indentation, depth, refs);
+    }
+    const basicResult = printBasicValue$1(
+      val,
+      config2.printFunctionName,
+      config2.escapeRegex,
+      config2.escapeString
+    );
+    if (basicResult !== null) {
+      return basicResult;
+    }
+    return printComplexValue$1(
+      val,
+      config2,
+      indentation,
+      depth,
+      refs,
+      hasCalledToJSON
+    );
+  }
+  const DEFAULT_THEME$1 = {
+    comment: "gray",
+    content: "reset",
+    prop: "yellow",
+    tag: "cyan",
+    value: "green"
+  };
+  const DEFAULT_THEME_KEYS$1 = Object.keys(DEFAULT_THEME$1);
+  const DEFAULT_OPTIONS$1 = {
+    callToJSON: true,
+    escapeRegex: false,
+    escapeString: true,
+    highlight: false,
+    indent: 2,
+    maxDepth: Infinity,
+    min: false,
+    plugins: [],
+    printFunctionName: true,
+    theme: DEFAULT_THEME$1
+  };
+  function validateOptions$1(options) {
+    Object.keys(options).forEach((key2) => {
+      if (!DEFAULT_OPTIONS$1.hasOwnProperty(key2)) {
+        throw new Error(`pretty-format: Unknown option "${key2}".`);
+      }
+    });
+    if (options.min && options.indent !== void 0 && options.indent !== 0) {
+      throw new Error(
+        'pretty-format: Options "min" and "indent" cannot be used together.'
+      );
+    }
+    if (options.theme !== void 0) {
+      if (options.theme === null) {
+        throw new Error(`pretty-format: Option "theme" must not be null.`);
+      }
+      if (typeof options.theme !== "object") {
+        throw new Error(
+          `pretty-format: Option "theme" must be of type "object" but instead received "${typeof options.theme}".`
+        );
+      }
+    }
+  }
+  const getColorsHighlight$1 = (options) => DEFAULT_THEME_KEYS$1.reduce((colors, key2) => {
+    const value = options.theme && options.theme[key2] !== void 0 ? options.theme[key2] : DEFAULT_THEME$1[key2];
+    const color = value && _ansiStyles$2.default[value];
+    if (color && typeof color.close === "string" && typeof color.open === "string") {
+      colors[key2] = color;
+    } else {
+      throw new Error(
+        `pretty-format: Option "theme" has a key "${key2}" whose value "${value}" is undefined in ansi-styles.`
+      );
+    }
+    return colors;
+  }, /* @__PURE__ */ Object.create(null));
+  const getColorsEmpty$1 = () => DEFAULT_THEME_KEYS$1.reduce((colors, key2) => {
+    colors[key2] = {
+      close: "",
+      open: ""
+    };
+    return colors;
+  }, /* @__PURE__ */ Object.create(null));
+  const getPrintFunctionName$1 = (options) => options && options.printFunctionName !== void 0 ? options.printFunctionName : DEFAULT_OPTIONS$1.printFunctionName;
+  const getEscapeRegex$1 = (options) => options && options.escapeRegex !== void 0 ? options.escapeRegex : DEFAULT_OPTIONS$1.escapeRegex;
+  const getEscapeString$1 = (options) => options && options.escapeString !== void 0 ? options.escapeString : DEFAULT_OPTIONS$1.escapeString;
+  const getConfig$1$1 = (options) => ({
+    callToJSON: options && options.callToJSON !== void 0 ? options.callToJSON : DEFAULT_OPTIONS$1.callToJSON,
+    colors: options && options.highlight ? getColorsHighlight$1(options) : getColorsEmpty$1(),
+    escapeRegex: getEscapeRegex$1(options),
+    escapeString: getEscapeString$1(options),
+    indent: options && options.min ? "" : createIndent$1(
+      options && options.indent !== void 0 ? options.indent : DEFAULT_OPTIONS$1.indent
+    ),
+    maxDepth: options && options.maxDepth !== void 0 ? options.maxDepth : DEFAULT_OPTIONS$1.maxDepth,
+    min: options && options.min !== void 0 ? options.min : DEFAULT_OPTIONS$1.min,
+    plugins: options && options.plugins !== void 0 ? options.plugins : DEFAULT_OPTIONS$1.plugins,
+    printFunctionName: getPrintFunctionName$1(options),
+    spacingInner: options && options.min ? " " : "\n",
+    spacingOuter: options && options.min ? "" : "\n"
+  });
+  function createIndent$1(indent) {
+    return new Array(indent + 1).join(" ");
+  }
+  function prettyFormat(val, options) {
+    if (options) {
+      validateOptions$1(options);
+      if (options.plugins) {
+        const plugin2 = findPlugin$1(options.plugins, val);
+        if (plugin2 !== null) {
+          return printPlugin$1(plugin2, val, getConfig$1$1(options), "", 0, []);
+        }
+      }
+    }
+    const basicResult = printBasicValue$1(
+      val,
+      getPrintFunctionName$1(options),
+      getEscapeRegex$1(options),
+      getEscapeString$1(options)
+    );
+    if (basicResult !== null) {
+      return basicResult;
+    }
+    return printComplexValue$1(val, getConfig$1$1(options), "", 0, []);
+  }
+  prettyFormat.plugins = {
+    AsymmetricMatcher: _AsymmetricMatcher$1.default,
+    ConvertAnsi: _ConvertAnsi$1.default,
+    DOMCollection: _DOMCollection$1.default,
+    DOMElement: _DOMElement$1.default,
+    Immutable: _Immutable$1.default,
+    ReactElement: _ReactElement$1.default,
+    ReactTestComponent: _ReactTestComponent$1.default
+  };
+  var build$1$1 = prettyFormat;
+  var toStr$7 = Object.prototype.toString;
+  function isCallable$2$1(fn2) {
+    return typeof fn2 === "function" || toStr$7.call(fn2) === "[object Function]";
+  }
+  function toInteger$1(value) {
+    var number = Number(value);
+    if (isNaN(number)) {
+      return 0;
+    }
+    if (number === 0 || !isFinite(number)) {
+      return number;
+    }
+    return (number > 0 ? 1 : -1) * Math.floor(Math.abs(number));
+  }
+  var maxSafeInteger$1 = Math.pow(2, 53) - 1;
+  function toLength$2(value) {
+    var len = toInteger$1(value);
+    return Math.min(Math.max(len, 0), maxSafeInteger$1);
+  }
+  function arrayFrom$1(arrayLike, mapFn) {
+    var C2 = Array;
+    var items = Object(arrayLike);
+    if (arrayLike == null) {
+      throw new TypeError("Array.from requires an array-like object - not null or undefined");
+    }
+    var len = toLength$2(items.length);
+    var A2 = isCallable$2$1(C2) ? Object(new C2(len)) : new Array(len);
+    var k2 = 0;
+    var kValue;
+    while (k2 < len) {
+      kValue = items[k2];
+      {
+        A2[k2] = kValue;
+      }
+      k2 += 1;
+    }
+    A2.length = len;
+    return A2;
+  }
+  function _typeof$3(obj) {
+    "@babel/helpers - typeof";
+    return _typeof$3 = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function(obj2) {
+      return typeof obj2;
+    } : function(obj2) {
+      return obj2 && "function" == typeof Symbol && obj2.constructor === Symbol && obj2 !== Symbol.prototype ? "symbol" : typeof obj2;
+    }, _typeof$3(obj);
+  }
+  function _classCallCheck$1(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError("Cannot call a class as a function");
+    }
+  }
+  function _defineProperties$1(target, props) {
+    for (var i2 = 0; i2 < props.length; i2++) {
+      var descriptor = props[i2];
+      descriptor.enumerable = descriptor.enumerable || false;
+      descriptor.configurable = true;
+      if ("value" in descriptor) descriptor.writable = true;
+      Object.defineProperty(target, _toPropertyKey$2(descriptor.key), descriptor);
+    }
+  }
+  function _createClass$1(Constructor, protoProps, staticProps) {
+    if (protoProps) _defineProperties$1(Constructor.prototype, protoProps);
+    Object.defineProperty(Constructor, "prototype", { writable: false });
+    return Constructor;
+  }
+  function _defineProperty$3(obj, key2, value) {
+    key2 = _toPropertyKey$2(key2);
+    if (key2 in obj) {
+      Object.defineProperty(obj, key2, { value, enumerable: true, configurable: true, writable: true });
+    } else {
+      obj[key2] = value;
+    }
+    return obj;
+  }
+  function _toPropertyKey$2(arg) {
+    var key2 = _toPrimitive$2(arg, "string");
+    return _typeof$3(key2) === "symbol" ? key2 : String(key2);
+  }
+  function _toPrimitive$2(input, hint) {
+    if (_typeof$3(input) !== "object" || input === null) return input;
+    var prim = input[Symbol.toPrimitive];
+    if (prim !== void 0) {
+      var res = prim.call(input, hint || "default");
+      if (_typeof$3(res) !== "object") return res;
+      throw new TypeError("@@toPrimitive must return a primitive value.");
+    }
+    return (hint === "string" ? String : Number)(input);
+  }
+  var SetLike$2 = /* @__PURE__ */ function() {
+    function SetLike2() {
+      var items = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : [];
+      _classCallCheck$1(this, SetLike2);
+      _defineProperty$3(this, "items", void 0);
+      this.items = items;
+    }
+    _createClass$1(SetLike2, [{
+      key: "add",
+      value: function add2(value) {
+        if (this.has(value) === false) {
+          this.items.push(value);
+        }
+        return this;
+      }
+    }, {
+      key: "clear",
+      value: function clear2() {
+        this.items = [];
+      }
+    }, {
+      key: "delete",
+      value: function _delete(value) {
+        var previousLength = this.items.length;
+        this.items = this.items.filter(function(item) {
+          return item !== value;
+        });
+        return previousLength !== this.items.length;
+      }
+    }, {
+      key: "forEach",
+      value: function forEach2(callbackfn) {
+        var _this = this;
+        this.items.forEach(function(item) {
+          callbackfn(item, item, _this);
+        });
+      }
+    }, {
+      key: "has",
+      value: function has2(value) {
+        return this.items.indexOf(value) !== -1;
+      }
+    }, {
+      key: "size",
+      get: function get2() {
+        return this.items.length;
+      }
+    }]);
+    return SetLike2;
+  }();
+  var SetLike$1$1 = typeof Set === "undefined" ? Set : SetLike$2;
+  function getLocalName$1(element) {
+    var _element$localName;
+    return (
+      // eslint-disable-next-line no-restricted-properties -- actual guard for environments without localName
+      (_element$localName = element.localName) !== null && _element$localName !== void 0 ? _element$localName : (
+        // eslint-disable-next-line no-restricted-properties -- required for the fallback
+        element.tagName.toLowerCase()
+      )
+    );
+  }
+  var localNameToRoleMappings$1 = {
+    article: "article",
+    aside: "complementary",
+    button: "button",
+    datalist: "listbox",
+    dd: "definition",
+    details: "group",
+    dialog: "dialog",
+    dt: "term",
+    fieldset: "group",
+    figure: "figure",
+    // WARNING: Only with an accessible name
+    form: "form",
+    footer: "contentinfo",
+    h1: "heading",
+    h2: "heading",
+    h3: "heading",
+    h4: "heading",
+    h5: "heading",
+    h6: "heading",
+    header: "banner",
+    hr: "separator",
+    html: "document",
+    legend: "legend",
+    li: "listitem",
+    math: "math",
+    main: "main",
+    menu: "list",
+    nav: "navigation",
+    ol: "list",
+    optgroup: "group",
+    // WARNING: Only in certain context
+    option: "option",
+    output: "status",
+    progress: "progressbar",
+    // WARNING: Only with an accessible name
+    section: "region",
+    summary: "button",
+    table: "table",
+    tbody: "rowgroup",
+    textarea: "textbox",
+    tfoot: "rowgroup",
+    // WARNING: Only in certain context
+    td: "cell",
+    th: "columnheader",
+    thead: "rowgroup",
+    tr: "row",
+    ul: "list"
+  };
+  var prohibitedAttributes$1 = {
+    caption: /* @__PURE__ */ new Set(["aria-label", "aria-labelledby"]),
+    code: /* @__PURE__ */ new Set(["aria-label", "aria-labelledby"]),
+    deletion: /* @__PURE__ */ new Set(["aria-label", "aria-labelledby"]),
+    emphasis: /* @__PURE__ */ new Set(["aria-label", "aria-labelledby"]),
+    generic: /* @__PURE__ */ new Set(["aria-label", "aria-labelledby", "aria-roledescription"]),
+    insertion: /* @__PURE__ */ new Set(["aria-label", "aria-labelledby"]),
+    paragraph: /* @__PURE__ */ new Set(["aria-label", "aria-labelledby"]),
+    presentation: /* @__PURE__ */ new Set(["aria-label", "aria-labelledby"]),
+    strong: /* @__PURE__ */ new Set(["aria-label", "aria-labelledby"]),
+    subscript: /* @__PURE__ */ new Set(["aria-label", "aria-labelledby"]),
+    superscript: /* @__PURE__ */ new Set(["aria-label", "aria-labelledby"])
+  };
+  function hasGlobalAriaAttributes$1(element, role2) {
+    return [
+      "aria-atomic",
+      "aria-busy",
+      "aria-controls",
+      "aria-current",
+      "aria-describedby",
+      "aria-details",
+      // "disabled",
+      "aria-dropeffect",
+      // "errormessage",
+      "aria-flowto",
+      "aria-grabbed",
+      // "haspopup",
+      "aria-hidden",
+      // "invalid",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ].some(function(attributeName) {
+      var _prohibitedAttributes;
+      return element.hasAttribute(attributeName) && !((_prohibitedAttributes = prohibitedAttributes$1[role2]) !== null && _prohibitedAttributes !== void 0 && _prohibitedAttributes.has(attributeName));
+    });
+  }
+  function ignorePresentationalRole$1(element, implicitRole) {
+    return hasGlobalAriaAttributes$1(element, implicitRole);
+  }
+  function getRole$1(element) {
+    var explicitRole = getExplicitRole$1(element);
+    if (explicitRole === null || explicitRole === "presentation") {
+      var implicitRole = getImplicitRole$1(element);
+      if (explicitRole !== "presentation" || ignorePresentationalRole$1(element, implicitRole || "")) {
+        return implicitRole;
+      }
+    }
+    return explicitRole;
+  }
+  function getImplicitRole$1(element) {
+    var mappedByTag = localNameToRoleMappings$1[getLocalName$1(element)];
+    if (mappedByTag !== void 0) {
+      return mappedByTag;
+    }
+    switch (getLocalName$1(element)) {
+      case "a":
+      case "area":
+      case "link":
+        if (element.hasAttribute("href")) {
+          return "link";
+        }
+        break;
+      case "img":
+        if (element.getAttribute("alt") === "" && !ignorePresentationalRole$1(element, "img")) {
+          return "presentation";
+        }
+        return "img";
+      case "input": {
+        var _ref = element, type2 = _ref.type;
+        switch (type2) {
+          case "button":
+          case "image":
+          case "reset":
+          case "submit":
+            return "button";
+          case "checkbox":
+          case "radio":
+            return type2;
+          case "range":
+            return "slider";
+          case "email":
+          case "tel":
+          case "text":
+          case "url":
+            if (element.hasAttribute("list")) {
+              return "combobox";
+            }
+            return "textbox";
+          case "search":
+            if (element.hasAttribute("list")) {
+              return "combobox";
+            }
+            return "searchbox";
+          case "number":
+            return "spinbutton";
+          default:
+            return null;
+        }
+      }
+      case "select":
+        if (element.hasAttribute("multiple") || element.size > 1) {
+          return "listbox";
+        }
+        return "combobox";
+    }
+    return null;
+  }
+  function getExplicitRole$1(element) {
+    var role2 = element.getAttribute("role");
+    if (role2 !== null) {
+      var explicitRole = role2.trim().split(" ")[0];
+      if (explicitRole.length > 0) {
+        return explicitRole;
+      }
+    }
+    return null;
+  }
+  function isElement$2(node) {
+    return node !== null && node.nodeType === node.ELEMENT_NODE;
+  }
+  function isHTMLTableCaptionElement$1(node) {
+    return isElement$2(node) && getLocalName$1(node) === "caption";
+  }
+  function isHTMLInputElement$1(node) {
+    return isElement$2(node) && getLocalName$1(node) === "input";
+  }
+  function isHTMLOptGroupElement$1(node) {
+    return isElement$2(node) && getLocalName$1(node) === "optgroup";
+  }
+  function isHTMLSelectElement$1(node) {
+    return isElement$2(node) && getLocalName$1(node) === "select";
+  }
+  function isHTMLTableElement$1(node) {
+    return isElement$2(node) && getLocalName$1(node) === "table";
+  }
+  function isHTMLTextAreaElement$1(node) {
+    return isElement$2(node) && getLocalName$1(node) === "textarea";
+  }
+  function safeWindow$1(node) {
+    var _ref = node.ownerDocument === null ? node : node.ownerDocument, defaultView = _ref.defaultView;
+    if (defaultView === null) {
+      throw new TypeError("no window available");
+    }
+    return defaultView;
+  }
+  function isHTMLFieldSetElement$1(node) {
+    return isElement$2(node) && getLocalName$1(node) === "fieldset";
+  }
+  function isHTMLLegendElement$1(node) {
+    return isElement$2(node) && getLocalName$1(node) === "legend";
+  }
+  function isHTMLSlotElement$1(node) {
+    return isElement$2(node) && getLocalName$1(node) === "slot";
+  }
+  function isSVGElement$1(node) {
+    return isElement$2(node) && node.ownerSVGElement !== void 0;
+  }
+  function isSVGSVGElement$1(node) {
+    return isElement$2(node) && getLocalName$1(node) === "svg";
+  }
+  function isSVGTitleElement$1(node) {
+    return isSVGElement$1(node) && getLocalName$1(node) === "title";
+  }
+  function queryIdRefs$1(node, attributeName) {
+    if (isElement$2(node) && node.hasAttribute(attributeName)) {
+      var ids = node.getAttribute(attributeName).split(" ");
+      var root = node.getRootNode ? node.getRootNode() : node.ownerDocument;
+      return ids.map(function(id2) {
+        return root.getElementById(id2);
+      }).filter(
+        function(element) {
+          return element !== null;
+        }
+        // TODO: why does this not narrow?
+      );
+    }
+    return [];
+  }
+  function hasAnyConcreteRoles$1(node, roles2) {
+    if (isElement$2(node)) {
+      return roles2.indexOf(getRole$1(node)) !== -1;
+    }
+    return false;
+  }
+  function asFlatString$1(s) {
+    return s.trim().replace(/\s\s+/g, " ");
+  }
+  function isHidden$1(node, getComputedStyleImplementation) {
+    if (!isElement$2(node)) {
+      return false;
+    }
+    if (node.hasAttribute("hidden") || node.getAttribute("aria-hidden") === "true") {
+      return true;
+    }
+    var style = getComputedStyleImplementation(node);
+    return style.getPropertyValue("display") === "none" || style.getPropertyValue("visibility") === "hidden";
+  }
+  function isControl$1(node) {
+    return hasAnyConcreteRoles$1(node, ["button", "combobox", "listbox", "textbox"]) || hasAbstractRole$1(node, "range");
+  }
+  function hasAbstractRole$1(node, role2) {
+    if (!isElement$2(node)) {
+      return false;
+    }
+    switch (role2) {
+      case "range":
+        return hasAnyConcreteRoles$1(node, ["meter", "progressbar", "scrollbar", "slider", "spinbutton"]);
+      default:
+        throw new TypeError("No knowledge about abstract role '".concat(role2, "'. This is likely a bug :("));
+    }
+  }
+  function querySelectorAllSubtree$1(element, selectors) {
+    var elements = arrayFrom$1(element.querySelectorAll(selectors));
+    queryIdRefs$1(element, "aria-owns").forEach(function(root) {
+      elements.push.apply(elements, arrayFrom$1(root.querySelectorAll(selectors)));
+    });
+    return elements;
+  }
+  function querySelectedOptions$1(listbox) {
+    if (isHTMLSelectElement$1(listbox)) {
+      return listbox.selectedOptions || querySelectorAllSubtree$1(listbox, "[selected]");
+    }
+    return querySelectorAllSubtree$1(listbox, '[aria-selected="true"]');
+  }
+  function isMarkedPresentational$1(node) {
+    return hasAnyConcreteRoles$1(node, ["none", "presentation"]);
+  }
+  function isNativeHostLanguageTextAlternativeElement$1(node) {
+    return isHTMLTableCaptionElement$1(node);
+  }
+  function allowsNameFromContent$1(node) {
+    return hasAnyConcreteRoles$1(node, ["button", "cell", "checkbox", "columnheader", "gridcell", "heading", "label", "legend", "link", "menuitem", "menuitemcheckbox", "menuitemradio", "option", "radio", "row", "rowheader", "switch", "tab", "tooltip", "treeitem"]);
+  }
+  function isDescendantOfNativeHostLanguageTextAlternativeElement$1(node) {
+    return false;
+  }
+  function getValueOfTextbox$1(element) {
+    if (isHTMLInputElement$1(element) || isHTMLTextAreaElement$1(element)) {
+      return element.value;
+    }
+    return element.textContent || "";
+  }
+  function getTextualContent$1(declaration) {
+    var content = declaration.getPropertyValue("content");
+    if (/^["'].*["']$/.test(content)) {
+      return content.slice(1, -1);
+    }
+    return "";
+  }
+  function isLabelableElement$1(element) {
+    var localName = getLocalName$1(element);
+    return localName === "button" || localName === "input" && element.getAttribute("type") !== "hidden" || localName === "meter" || localName === "output" || localName === "progress" || localName === "select" || localName === "textarea";
+  }
+  function findLabelableElement$1(element) {
+    if (isLabelableElement$1(element)) {
+      return element;
+    }
+    var labelableElement = null;
+    element.childNodes.forEach(function(childNode) {
+      if (labelableElement === null && isElement$2(childNode)) {
+        var descendantLabelableElement = findLabelableElement$1(childNode);
+        if (descendantLabelableElement !== null) {
+          labelableElement = descendantLabelableElement;
+        }
+      }
+    });
+    return labelableElement;
+  }
+  function getControlOfLabel$1(label) {
+    if (label.control !== void 0) {
+      return label.control;
+    }
+    var htmlFor = label.getAttribute("for");
+    if (htmlFor !== null) {
+      return label.ownerDocument.getElementById(htmlFor);
+    }
+    return findLabelableElement$1(label);
+  }
+  function getLabels$1$1(element) {
+    var labelsProperty = element.labels;
+    if (labelsProperty === null) {
+      return labelsProperty;
+    }
+    if (labelsProperty !== void 0) {
+      return arrayFrom$1(labelsProperty);
+    }
+    if (!isLabelableElement$1(element)) {
+      return null;
+    }
+    var document2 = element.ownerDocument;
+    return arrayFrom$1(document2.querySelectorAll("label")).filter(function(label) {
+      return getControlOfLabel$1(label) === element;
+    });
+  }
+  function getSlotContents$1(slot) {
+    var assignedNodes = slot.assignedNodes();
+    if (assignedNodes.length === 0) {
+      return arrayFrom$1(slot.childNodes);
+    }
+    return assignedNodes;
+  }
+  function computeTextAlternative$1(root) {
+    var options = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {};
+    var consultedNodes = new SetLike$1$1();
+    var window2 = safeWindow$1(root);
+    var _options$compute = options.compute, compute = _options$compute === void 0 ? "name" : _options$compute, _options$computedStyl = options.computedStyleSupportsPseudoElements, computedStyleSupportsPseudoElements = _options$computedStyl === void 0 ? options.getComputedStyle !== void 0 : _options$computedStyl, _options$getComputedS = options.getComputedStyle, getComputedStyle = _options$getComputedS === void 0 ? window2.getComputedStyle.bind(window2) : _options$getComputedS, _options$hidden = options.hidden, hidden = _options$hidden === void 0 ? false : _options$hidden;
+    function computeMiscTextAlternative(node, context) {
+      var accumulatedText = "";
+      if (isElement$2(node) && computedStyleSupportsPseudoElements) {
+        var pseudoBefore = getComputedStyle(node, "::before");
+        var beforeContent = getTextualContent$1(pseudoBefore);
+        accumulatedText = "".concat(beforeContent, " ").concat(accumulatedText);
+      }
+      var childNodes = isHTMLSlotElement$1(node) ? getSlotContents$1(node) : arrayFrom$1(node.childNodes).concat(queryIdRefs$1(node, "aria-owns"));
+      childNodes.forEach(function(child) {
+        var result = computeTextAlternative2(child, {
+          isEmbeddedInLabel: context.isEmbeddedInLabel,
+          isReferenced: false,
+          recursion: true
+        });
+        var display = isElement$2(child) ? getComputedStyle(child).getPropertyValue("display") : "inline";
+        var separator = display !== "inline" ? " " : "";
+        accumulatedText += "".concat(separator).concat(result).concat(separator);
+      });
+      if (isElement$2(node) && computedStyleSupportsPseudoElements) {
+        var pseudoAfter = getComputedStyle(node, "::after");
+        var afterContent = getTextualContent$1(pseudoAfter);
+        accumulatedText = "".concat(accumulatedText, " ").concat(afterContent);
+      }
+      return accumulatedText.trim();
+    }
+    function useAttribute(element, attributeName) {
+      var attribute = element.getAttributeNode(attributeName);
+      if (attribute !== null && !consultedNodes.has(attribute) && attribute.value.trim() !== "") {
+        consultedNodes.add(attribute);
+        return attribute.value;
+      }
+      return null;
+    }
+    function computeTooltipAttributeValue(node) {
+      if (!isElement$2(node)) {
+        return null;
+      }
+      return useAttribute(node, "title");
+    }
+    function computeElementTextAlternative(node) {
+      if (!isElement$2(node)) {
+        return null;
+      }
+      if (isHTMLFieldSetElement$1(node)) {
+        consultedNodes.add(node);
+        var children = arrayFrom$1(node.childNodes);
+        for (var i2 = 0; i2 < children.length; i2 += 1) {
+          var child = children[i2];
+          if (isHTMLLegendElement$1(child)) {
+            return computeTextAlternative2(child, {
+              isEmbeddedInLabel: false,
+              isReferenced: false,
+              recursion: false
+            });
+          }
+        }
+      } else if (isHTMLTableElement$1(node)) {
+        consultedNodes.add(node);
+        var _children = arrayFrom$1(node.childNodes);
+        for (var _i = 0; _i < _children.length; _i += 1) {
+          var _child = _children[_i];
+          if (isHTMLTableCaptionElement$1(_child)) {
+            return computeTextAlternative2(_child, {
+              isEmbeddedInLabel: false,
+              isReferenced: false,
+              recursion: false
+            });
+          }
+        }
+      } else if (isSVGSVGElement$1(node)) {
+        consultedNodes.add(node);
+        var _children2 = arrayFrom$1(node.childNodes);
+        for (var _i2 = 0; _i2 < _children2.length; _i2 += 1) {
+          var _child2 = _children2[_i2];
+          if (isSVGTitleElement$1(_child2)) {
+            return _child2.textContent;
+          }
+        }
+        return null;
+      } else if (getLocalName$1(node) === "img" || getLocalName$1(node) === "area") {
+        var nameFromAlt = useAttribute(node, "alt");
+        if (nameFromAlt !== null) {
+          return nameFromAlt;
+        }
+      } else if (isHTMLOptGroupElement$1(node)) {
+        var nameFromLabel = useAttribute(node, "label");
+        if (nameFromLabel !== null) {
+          return nameFromLabel;
+        }
+      }
+      if (isHTMLInputElement$1(node) && (node.type === "button" || node.type === "submit" || node.type === "reset")) {
+        var nameFromValue = useAttribute(node, "value");
+        if (nameFromValue !== null) {
+          return nameFromValue;
+        }
+        if (node.type === "submit") {
+          return "Submit";
+        }
+        if (node.type === "reset") {
+          return "Reset";
+        }
+      }
+      var labels = getLabels$1$1(node);
+      if (labels !== null && labels.length !== 0) {
+        consultedNodes.add(node);
+        return arrayFrom$1(labels).map(function(element) {
+          return computeTextAlternative2(element, {
+            isEmbeddedInLabel: true,
+            isReferenced: false,
+            recursion: true
+          });
+        }).filter(function(label) {
+          return label.length > 0;
+        }).join(" ");
+      }
+      if (isHTMLInputElement$1(node) && node.type === "image") {
+        var _nameFromAlt = useAttribute(node, "alt");
+        if (_nameFromAlt !== null) {
+          return _nameFromAlt;
+        }
+        var nameFromTitle = useAttribute(node, "title");
+        if (nameFromTitle !== null) {
+          return nameFromTitle;
+        }
+        return "Submit Query";
+      }
+      if (hasAnyConcreteRoles$1(node, ["button"])) {
+        var nameFromSubTree = computeMiscTextAlternative(node, {
+          isEmbeddedInLabel: false,
+          isReferenced: false
+        });
+        if (nameFromSubTree !== "") {
+          return nameFromSubTree;
+        }
+      }
+      return null;
+    }
+    function computeTextAlternative2(current, context) {
+      if (consultedNodes.has(current)) {
+        return "";
+      }
+      if (!hidden && isHidden$1(current, getComputedStyle) && !context.isReferenced) {
+        consultedNodes.add(current);
+        return "";
+      }
+      var labelAttributeNode = isElement$2(current) ? current.getAttributeNode("aria-labelledby") : null;
+      var labelElements = labelAttributeNode !== null && !consultedNodes.has(labelAttributeNode) ? queryIdRefs$1(current, "aria-labelledby") : [];
+      if (compute === "name" && !context.isReferenced && labelElements.length > 0) {
+        consultedNodes.add(labelAttributeNode);
+        return labelElements.map(function(element) {
+          return computeTextAlternative2(element, {
+            isEmbeddedInLabel: context.isEmbeddedInLabel,
+            isReferenced: true,
+            // this isn't recursion as specified, otherwise we would skip
+            // `aria-label` in
+            // <input id="myself" aria-label="foo" aria-labelledby="myself"
+            recursion: false
+          });
+        }).join(" ");
+      }
+      var skipToStep2E = context.recursion && isControl$1(current) && compute === "name";
+      if (!skipToStep2E) {
+        var ariaLabel = (isElement$2(current) && current.getAttribute("aria-label") || "").trim();
+        if (ariaLabel !== "" && compute === "name") {
+          consultedNodes.add(current);
+          return ariaLabel;
+        }
+        if (!isMarkedPresentational$1(current)) {
+          var elementTextAlternative = computeElementTextAlternative(current);
+          if (elementTextAlternative !== null) {
+            consultedNodes.add(current);
+            return elementTextAlternative;
+          }
+        }
+      }
+      if (hasAnyConcreteRoles$1(current, ["menu"])) {
+        consultedNodes.add(current);
+        return "";
+      }
+      if (skipToStep2E || context.isEmbeddedInLabel || context.isReferenced) {
+        if (hasAnyConcreteRoles$1(current, ["combobox", "listbox"])) {
+          consultedNodes.add(current);
+          var selectedOptions = querySelectedOptions$1(current);
+          if (selectedOptions.length === 0) {
+            return isHTMLInputElement$1(current) ? current.value : "";
+          }
+          return arrayFrom$1(selectedOptions).map(function(selectedOption) {
+            return computeTextAlternative2(selectedOption, {
+              isEmbeddedInLabel: context.isEmbeddedInLabel,
+              isReferenced: false,
+              recursion: true
+            });
+          }).join(" ");
+        }
+        if (hasAbstractRole$1(current, "range")) {
+          consultedNodes.add(current);
+          if (current.hasAttribute("aria-valuetext")) {
+            return current.getAttribute("aria-valuetext");
+          }
+          if (current.hasAttribute("aria-valuenow")) {
+            return current.getAttribute("aria-valuenow");
+          }
+          return current.getAttribute("value") || "";
+        }
+        if (hasAnyConcreteRoles$1(current, ["textbox"])) {
+          consultedNodes.add(current);
+          return getValueOfTextbox$1(current);
+        }
+      }
+      if (allowsNameFromContent$1(current) || isElement$2(current) && context.isReferenced || isNativeHostLanguageTextAlternativeElement$1(current) || isDescendantOfNativeHostLanguageTextAlternativeElement$1()) {
+        var accumulatedText2F = computeMiscTextAlternative(current, {
+          isEmbeddedInLabel: context.isEmbeddedInLabel,
+          isReferenced: false
+        });
+        if (accumulatedText2F !== "") {
+          consultedNodes.add(current);
+          return accumulatedText2F;
+        }
+      }
+      if (current.nodeType === current.TEXT_NODE) {
+        consultedNodes.add(current);
+        return current.textContent || "";
+      }
+      if (context.recursion) {
+        consultedNodes.add(current);
+        return computeMiscTextAlternative(current, {
+          isEmbeddedInLabel: context.isEmbeddedInLabel,
+          isReferenced: false
+        });
+      }
+      var tooltipAttributeValue = computeTooltipAttributeValue(current);
+      if (tooltipAttributeValue !== null) {
+        consultedNodes.add(current);
+        return tooltipAttributeValue;
+      }
+      consultedNodes.add(current);
+      return "";
+    }
+    return asFlatString$1(computeTextAlternative2(root, {
+      isEmbeddedInLabel: false,
+      // by spec computeAccessibleDescription starts with the referenced elements as roots
+      isReferenced: compute === "description",
+      recursion: false
+    }));
+  }
+  function prohibitsNaming$1(node) {
+    return hasAnyConcreteRoles$1(node, ["caption", "code", "deletion", "emphasis", "generic", "insertion", "paragraph", "presentation", "strong", "subscript", "superscript"]);
+  }
+  function computeAccessibleName$1(root) {
+    var options = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {};
+    if (prohibitsNaming$1(root)) {
+      return "";
+    }
+    return computeTextAlternative$1(root, options);
+  }
+  var interopRequireDefault = createCommonjsModule(function(module2) {
+    function _interopRequireDefault2(e2) {
+      return e2 && e2.__esModule ? e2 : {
+        "default": e2
+      };
+    }
+    module2.exports = _interopRequireDefault2, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+  });
+  var check = function(it) {
+    return it && it.Math === Math && it;
+  };
+  var globalThis_1 = (
+    // eslint-disable-next-line es/no-global-this -- safe
+    check(typeof globalThis == "object" && globalThis) || check(typeof window == "object" && window) || // eslint-disable-next-line no-restricted-globals -- safe
+    check(typeof self == "object" && self) || check(typeof global$1$1 == "object" && global$1$1) || check(false) || // eslint-disable-next-line no-new-func -- fallback
+    /* @__PURE__ */ function() {
+      return this;
+    }() || Function("return this")()
+  );
+  var fails$1 = function(exec2) {
+    try {
+      return !!exec2();
+    } catch (error) {
+      return true;
+    }
+  };
+  var fails = fails$1;
+  var functionBindNative = !fails(function() {
+    var test2 = (function() {
+    }).bind();
+    return typeof test2 != "function" || test2.hasOwnProperty("prototype");
+  });
+  var NATIVE_BIND = functionBindNative;
+  var FunctionPrototype$3 = Function.prototype;
+  var apply$1 = FunctionPrototype$3.apply;
+  var call$3 = FunctionPrototype$3.call;
+  var functionApply$1 = typeof Reflect == "object" && Reflect.apply || (NATIVE_BIND ? call$3.bind(apply$1) : function() {
+    return call$3.apply(apply$1, arguments);
+  });
+  var FunctionPrototype$2 = Function.prototype;
+  var call$2 = FunctionPrototype$2.call;
+  var uncurryThisWithBind = NATIVE_BIND && FunctionPrototype$2.bind.bind(call$2, call$2);
+  var functionUncurryThis = NATIVE_BIND ? uncurryThisWithBind : function(fn2) {
+    return function() {
+      return call$2.apply(fn2, arguments);
+    };
+  };
+  var uncurryThis$1 = functionUncurryThis;
+  var toString$4 = uncurryThis$1({}.toString);
+  var stringSlice$2 = uncurryThis$1("".slice);
+  var classofRaw = function(it) {
+    return stringSlice$2(toString$4(it), 8, -1);
+  };
+  var classof$2 = classofRaw;
+  var functionUncurryThisClause = function(fn2) {
+    if (classof$2(fn2) === "Function") return uncurryThis$1(fn2);
+  };
+  var documentAll = typeof document == "object" && document.all;
+  var isCallable$1$1 = typeof documentAll == "undefined" && documentAll !== void 0 ? function(argument) {
+    return typeof argument == "function" || argument === documentAll;
+  } : function(argument) {
+    return typeof argument == "function";
+  };
+  var descriptors = !fails(function() {
+    return Object.defineProperty({}, 1, { get: function() {
+      return 7;
+    } })[1] !== 7;
+  });
+  var call$1 = Function.prototype.call;
+  var functionCall$1 = NATIVE_BIND ? call$1.bind(call$1) : function() {
+    return call$1.apply(call$1, arguments);
+  };
+  var $propertyIsEnumerable$1 = {}.propertyIsEnumerable;
+  var getOwnPropertyDescriptor$2 = Object.getOwnPropertyDescriptor;
+  var NASHORN_BUG = getOwnPropertyDescriptor$2 && !$propertyIsEnumerable$1.call({ 1: 2 }, 1);
+  var f$7 = NASHORN_BUG ? function propertyIsEnumerable(V2) {
+    var descriptor = getOwnPropertyDescriptor$2(this, V2);
+    return !!descriptor && descriptor.enumerable;
+  } : $propertyIsEnumerable$1;
+  var objectPropertyIsEnumerable = {
+    f: f$7
+  };
+  var createPropertyDescriptor$1 = function(bitmap, value) {
+    return {
+      enumerable: !(bitmap & 1),
+      configurable: !(bitmap & 2),
+      writable: !(bitmap & 4),
+      value
+    };
+  };
+  var $Object$4 = Object;
+  var split = uncurryThis$1("".split);
+  var indexedObject = fails(function() {
+    return !$Object$4("z").propertyIsEnumerable(0);
+  }) ? function(it) {
+    return classof$2(it) === "String" ? split(it, "") : $Object$4(it);
+  } : $Object$4;
+  var isNullOrUndefined$1 = function(it) {
+    return it === null || it === void 0;
+  };
+  var isNullOrUndefined = isNullOrUndefined$1;
+  var $TypeError$d = TypeError;
+  var requireObjectCoercible$1 = function(it) {
+    if (isNullOrUndefined(it)) throw new $TypeError$d("Can't call method on " + it);
+    return it;
+  };
+  var IndexedObject = indexedObject;
+  var requireObjectCoercible = requireObjectCoercible$1;
+  var toIndexedObject$1 = function(it) {
+    return IndexedObject(requireObjectCoercible(it));
+  };
+  var isCallable$3 = isCallable$1$1;
+  var isObject$1 = function(it) {
+    return typeof it == "object" ? it !== null : isCallable$3(it);
+  };
+  var path$1 = {};
+  var path = path$1;
+  var globalThis$1 = globalThis_1;
+  var aFunction = function(variable) {
+    return isCallable$3(variable) ? variable : void 0;
+  };
+  var getBuiltIn$1 = function(namespace, method2) {
+    return arguments.length < 2 ? aFunction(path[namespace]) || aFunction(globalThis$1[namespace]) : path[namespace] && path[namespace][method2] || globalThis$1[namespace] && globalThis$1[namespace][method2];
+  };
+  var objectIsPrototypeOf = uncurryThis$1({}.isPrototypeOf);
+  var navigator = globalThis$1.navigator;
+  var userAgent$1 = navigator && navigator.userAgent;
+  var environmentUserAgent = userAgent$1 ? String(userAgent$1) : "";
+  var userAgent = environmentUserAgent;
+  var process$2 = globalThis$1.process;
+  var Deno = globalThis$1.Deno;
+  var versions = process$2 && process$2.versions || Deno && Deno.version;
+  var v8 = versions && versions.v8;
+  var match, version;
+  if (v8) {
+    match = v8.split(".");
+    version = match[0] > 0 && match[0] < 4 ? 1 : +(match[0] + match[1]);
+  }
+  if (!version && userAgent) {
+    match = userAgent.match(/Edge\/(\d+)/);
+    if (!match || match[1] >= 74) {
+      match = userAgent.match(/Chrome\/(\d+)/);
+      if (match) version = +match[1];
+    }
+  }
+  var environmentV8Version = version;
+  var V8_VERSION = environmentV8Version;
+  var $String$5 = globalThis$1.String;
+  var symbolConstructorDetection = !!Object.getOwnPropertySymbols && !fails(function() {
+    var symbol2 = Symbol("symbol detection");
+    return !$String$5(symbol2) || !(Object(symbol2) instanceof Symbol) || // Chrome 38-40 symbols are not inherited from DOM collections prototypes to instances
+    !Symbol.sham && V8_VERSION && V8_VERSION < 41;
+  });
+  var NATIVE_SYMBOL = symbolConstructorDetection;
+  var useSymbolAsUid = NATIVE_SYMBOL && !Symbol.sham && typeof Symbol.iterator == "symbol";
+  var getBuiltIn = getBuiltIn$1;
+  var isPrototypeOf = objectIsPrototypeOf;
+  var USE_SYMBOL_AS_UID = useSymbolAsUid;
+  var $Object$3 = Object;
+  var isSymbol$1$1 = USE_SYMBOL_AS_UID ? function(it) {
+    return typeof it == "symbol";
+  } : function(it) {
+    var $Symbol2 = getBuiltIn("Symbol");
+    return isCallable$3($Symbol2) && isPrototypeOf($Symbol2.prototype, $Object$3(it));
+  };
+  var $String$4 = String;
+  var tryToString$1 = function(argument) {
+    try {
+      return $String$4(argument);
+    } catch (error) {
+      return "Object";
+    }
+  };
+  var tryToString = tryToString$1;
+  var $TypeError$c = TypeError;
+  var aCallable$1 = function(argument) {
+    if (isCallable$3(argument)) return argument;
+    throw new $TypeError$c(tryToString(argument) + " is not a function");
+  };
+  var aCallable = aCallable$1;
+  var getMethod$1 = function(V2, P2) {
+    var func = V2[P2];
+    return isNullOrUndefined(func) ? void 0 : aCallable(func);
+  };
+  var call$4 = functionCall$1;
+  var isObject = isObject$1;
+  var $TypeError$b = TypeError;
+  var ordinaryToPrimitive$1 = function(input, pref) {
+    var fn2, val;
+    if (pref === "string" && isCallable$3(fn2 = input.toString) && !isObject(val = call$4(fn2, input))) return val;
+    if (isCallable$3(fn2 = input.valueOf) && !isObject(val = call$4(fn2, input))) return val;
+    if (pref !== "string" && isCallable$3(fn2 = input.toString) && !isObject(val = call$4(fn2, input))) return val;
+    throw new $TypeError$b("Can't convert object to primitive value");
+  };
+  var isPure = true;
+  var defineProperty$d = Object.defineProperty;
+  var defineGlobalProperty$1 = function(key2, value) {
+    try {
+      defineProperty$d(globalThis$1, key2, { value, configurable: true, writable: true });
+    } catch (error) {
+      globalThis$1[key2] = value;
+    }
+    return value;
+  };
+  var IS_PURE = isPure;
+  var defineGlobalProperty = defineGlobalProperty$1;
+  var sharedStore = createCommonjsModule(function(module2) {
+    var SHARED = "__core-js_shared__";
+    var store2 = module2.exports = globalThis$1[SHARED] || defineGlobalProperty(SHARED, {});
+    (store2.versions || (store2.versions = [])).push({
+      version: "3.40.0",
+      mode: "pure",
+      copyright: "© 2014-2025 Denis Pushkarev (zloirock.ru)",
+      license: "https://github.com/zloirock/core-js/blob/v3.40.0/LICENSE",
+      source: "https://github.com/zloirock/core-js"
+    });
+  });
+  var store$1 = sharedStore;
+  var shared$2 = function(key2, value) {
+    return store$1[key2] || (store$1[key2] = value || {});
+  };
+  var $Object$2$1 = Object;
+  var toObject$2 = function(argument) {
+    return $Object$2$1(requireObjectCoercible(argument));
+  };
+  var toObject$1 = toObject$2;
+  var hasOwnProperty$1 = uncurryThis$1({}.hasOwnProperty);
+  var hasOwnProperty_1 = Object.hasOwn || function hasOwn2(it, key2) {
+    return hasOwnProperty$1(toObject$1(it), key2);
+  };
+  var id = 0;
+  var postfix = Math.random();
+  var toString$3 = uncurryThis$1(1 .toString);
+  var uid$1 = function(key2) {
+    return "Symbol(" + (key2 === void 0 ? "" : key2) + ")_" + toString$3(++id + postfix, 36);
+  };
+  var shared$1 = shared$2;
+  var hasOwn$4 = hasOwnProperty_1;
+  var uid = uid$1;
+  var Symbol$3 = globalThis$1.Symbol;
+  var WellKnownSymbolsStore$2 = shared$1("wks");
+  var createWellKnownSymbol = USE_SYMBOL_AS_UID ? Symbol$3["for"] || Symbol$3 : Symbol$3 && Symbol$3.withoutSetter || uid;
+  var wellKnownSymbol$1 = function(name) {
+    if (!hasOwn$4(WellKnownSymbolsStore$2, name)) {
+      WellKnownSymbolsStore$2[name] = NATIVE_SYMBOL && hasOwn$4(Symbol$3, name) ? Symbol$3[name] : createWellKnownSymbol("Symbol." + name);
+    }
+    return WellKnownSymbolsStore$2[name];
+  };
+  var isSymbol$3 = isSymbol$1$1;
+  var getMethod = getMethod$1;
+  var ordinaryToPrimitive = ordinaryToPrimitive$1;
+  var wellKnownSymbol = wellKnownSymbol$1;
+  var $TypeError$a$1 = TypeError;
+  var TO_PRIMITIVE = wellKnownSymbol("toPrimitive");
+  var toPrimitive$6 = function(input, pref) {
+    if (!isObject(input) || isSymbol$3(input)) return input;
+    var exoticToPrim = getMethod(input, TO_PRIMITIVE);
+    var result;
+    if (exoticToPrim) {
+      if (pref === void 0) pref = "default";
+      result = call$4(exoticToPrim, input, pref);
+      if (!isObject(result) || isSymbol$3(result)) return result;
+      throw new $TypeError$a$1("Can't convert object to primitive value");
+    }
+    if (pref === void 0) pref = "number";
+    return ordinaryToPrimitive(input, pref);
+  };
+  var toPrimitive$5 = toPrimitive$6;
+  var toPropertyKey$1 = function(argument) {
+    var key2 = toPrimitive$5(argument, "string");
+    return isSymbol$3(key2) ? key2 : key2 + "";
+  };
+  var document$1 = globalThis$1.document;
+  var EXISTS$1 = isObject(document$1) && isObject(document$1.createElement);
+  var documentCreateElement$1 = function(it) {
+    return EXISTS$1 ? document$1.createElement(it) : {};
+  };
+  var DESCRIPTORS = descriptors;
+  var documentCreateElement = documentCreateElement$1;
+  var ie8DomDefine = !DESCRIPTORS && !fails(function() {
+    return Object.defineProperty(documentCreateElement("div"), "a", {
+      get: function() {
+        return 7;
+      }
+    }).a !== 7;
+  });
+  var propertyIsEnumerableModule = objectPropertyIsEnumerable;
+  var createPropertyDescriptor = createPropertyDescriptor$1;
+  var toIndexedObject = toIndexedObject$1;
+  var toPropertyKey = toPropertyKey$1;
+  var IE8_DOM_DEFINE = ie8DomDefine;
+  var $getOwnPropertyDescriptor$2 = Object.getOwnPropertyDescriptor;
+  var f$6 = DESCRIPTORS ? $getOwnPropertyDescriptor$2 : function getOwnPropertyDescriptor2(O2, P2) {
+    O2 = toIndexedObject(O2);
+    P2 = toPropertyKey(P2);
+    if (IE8_DOM_DEFINE) try {
+      return $getOwnPropertyDescriptor$2(O2, P2);
+    } catch (error) {
+    }
+    if (hasOwn$4(O2, P2)) return createPropertyDescriptor(!call$4(propertyIsEnumerableModule.f, O2, P2), O2[P2]);
+  };
+  var objectGetOwnPropertyDescriptor = {
+    f: f$6
+  };
+  var replacement = /#|\.prototype\./;
+  var isForced$1 = function(feature, detection) {
+    var value = data[normalize$1(feature)];
+    return value === POLYFILL ? true : value === NATIVE ? false : isCallable$3(detection) ? fails(detection) : !!detection;
+  };
+  var normalize$1 = isForced$1.normalize = function(string) {
+    return String(string).replace(replacement, ".").toLowerCase();
+  };
+  var data = isForced$1.data = {};
+  var NATIVE = isForced$1.NATIVE = "N";
+  var POLYFILL = isForced$1.POLYFILL = "P";
+  var isForced_1 = isForced$1;
+  var uncurryThis = functionUncurryThisClause;
+  var bind$1$1 = uncurryThis(uncurryThis.bind);
+  var functionBindContext = function(fn2, that) {
+    aCallable(fn2);
+    return that === void 0 ? fn2 : NATIVE_BIND ? bind$1$1(fn2, that) : function() {
+      return fn2.apply(that, arguments);
+    };
+  };
+  var v8PrototypeDefineBug = DESCRIPTORS && fails(function() {
+    return Object.defineProperty(function() {
+    }, "prototype", {
+      value: 42,
+      writable: false
+    }).prototype !== 42;
+  });
+  var $String$3 = String;
+  var $TypeError$9$1 = TypeError;
+  var anObject$1 = function(argument) {
+    if (isObject(argument)) return argument;
+    throw new $TypeError$9$1($String$3(argument) + " is not an object");
+  };
+  var V8_PROTOTYPE_DEFINE_BUG = v8PrototypeDefineBug;
+  var anObject = anObject$1;
+  var $TypeError$8$1 = TypeError;
+  var $defineProperty$1$1 = Object.defineProperty;
+  var $getOwnPropertyDescriptor$1 = Object.getOwnPropertyDescriptor;
+  var ENUMERABLE = "enumerable";
+  var CONFIGURABLE$1 = "configurable";
+  var WRITABLE = "writable";
+  var f$5 = DESCRIPTORS ? V8_PROTOTYPE_DEFINE_BUG ? function defineProperty2(O2, P2, Attributes) {
+    anObject(O2);
+    P2 = toPropertyKey(P2);
+    anObject(Attributes);
+    if (typeof O2 === "function" && P2 === "prototype" && "value" in Attributes && WRITABLE in Attributes && !Attributes[WRITABLE]) {
+      var current = $getOwnPropertyDescriptor$1(O2, P2);
+      if (current && current[WRITABLE]) {
+        O2[P2] = Attributes.value;
+        Attributes = {
+          configurable: CONFIGURABLE$1 in Attributes ? Attributes[CONFIGURABLE$1] : current[CONFIGURABLE$1],
+          enumerable: ENUMERABLE in Attributes ? Attributes[ENUMERABLE] : current[ENUMERABLE],
+          writable: false
+        };
+      }
+    }
+    return $defineProperty$1$1(O2, P2, Attributes);
+  } : $defineProperty$1$1 : function defineProperty2(O2, P2, Attributes) {
+    anObject(O2);
+    P2 = toPropertyKey(P2);
+    anObject(Attributes);
+    if (IE8_DOM_DEFINE) try {
+      return $defineProperty$1$1(O2, P2, Attributes);
+    } catch (error) {
+    }
+    if ("get" in Attributes || "set" in Attributes) throw new $TypeError$8$1("Accessors not supported");
+    if ("value" in Attributes) O2[P2] = Attributes.value;
+    return O2;
+  };
+  var objectDefineProperty = {
+    f: f$5
+  };
+  var require$$0$r = objectDefineProperty;
+  var createNonEnumerableProperty$1 = DESCRIPTORS ? function(object, key2, value) {
+    return require$$0$r.f(object, key2, createPropertyDescriptor(1, value));
+  } : function(object, key2, value) {
+    object[key2] = value;
+    return object;
+  };
+  var apply = functionApply$1;
+  var getOwnPropertyDescriptorModule = objectGetOwnPropertyDescriptor;
+  var isForced = isForced_1;
+  var bind$5 = functionBindContext;
+  var createNonEnumerableProperty = createNonEnumerableProperty$1;
+  var getOwnPropertyDescriptor$1 = getOwnPropertyDescriptorModule.f;
+  var wrapConstructor = function(NativeConstructor) {
+    var Wrapper = function(a, b2, c2) {
+      if (this instanceof Wrapper) {
+        switch (arguments.length) {
+          case 0:
+            return new NativeConstructor();
+          case 1:
+            return new NativeConstructor(a);
+          case 2:
+            return new NativeConstructor(a, b2);
+        }
+        return new NativeConstructor(a, b2, c2);
+      }
+      return apply(NativeConstructor, this, arguments);
+    };
+    Wrapper.prototype = NativeConstructor.prototype;
+    return Wrapper;
+  };
+  var _export = function(options, source) {
+    var TARGET = options.target;
+    var GLOBAL = options.global;
+    var STATIC = options.stat;
+    var PROTO = options.proto;
+    var nativeSource = GLOBAL ? globalThis$1 : STATIC ? globalThis$1[TARGET] : globalThis$1[TARGET] && globalThis$1[TARGET].prototype;
+    var target = GLOBAL ? path : path[TARGET] || createNonEnumerableProperty(path, TARGET, {})[TARGET];
+    var targetPrototype = target.prototype;
+    var FORCED2, USE_NATIVE, VIRTUAL_PROTOTYPE;
+    var key2, sourceProperty, targetProperty, nativeProperty, resultProperty, descriptor;
+    for (key2 in source) {
+      FORCED2 = isForced(GLOBAL ? key2 : TARGET + (STATIC ? "." : "#") + key2, options.forced);
+      USE_NATIVE = !FORCED2 && nativeSource && hasOwn$4(nativeSource, key2);
+      targetProperty = target[key2];
+      if (USE_NATIVE) if (options.dontCallGetSet) {
+        descriptor = getOwnPropertyDescriptor$1(nativeSource, key2);
+        nativeProperty = descriptor && descriptor.value;
+      } else nativeProperty = nativeSource[key2];
+      sourceProperty = USE_NATIVE && nativeProperty ? nativeProperty : source[key2];
+      if (!FORCED2 && !PROTO && typeof targetProperty == typeof sourceProperty) continue;
+      if (options.bind && USE_NATIVE) resultProperty = bind$5(sourceProperty, globalThis$1);
+      else if (options.wrap && USE_NATIVE) resultProperty = wrapConstructor(sourceProperty);
+      else if (PROTO && isCallable$3(sourceProperty)) resultProperty = uncurryThis(sourceProperty);
+      else resultProperty = sourceProperty;
+      if (options.sham || sourceProperty && sourceProperty.sham || targetProperty && targetProperty.sham) {
+        createNonEnumerableProperty(resultProperty, "sham", true);
+      }
+      createNonEnumerableProperty(target, key2, resultProperty);
+      if (PROTO) {
+        VIRTUAL_PROTOTYPE = TARGET + "Prototype";
+        if (!hasOwn$4(path, VIRTUAL_PROTOTYPE)) {
+          createNonEnumerableProperty(path, VIRTUAL_PROTOTYPE, {});
+        }
+        createNonEnumerableProperty(path[VIRTUAL_PROTOTYPE], key2, sourceProperty);
+        if (options.real && targetPrototype && (FORCED2 || !targetPrototype[key2])) {
+          createNonEnumerableProperty(targetPrototype, key2, sourceProperty);
+        }
+      }
+    }
+  };
+  var $ = _export;
+  var defineProperty$c = require$$0$r.f;
+  $({ target: "Object", stat: true, forced: Object.defineProperty !== defineProperty$c, sham: !DESCRIPTORS }, {
+    defineProperty: defineProperty$c
+  });
+  var defineProperty_1 = createCommonjsModule(function(module2) {
+    var Object2 = path.Object;
+    var defineProperty2 = module2.exports = function defineProperty3(it, key2, desc) {
+      return Object2.defineProperty(it, key2, desc);
+    };
+    if (Object2.defineProperty.sham) defineProperty2.sham = true;
+  });
+  var parent$D = defineProperty_1;
+  var defineProperty$b = parent$D;
+  var parent$C = defineProperty$b;
+  var defineProperty$a = parent$C;
+  var iterators = {};
+  var WeakMap$2 = globalThis$1.WeakMap;
+  var weakMapBasicDetection = isCallable$3(WeakMap$2) && /native code/.test(String(WeakMap$2));
+  var keys$7 = shared$1("keys");
+  var sharedKey$1 = function(key2) {
+    return keys$7[key2] || (keys$7[key2] = uid(key2));
+  };
+  var hiddenKeys$2 = {};
+  var NATIVE_WEAK_MAP = weakMapBasicDetection;
+  var sharedKey = sharedKey$1;
+  var hiddenKeys$1 = hiddenKeys$2;
+  var OBJECT_ALREADY_INITIALIZED = "Object already initialized";
+  var TypeError$2 = globalThis$1.TypeError;
+  var WeakMap$1 = globalThis$1.WeakMap;
+  var set$4, get$1, has$6;
+  var enforce = function(it) {
+    return has$6(it) ? get$1(it) : set$4(it, {});
+  };
+  var getterFor = function(TYPE) {
+    return function(it) {
+      var state;
+      if (!isObject(it) || (state = get$1(it)).type !== TYPE) {
+        throw new TypeError$2("Incompatible receiver, " + TYPE + " required");
+      }
+      return state;
+    };
+  };
+  if (NATIVE_WEAK_MAP || store$1.state) {
+    var store = store$1.state || (store$1.state = new WeakMap$1());
+    store.get = store.get;
+    store.has = store.has;
+    store.set = store.set;
+    set$4 = function(it, metadata) {
+      if (store.has(it)) throw new TypeError$2(OBJECT_ALREADY_INITIALIZED);
+      metadata.facade = it;
+      store.set(it, metadata);
+      return metadata;
+    };
+    get$1 = function(it) {
+      return store.get(it) || {};
+    };
+    has$6 = function(it) {
+      return store.has(it);
+    };
+  } else {
+    var STATE = sharedKey("state");
+    hiddenKeys$1[STATE] = true;
+    set$4 = function(it, metadata) {
+      if (hasOwn$4(it, STATE)) throw new TypeError$2(OBJECT_ALREADY_INITIALIZED);
+      metadata.facade = it;
+      createNonEnumerableProperty(it, STATE, metadata);
+      return metadata;
+    };
+    get$1 = function(it) {
+      return hasOwn$4(it, STATE) ? it[STATE] : {};
+    };
+    has$6 = function(it) {
+      return hasOwn$4(it, STATE);
+    };
+  }
+  var internalState = {
+    set: set$4,
+    get: get$1,
+    has: has$6,
+    enforce,
+    getterFor
+  };
+  var FunctionPrototype$1 = Function.prototype;
+  var getDescriptor = DESCRIPTORS && Object.getOwnPropertyDescriptor;
+  var EXISTS = hasOwn$4(FunctionPrototype$1, "name");
+  var PROPER = EXISTS && (function something() {
+  }).name === "something";
+  var CONFIGURABLE = EXISTS && (!DESCRIPTORS || DESCRIPTORS && getDescriptor(FunctionPrototype$1, "name").configurable);
+  var functionName = {
+    EXISTS,
+    PROPER,
+    CONFIGURABLE
+  };
+  var ceil$1 = Math.ceil;
+  var floor$2 = Math.floor;
+  var mathTrunc = Math.trunc || function trunc2(x2) {
+    var n2 = +x2;
+    return (n2 > 0 ? floor$2 : ceil$1)(n2);
+  };
+  var trunc = mathTrunc;
+  var toIntegerOrInfinity$1 = function(argument) {
+    var number = +argument;
+    return number !== number || number === 0 ? 0 : trunc(number);
+  };
+  var toIntegerOrInfinity = toIntegerOrInfinity$1;
+  var max$2 = Math.max;
+  var min$1$1 = Math.min;
+  var toAbsoluteIndex$1 = function(index2, length) {
+    var integer = toIntegerOrInfinity(index2);
+    return integer < 0 ? max$2(integer + length, 0) : min$1$1(integer, length);
+  };
+  var min$2 = Math.min;
+  var toLength$1 = function(argument) {
+    var len = toIntegerOrInfinity(argument);
+    return len > 0 ? min$2(len, 9007199254740991) : 0;
+  };
+  var toLength$3 = toLength$1;
+  var lengthOfArrayLike$1 = function(obj) {
+    return toLength$3(obj.length);
+  };
+  var toAbsoluteIndex = toAbsoluteIndex$1;
+  var lengthOfArrayLike = lengthOfArrayLike$1;
+  var createMethod$3 = function(IS_INCLUDES) {
+    return function($this, el, fromIndex) {
+      var O2 = toIndexedObject($this);
+      var length = lengthOfArrayLike(O2);
+      if (length === 0) return !IS_INCLUDES && -1;
+      var index2 = toAbsoluteIndex(fromIndex, length);
+      var value;
+      if (IS_INCLUDES && el !== el) while (length > index2) {
+        value = O2[index2++];
+        if (value !== value) return true;
+      }
+      else for (; length > index2; index2++) {
+        if ((IS_INCLUDES || index2 in O2) && O2[index2] === el) return IS_INCLUDES || index2 || 0;
+      }
+      return !IS_INCLUDES && -1;
+    };
+  };
+  var arrayIncludes = {
+    // `Array.prototype.includes` method
+    // https://tc39.es/ecma262/#sec-array.prototype.includes
+    includes: createMethod$3(true),
+    // `Array.prototype.indexOf` method
+    // https://tc39.es/ecma262/#sec-array.prototype.indexof
+    indexOf: createMethod$3(false)
+  };
+  var require$$0$q = arrayIncludes;
+  var indexOf$1 = require$$0$q.indexOf;
+  var push$a = uncurryThis$1([].push);
+  var objectKeysInternal = function(object, names) {
+    var O2 = toIndexedObject(object);
+    var i2 = 0;
+    var result = [];
+    var key2;
+    for (key2 in O2) !hasOwn$4(hiddenKeys$1, key2) && hasOwn$4(O2, key2) && push$a(result, key2);
+    while (names.length > i2) if (hasOwn$4(O2, key2 = names[i2++])) {
+      ~indexOf$1(result, key2) || push$a(result, key2);
+    }
+    return result;
+  };
+  var enumBugKeys$1 = [
+    "constructor",
+    "hasOwnProperty",
+    "isPrototypeOf",
+    "propertyIsEnumerable",
+    "toLocaleString",
+    "toString",
+    "valueOf"
+  ];
+  var internalObjectKeys = objectKeysInternal;
+  var enumBugKeys = enumBugKeys$1;
+  var objectKeys$3 = Object.keys || function keys2(O2) {
+    return internalObjectKeys(O2, enumBugKeys);
+  };
+  var nativeKeys = objectKeys$3;
+  var f$4 = DESCRIPTORS && !V8_PROTOTYPE_DEFINE_BUG ? Object.defineProperties : function defineProperties2(O2, Properties) {
+    anObject(O2);
+    var props = toIndexedObject(Properties);
+    var keys2 = nativeKeys(Properties);
+    var length = keys2.length;
+    var index2 = 0;
+    var key2;
+    while (length > index2) require$$0$r.f(O2, key2 = keys2[index2++], props[key2]);
+    return O2;
+  };
+  var objectDefineProperties = {
+    f: f$4
+  };
+  var html$1 = getBuiltIn("document", "documentElement");
+  var definePropertiesModule = objectDefineProperties;
+  var html = html$1;
+  var GT = ">";
+  var LT = "<";
+  var PROTOTYPE$1 = "prototype";
+  var SCRIPT = "script";
+  var IE_PROTO$1 = sharedKey("IE_PROTO");
+  var EmptyConstructor = function() {
+  };
+  var scriptTag = function(content) {
+    return LT + SCRIPT + GT + content + LT + "/" + SCRIPT + GT;
+  };
+  var NullProtoObjectViaActiveX = function(activeXDocument2) {
+    activeXDocument2.write(scriptTag(""));
+    activeXDocument2.close();
+    var temp = activeXDocument2.parentWindow.Object;
+    activeXDocument2 = null;
+    return temp;
+  };
+  var NullProtoObjectViaIFrame = function() {
+    var iframe = documentCreateElement("iframe");
+    var JS = "java" + SCRIPT + ":";
+    var iframeDocument;
+    iframe.style.display = "none";
+    html.appendChild(iframe);
+    iframe.src = String(JS);
+    iframeDocument = iframe.contentWindow.document;
+    iframeDocument.open();
+    iframeDocument.write(scriptTag("document.F=Object"));
+    iframeDocument.close();
+    return iframeDocument.F;
+  };
+  var activeXDocument;
+  var NullProtoObject = function() {
+    try {
+      activeXDocument = new ActiveXObject("htmlfile");
+    } catch (error) {
+    }
+    NullProtoObject = typeof document != "undefined" ? document.domain && activeXDocument ? NullProtoObjectViaActiveX(activeXDocument) : NullProtoObjectViaIFrame() : NullProtoObjectViaActiveX(activeXDocument);
+    var length = enumBugKeys.length;
+    while (length--) delete NullProtoObject[PROTOTYPE$1][enumBugKeys[length]];
+    return NullProtoObject();
+  };
+  hiddenKeys$1[IE_PROTO$1] = true;
+  var objectCreate = Object.create || function create(O2, Properties) {
+    var result;
+    if (O2 !== null) {
+      EmptyConstructor[PROTOTYPE$1] = anObject(O2);
+      result = new EmptyConstructor();
+      EmptyConstructor[PROTOTYPE$1] = null;
+      result[IE_PROTO$1] = O2;
+    } else result = NullProtoObject();
+    return Properties === void 0 ? result : definePropertiesModule.f(result, Properties);
+  };
+  var correctPrototypeGetter = !fails(function() {
+    function F2() {
+    }
+    F2.prototype.constructor = null;
+    return Object.getPrototypeOf(new F2()) !== F2.prototype;
+  });
+  var CORRECT_PROTOTYPE_GETTER = correctPrototypeGetter;
+  var IE_PROTO = sharedKey("IE_PROTO");
+  var $Object$1$1 = Object;
+  var ObjectPrototype$1 = $Object$1$1.prototype;
+  var objectGetPrototypeOf = CORRECT_PROTOTYPE_GETTER ? $Object$1$1.getPrototypeOf : function(O2) {
+    var object = toObject$1(O2);
+    if (hasOwn$4(object, IE_PROTO)) return object[IE_PROTO];
+    var constructor = object.constructor;
+    if (isCallable$3(constructor) && object instanceof constructor) {
+      return constructor.prototype;
+    }
+    return object instanceof $Object$1$1 ? ObjectPrototype$1 : null;
+  };
+  var defineBuiltIn$1 = function(target, key2, value, options) {
+    if (options && options.enumerable) target[key2] = value;
+    else createNonEnumerableProperty(target, key2, value);
+    return target;
+  };
+  var nativeObjectCreate = objectCreate;
+  var getPrototypeOf$1 = objectGetPrototypeOf;
+  var defineBuiltIn = defineBuiltIn$1;
+  var ITERATOR$4 = wellKnownSymbol("iterator");
+  var BUGGY_SAFARI_ITERATORS$1 = false;
+  var IteratorPrototype$2, PrototypeOfArrayIteratorPrototype, arrayIterator;
+  if ([].keys) {
+    arrayIterator = [].keys();
+    if (!("next" in arrayIterator)) BUGGY_SAFARI_ITERATORS$1 = true;
+    else {
+      PrototypeOfArrayIteratorPrototype = getPrototypeOf$1(getPrototypeOf$1(arrayIterator));
+      if (PrototypeOfArrayIteratorPrototype !== Object.prototype) IteratorPrototype$2 = PrototypeOfArrayIteratorPrototype;
+    }
+  }
+  var NEW_ITERATOR_PROTOTYPE = !isObject(IteratorPrototype$2) || fails(function() {
+    var test2 = {};
+    return IteratorPrototype$2[ITERATOR$4].call(test2) !== test2;
+  });
+  if (NEW_ITERATOR_PROTOTYPE) IteratorPrototype$2 = {};
+  else IteratorPrototype$2 = nativeObjectCreate(IteratorPrototype$2);
+  if (!isCallable$3(IteratorPrototype$2[ITERATOR$4])) {
+    defineBuiltIn(IteratorPrototype$2, ITERATOR$4, function() {
+      return this;
+    });
+  }
+  var iteratorsCore = {
+    IteratorPrototype: IteratorPrototype$2,
+    BUGGY_SAFARI_ITERATORS: BUGGY_SAFARI_ITERATORS$1
+  };
+  var TO_STRING_TAG$2 = wellKnownSymbol("toStringTag");
+  var test$7 = {};
+  test$7[TO_STRING_TAG$2] = "z";
+  var toStringTagSupport = String(test$7) === "[object z]";
+  var TO_STRING_TAG_SUPPORT = toStringTagSupport;
+  var TO_STRING_TAG$1 = wellKnownSymbol("toStringTag");
+  var $Object$5 = Object;
+  var CORRECT_ARGUMENTS = classof$2(/* @__PURE__ */ function() {
+    return arguments;
+  }()) === "Arguments";
+  var tryGet = function(it, key2) {
+    try {
+      return it[key2];
+    } catch (error) {
+    }
+  };
+  var classof$1 = TO_STRING_TAG_SUPPORT ? classof$2 : function(it) {
+    var O2, tag, result;
+    return it === void 0 ? "Undefined" : it === null ? "Null" : typeof (tag = tryGet(O2 = $Object$5(it), TO_STRING_TAG$1)) == "string" ? tag : CORRECT_ARGUMENTS ? classof$2(O2) : (result = classof$2(O2)) === "Object" && isCallable$3(O2.callee) ? "Arguments" : result;
+  };
+  var classof = classof$1;
+  var objectToString$1 = TO_STRING_TAG_SUPPORT ? {}.toString : function toString2() {
+    return "[object " + classof(this) + "]";
+  };
+  var toString$2 = objectToString$1;
+  var defineProperty$9 = require$$0$r.f;
+  var TO_STRING_TAG = wellKnownSymbol("toStringTag");
+  var setToStringTag$1 = function(it, TAG, STATIC, SET_METHOD) {
+    var target = STATIC ? it : it && it.prototype;
+    if (target) {
+      if (!hasOwn$4(target, TO_STRING_TAG)) {
+        defineProperty$9(target, TO_STRING_TAG, { configurable: true, value: TAG });
+      }
+      if (SET_METHOD && !TO_STRING_TAG_SUPPORT) {
+        createNonEnumerableProperty(target, "toString", toString$2);
+      }
+    }
+  };
+  var IteratorsCore = iteratorsCore;
+  var setToStringTag = setToStringTag$1;
+  var Iterators = iterators;
+  var IteratorPrototype$1 = IteratorsCore.IteratorPrototype;
+  var returnThis$1 = function() {
+    return this;
+  };
+  var iteratorCreateConstructor = function(IteratorConstructor, NAME, next, ENUMERABLE_NEXT) {
+    var TO_STRING_TAG2 = NAME + " Iterator";
+    IteratorConstructor.prototype = nativeObjectCreate(IteratorPrototype$1, { next: createPropertyDescriptor(+!ENUMERABLE_NEXT, next) });
+    setToStringTag(IteratorConstructor, TO_STRING_TAG2, false, true);
+    Iterators[TO_STRING_TAG2] = returnThis$1;
+    return IteratorConstructor;
+  };
+  var functionUncurryThisAccessor = function(object, key2, method2) {
+    try {
+      return uncurryThis$1(aCallable(Object.getOwnPropertyDescriptor(object, key2)[method2]));
+    } catch (error) {
+    }
+  };
+  var isPossiblePrototype$1 = function(argument) {
+    return isObject(argument) || argument === null;
+  };
+  var isPossiblePrototype = isPossiblePrototype$1;
+  var $String$2 = String;
+  var $TypeError$7$1 = TypeError;
+  var aPossiblePrototype$1 = function(argument) {
+    if (isPossiblePrototype(argument)) return argument;
+    throw new $TypeError$7$1("Can't set " + $String$2(argument) + " as a prototype");
+  };
+  var uncurryThisAccessor = functionUncurryThisAccessor;
+  var aPossiblePrototype = aPossiblePrototype$1;
+  Object.setPrototypeOf || ("__proto__" in {} ? function() {
+    var CORRECT_SETTER = false;
+    var test2 = {};
+    var setter;
+    try {
+      setter = uncurryThisAccessor(Object.prototype, "__proto__", "set");
+      setter(test2, []);
+      CORRECT_SETTER = test2 instanceof Array;
+    } catch (error) {
+    }
+    return function setPrototypeOf(O2, proto) {
+      requireObjectCoercible(O2);
+      aPossiblePrototype(proto);
+      if (!isObject(O2)) return O2;
+      if (CORRECT_SETTER) setter(O2, proto);
+      else O2.__proto__ = proto;
+      return O2;
+    };
+  }() : void 0);
+  var FunctionName = functionName;
+  var createIteratorConstructor = iteratorCreateConstructor;
+  var PROPER_FUNCTION_NAME = FunctionName.PROPER;
+  var BUGGY_SAFARI_ITERATORS = IteratorsCore.BUGGY_SAFARI_ITERATORS;
+  var ITERATOR$3 = wellKnownSymbol("iterator");
+  var KEYS = "keys";
+  var VALUES = "values";
+  var ENTRIES = "entries";
+  var returnThis = function() {
+    return this;
+  };
+  var iteratorDefine = function(Iterable, NAME, IteratorConstructor, next, DEFAULT, IS_SET, FORCED2) {
+    createIteratorConstructor(IteratorConstructor, NAME, next);
+    var getIterationMethod = function(KIND) {
+      if (KIND === DEFAULT && defaultIterator) return defaultIterator;
+      if (!BUGGY_SAFARI_ITERATORS && KIND && KIND in IterablePrototype) return IterablePrototype[KIND];
+      switch (KIND) {
+        case KEYS:
+          return function keys2() {
+            return new IteratorConstructor(this, KIND);
+          };
+        case VALUES:
+          return function values() {
+            return new IteratorConstructor(this, KIND);
+          };
+        case ENTRIES:
+          return function entries2() {
+            return new IteratorConstructor(this, KIND);
+          };
+      }
+      return function() {
+        return new IteratorConstructor(this);
+      };
+    };
+    var TO_STRING_TAG2 = NAME + " Iterator";
+    var INCORRECT_VALUES_NAME = false;
+    var IterablePrototype = Iterable.prototype;
+    var nativeIterator = IterablePrototype[ITERATOR$3] || IterablePrototype["@@iterator"] || DEFAULT && IterablePrototype[DEFAULT];
+    var defaultIterator = !BUGGY_SAFARI_ITERATORS && nativeIterator || getIterationMethod(DEFAULT);
+    var anyNativeIterator = NAME === "Array" ? IterablePrototype.entries || nativeIterator : nativeIterator;
+    var CurrentIteratorPrototype, methods, KEY;
+    if (anyNativeIterator) {
+      CurrentIteratorPrototype = getPrototypeOf$1(anyNativeIterator.call(new Iterable()));
+      if (CurrentIteratorPrototype !== Object.prototype && CurrentIteratorPrototype.next) {
+        setToStringTag(CurrentIteratorPrototype, TO_STRING_TAG2, true, true);
+        Iterators[TO_STRING_TAG2] = returnThis;
+      }
+    }
+    if (PROPER_FUNCTION_NAME && DEFAULT === VALUES && nativeIterator && nativeIterator.name !== VALUES) {
+      {
+        INCORRECT_VALUES_NAME = true;
+        defaultIterator = function values() {
+          return call$4(nativeIterator, this);
+        };
+      }
+    }
+    if (DEFAULT) {
+      methods = {
+        values: getIterationMethod(VALUES),
+        keys: IS_SET ? defaultIterator : getIterationMethod(KEYS),
+        entries: getIterationMethod(ENTRIES)
+      };
+      if (FORCED2) for (KEY in methods) {
+        if (BUGGY_SAFARI_ITERATORS || INCORRECT_VALUES_NAME || !(KEY in IterablePrototype)) {
+          defineBuiltIn(IterablePrototype, KEY, methods[KEY]);
+        }
+      }
+      else $({ target: NAME, proto: true, forced: BUGGY_SAFARI_ITERATORS || INCORRECT_VALUES_NAME }, methods);
+    }
+    if (FORCED2 && IterablePrototype[ITERATOR$3] !== defaultIterator) {
+      defineBuiltIn(IterablePrototype, ITERATOR$3, defaultIterator, { name: DEFAULT });
+    }
+    Iterators[NAME] = defaultIterator;
+    return methods;
+  };
+  var createIterResultObject$1 = function(value, done) {
+    return { value, done };
+  };
+  var InternalStateModule = internalState;
+  var defineIterator = iteratorDefine;
+  var createIterResultObject = createIterResultObject$1;
+  require$$0$r.f;
+  var ARRAY_ITERATOR = "Array Iterator";
+  var setInternalState$4 = InternalStateModule.set;
+  var getInternalState$2 = InternalStateModule.getterFor(ARRAY_ITERATOR);
+  defineIterator(Array, "Array", function(iterated, kind) {
+    setInternalState$4(this, {
+      type: ARRAY_ITERATOR,
+      target: toIndexedObject(iterated),
+      // target
+      index: 0,
+      // next index
+      kind
+      // kind
+    });
+  }, function() {
+    var state = getInternalState$2(this);
+    var target = state.target;
+    var index2 = state.index++;
+    if (!target || index2 >= target.length) {
+      state.target = null;
+      return createIterResultObject(void 0, true);
+    }
+    switch (state.kind) {
+      case "keys":
+        return createIterResultObject(index2, false);
+      case "values":
+        return createIterResultObject(target[index2], false);
+    }
+    return createIterResultObject([index2, target[index2]], false);
+  }, "values");
+  Iterators.Arguments = Iterators.Array;
+  var hiddenKeys = enumBugKeys.concat("length", "prototype");
+  var f$3 = Object.getOwnPropertyNames || function getOwnPropertyNames2(O2) {
+    return internalObjectKeys(O2, hiddenKeys);
+  };
+  var objectGetOwnPropertyNames = {
+    f: f$3
+  };
+  var arraySlice = uncurryThis$1([].slice);
+  var getOwnPropertyNamesModule = objectGetOwnPropertyNames;
+  var nativeSlice = arraySlice;
+  var $getOwnPropertyNames$1 = getOwnPropertyNamesModule.f;
+  var windowNames = typeof window == "object" && window && Object.getOwnPropertyNames ? Object.getOwnPropertyNames(window) : [];
+  var getWindowNames = function(it) {
+    try {
+      return $getOwnPropertyNames$1(it);
+    } catch (error) {
+      return nativeSlice(windowNames);
+    }
+  };
+  var f$2 = function getOwnPropertyNames2(it) {
+    return windowNames && classof$2(it) === "Window" ? getWindowNames(it) : $getOwnPropertyNames$1(toIndexedObject(it));
+  };
+  var objectGetOwnPropertyNamesExternal = {
+    f: f$2
+  };
+  var arrayBufferNonExtensible = fails(function() {
+    if (typeof ArrayBuffer == "function") {
+      var buffer = new ArrayBuffer(8);
+      if (Object.isExtensible(buffer)) Object.defineProperty(buffer, "a", { value: 8 });
+    }
+  });
+  var ARRAY_BUFFER_NON_EXTENSIBLE = arrayBufferNonExtensible;
+  var $isExtensible = Object.isExtensible;
+  var FAILS_ON_PRIMITIVES$1 = fails(function() {
+    $isExtensible(1);
+  });
+  var objectIsExtensible = FAILS_ON_PRIMITIVES$1 || ARRAY_BUFFER_NON_EXTENSIBLE ? function isExtensible2(it) {
+    if (!isObject(it)) return false;
+    if (ARRAY_BUFFER_NON_EXTENSIBLE && classof$2(it) === "ArrayBuffer") return false;
+    return $isExtensible ? $isExtensible(it) : true;
+  } : $isExtensible;
+  var freezing = !fails(function() {
+    return Object.isExtensible(Object.preventExtensions({}));
+  });
+  var getOwnPropertyNamesExternal = objectGetOwnPropertyNamesExternal;
+  var isExtensible = objectIsExtensible;
+  var FREEZING = freezing;
+  var internalMetadata = createCommonjsModule(function(module2) {
+    var defineProperty2 = require$$0$r.f;
+    var REQUIRED = false;
+    var METADATA2 = uid("meta");
+    var id2 = 0;
+    var setMetadata = function(it) {
+      defineProperty2(it, METADATA2, { value: {
+        objectID: "O" + id2++,
+        // object ID
+        weakData: {}
+        // weak collections IDs
+      } });
+    };
+    var fastKey2 = function(it, create) {
+      if (!isObject(it)) return typeof it == "symbol" ? it : (typeof it == "string" ? "S" : "P") + it;
+      if (!hasOwn$4(it, METADATA2)) {
+        if (!isExtensible(it)) return "F";
+        if (!create) return "E";
+        setMetadata(it);
+      }
+      return it[METADATA2].objectID;
+    };
+    var getWeakData = function(it, create) {
+      if (!hasOwn$4(it, METADATA2)) {
+        if (!isExtensible(it)) return true;
+        if (!create) return false;
+        setMetadata(it);
+      }
+      return it[METADATA2].weakData;
+    };
+    var onFreeze = function(it) {
+      if (FREEZING && REQUIRED && isExtensible(it) && !hasOwn$4(it, METADATA2)) setMetadata(it);
+      return it;
+    };
+    var enable = function() {
+      meta.enable = function() {
+      };
+      REQUIRED = true;
+      var getOwnPropertyNames2 = getOwnPropertyNamesModule.f;
+      var splice = uncurryThis$1([].splice);
+      var test2 = {};
+      test2[METADATA2] = 1;
+      if (getOwnPropertyNames2(test2).length) {
+        getOwnPropertyNamesModule.f = function(it) {
+          var result = getOwnPropertyNames2(it);
+          for (var i2 = 0, length = result.length; i2 < length; i2++) {
+            if (result[i2] === METADATA2) {
+              splice(result, i2, 1);
+              break;
+            }
+          }
+          return result;
+        };
+        $({ target: "Object", stat: true, forced: true }, {
+          getOwnPropertyNames: getOwnPropertyNamesExternal.f
+        });
+      }
+    };
+    var meta = module2.exports = {
+      enable,
+      fastKey: fastKey2,
+      getWeakData,
+      onFreeze
+    };
+    hiddenKeys$1[METADATA2] = true;
+  });
+  var ITERATOR$2 = wellKnownSymbol("iterator");
+  var ArrayPrototype$7 = Array.prototype;
+  var isArrayIteratorMethod$1 = function(it) {
+    return it !== void 0 && (Iterators.Array === it || ArrayPrototype$7[ITERATOR$2] === it);
+  };
+  var ITERATOR$1 = wellKnownSymbol("iterator");
+  var getIteratorMethod$6 = function(it) {
+    if (!isNullOrUndefined(it)) return getMethod(it, ITERATOR$1) || getMethod(it, "@@iterator") || Iterators[classof(it)];
+  };
+  var getIteratorMethod$5 = getIteratorMethod$6;
+  var $TypeError$6$1 = TypeError;
+  var getIterator$6 = function(argument, usingIterator) {
+    var iteratorMethod = arguments.length < 2 ? getIteratorMethod$5(argument) : usingIterator;
+    if (aCallable(iteratorMethod)) return anObject(call$4(iteratorMethod, argument));
+    throw new $TypeError$6$1(tryToString(argument) + " is not iterable");
+  };
+  var iteratorClose$1 = function(iterator2, kind, value) {
+    var innerResult, innerError;
+    anObject(iterator2);
+    try {
+      innerResult = getMethod(iterator2, "return");
+      if (!innerResult) {
+        if (kind === "throw") throw value;
+        return value;
+      }
+      innerResult = call$4(innerResult, iterator2);
+    } catch (error) {
+      innerError = true;
+      innerResult = error;
+    }
+    if (kind === "throw") throw value;
+    if (innerError) throw innerResult;
+    anObject(innerResult);
+    return value;
+  };
+  var isArrayIteratorMethod = isArrayIteratorMethod$1;
+  var getIterator$5 = getIterator$6;
+  var iteratorClose = iteratorClose$1;
+  var $TypeError$5$1 = TypeError;
+  var Result = function(stopped, result) {
+    this.stopped = stopped;
+    this.result = result;
+  };
+  var ResultPrototype = Result.prototype;
+  var iterate$2 = function(iterable, unboundFunction, options) {
+    var that = options && options.that;
+    var AS_ENTRIES = !!(options && options.AS_ENTRIES);
+    var IS_RECORD = !!(options && options.IS_RECORD);
+    var IS_ITERATOR = !!(options && options.IS_ITERATOR);
+    var INTERRUPTED = !!(options && options.INTERRUPTED);
+    var fn2 = bind$5(unboundFunction, that);
+    var iterator2, iterFn, index2, length, result, next, step;
+    var stop = function(condition) {
+      if (iterator2) iteratorClose(iterator2, "normal", condition);
+      return new Result(true, condition);
+    };
+    var callFn = function(value) {
+      if (AS_ENTRIES) {
+        anObject(value);
+        return INTERRUPTED ? fn2(value[0], value[1], stop) : fn2(value[0], value[1]);
+      }
+      return INTERRUPTED ? fn2(value, stop) : fn2(value);
+    };
+    if (IS_RECORD) {
+      iterator2 = iterable.iterator;
+    } else if (IS_ITERATOR) {
+      iterator2 = iterable;
+    } else {
+      iterFn = getIteratorMethod$5(iterable);
+      if (!iterFn) throw new $TypeError$5$1(tryToString(iterable) + " is not iterable");
+      if (isArrayIteratorMethod(iterFn)) {
+        for (index2 = 0, length = lengthOfArrayLike(iterable); length > index2; index2++) {
+          result = callFn(iterable[index2]);
+          if (result && isPrototypeOf(ResultPrototype, result)) return result;
+        }
+        return new Result(false);
+      }
+      iterator2 = getIterator$5(iterable, iterFn);
+    }
+    next = IS_RECORD ? iterable.next : iterator2.next;
+    while (!(step = call$4(next, iterator2)).done) {
+      try {
+        result = callFn(step.value);
+      } catch (error) {
+        iteratorClose(iterator2, "throw", error);
+      }
+      if (typeof result == "object" && result && isPrototypeOf(ResultPrototype, result)) return result;
+    }
+    return new Result(false);
+  };
+  var $TypeError$4$1 = TypeError;
+  var anInstance$1 = function(it, Prototype) {
+    if (isPrototypeOf(Prototype, it)) return it;
+    throw new $TypeError$4$1("Incorrect invocation");
+  };
+  var isArray$7 = Array.isArray || function isArray2(argument) {
+    return classof$2(argument) === "Array";
+  };
+  var functionToString$1 = uncurryThis$1(Function.toString);
+  if (!isCallable$3(store$1.inspectSource)) {
+    store$1.inspectSource = function(it) {
+      return functionToString$1(it);
+    };
+  }
+  var inspectSource$1 = store$1.inspectSource;
+  var inspectSource = inspectSource$1;
+  var noop = function() {
+  };
+  var construct = getBuiltIn("Reflect", "construct");
+  var constructorRegExp = /^\s*(?:class|function)\b/;
+  var exec$1 = uncurryThis$1(constructorRegExp.exec);
+  var INCORRECT_TO_STRING = !constructorRegExp.test(noop);
+  var isConstructorModern = function isConstructor2(argument) {
+    if (!isCallable$3(argument)) return false;
+    try {
+      construct(noop, [], argument);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  };
+  var isConstructorLegacy = function isConstructor2(argument) {
+    if (!isCallable$3(argument)) return false;
+    switch (classof(argument)) {
+      case "AsyncFunction":
+      case "GeneratorFunction":
+      case "AsyncGeneratorFunction":
+        return false;
+    }
+    try {
+      return INCORRECT_TO_STRING || !!exec$1(constructorRegExp, inspectSource(argument));
+    } catch (error) {
+      return true;
+    }
+  };
+  isConstructorLegacy.sham = true;
+  var isConstructor$1 = !construct || fails(function() {
+    var called2;
+    return isConstructorModern(isConstructorModern.call) || !isConstructorModern(Object) || !isConstructorModern(function() {
+      called2 = true;
+    }) || called2;
+  }) ? isConstructorLegacy : isConstructorModern;
+  var isArray$6 = isArray$7;
+  var isConstructor = isConstructor$1;
+  var SPECIES$3 = wellKnownSymbol("species");
+  var $Array$2 = Array;
+  var arraySpeciesConstructor$1 = function(originalArray) {
+    var C2;
+    if (isArray$6(originalArray)) {
+      C2 = originalArray.constructor;
+      if (isConstructor(C2) && (C2 === $Array$2 || isArray$6(C2.prototype))) C2 = void 0;
+      else if (isObject(C2)) {
+        C2 = C2[SPECIES$3];
+        if (C2 === null) C2 = void 0;
+      }
+    }
+    return C2 === void 0 ? $Array$2 : C2;
+  };
+  var arraySpeciesConstructor = arraySpeciesConstructor$1;
+  var arraySpeciesCreate$1 = function(originalArray, length) {
+    return new (arraySpeciesConstructor(originalArray))(length === 0 ? 0 : length);
+  };
+  var arraySpeciesCreate = arraySpeciesCreate$1;
+  var push$9 = uncurryThis$1([].push);
+  var createMethod$2 = function(TYPE) {
+    var IS_MAP = TYPE === 1;
+    var IS_FILTER = TYPE === 2;
+    var IS_SOME = TYPE === 3;
+    var IS_EVERY = TYPE === 4;
+    var IS_FIND_INDEX = TYPE === 6;
+    var IS_FILTER_REJECT = TYPE === 7;
+    var NO_HOLES = TYPE === 5 || IS_FIND_INDEX;
+    return function($this, callbackfn, that, specificCreate) {
+      var O2 = toObject$1($this);
+      var self2 = IndexedObject(O2);
+      var length = lengthOfArrayLike(self2);
+      var boundFunction = bind$5(callbackfn, that);
+      var index2 = 0;
+      var create = specificCreate || arraySpeciesCreate;
+      var target = IS_MAP ? create($this, length) : IS_FILTER || IS_FILTER_REJECT ? create($this, 0) : void 0;
+      var value, result;
+      for (; length > index2; index2++) if (NO_HOLES || index2 in self2) {
+        value = self2[index2];
+        result = boundFunction(value, index2, O2);
+        if (TYPE) {
+          if (IS_MAP) target[index2] = result;
+          else if (result) switch (TYPE) {
+            case 3:
+              return true;
+            case 5:
+              return value;
+            case 6:
+              return index2;
+            case 2:
+              push$9(target, value);
+          }
+          else switch (TYPE) {
+            case 4:
+              return false;
+            case 7:
+              push$9(target, value);
+          }
+        }
+      }
+      return IS_FIND_INDEX ? -1 : IS_SOME || IS_EVERY ? IS_EVERY : target;
+    };
+  };
+  var arrayIteration = {
+    // `Array.prototype.forEach` method
+    // https://tc39.es/ecma262/#sec-array.prototype.foreach
+    forEach: createMethod$2(0),
+    // `Array.prototype.map` method
+    // https://tc39.es/ecma262/#sec-array.prototype.map
+    map: createMethod$2(1),
+    // `Array.prototype.filter` method
+    // https://tc39.es/ecma262/#sec-array.prototype.filter
+    filter: createMethod$2(2),
+    // `Array.prototype.some` method
+    // https://tc39.es/ecma262/#sec-array.prototype.some
+    some: createMethod$2(3),
+    // `Array.prototype.every` method
+    // https://tc39.es/ecma262/#sec-array.prototype.every
+    every: createMethod$2(4),
+    // `Array.prototype.find` method
+    // https://tc39.es/ecma262/#sec-array.prototype.find
+    find: createMethod$2(5),
+    // `Array.prototype.findIndex` method
+    // https://tc39.es/ecma262/#sec-array.prototype.findIndex
+    findIndex: createMethod$2(6),
+    // `Array.prototype.filterReject` method
+    // https://github.com/tc39/proposal-array-filtering
+    filterReject: createMethod$2(7)
+  };
+  var require$$0$p = internalMetadata;
+  var iterate$1 = iterate$2;
+  var anInstance = anInstance$1;
+  var require$$0$o = arrayIteration;
+  var defineProperty$7 = require$$0$r.f;
+  var forEach$5 = require$$0$o.forEach;
+  var setInternalState$3 = InternalStateModule.set;
+  var internalStateGetterFor$1 = InternalStateModule.getterFor;
+  var collection$1 = function(CONSTRUCTOR_NAME, wrapper, common) {
+    var IS_MAP = CONSTRUCTOR_NAME.indexOf("Map") !== -1;
+    var IS_WEAK = CONSTRUCTOR_NAME.indexOf("Weak") !== -1;
+    var ADDER = IS_MAP ? "set" : "add";
+    var NativeConstructor = globalThis$1[CONSTRUCTOR_NAME];
+    var NativePrototype = NativeConstructor && NativeConstructor.prototype;
+    var exported2 = {};
+    var Constructor;
+    if (!DESCRIPTORS || !isCallable$3(NativeConstructor) || !(IS_WEAK || NativePrototype.forEach && !fails(function() {
+      new NativeConstructor().entries().next();
+    }))) {
+      Constructor = common.getConstructor(wrapper, CONSTRUCTOR_NAME, IS_MAP, ADDER);
+      require$$0$p.enable();
+    } else {
+      Constructor = wrapper(function(target, iterable) {
+        setInternalState$3(anInstance(target, Prototype), {
+          type: CONSTRUCTOR_NAME,
+          collection: new NativeConstructor()
+        });
+        if (!isNullOrUndefined(iterable)) iterate$1(iterable, target[ADDER], { that: target, AS_ENTRIES: IS_MAP });
+      });
+      var Prototype = Constructor.prototype;
+      var getInternalState2 = internalStateGetterFor$1(CONSTRUCTOR_NAME);
+      forEach$5(["add", "clear", "delete", "forEach", "get", "has", "set", "keys", "values", "entries"], function(KEY) {
+        var IS_ADDER = KEY === "add" || KEY === "set";
+        if (KEY in NativePrototype && !(IS_WEAK && KEY === "clear")) {
+          createNonEnumerableProperty(Prototype, KEY, function(a, b2) {
+            var collection2 = getInternalState2(this).collection;
+            if (!IS_ADDER && IS_WEAK && !isObject(a)) return KEY === "get" ? void 0 : false;
+            var result = collection2[KEY](a === 0 ? 0 : a, b2);
+            return IS_ADDER ? this : result;
+          });
+        }
+      });
+      IS_WEAK || defineProperty$7(Prototype, "size", {
+        configurable: true,
+        get: function() {
+          return getInternalState2(this).collection.size;
+        }
+      });
+    }
+    setToStringTag(Constructor, CONSTRUCTOR_NAME, false, true);
+    exported2[CONSTRUCTOR_NAME] = Constructor;
+    $({ global: true, forced: true }, exported2);
+    if (!IS_WEAK) common.setStrong(Constructor, CONSTRUCTOR_NAME, IS_MAP);
+    return Constructor;
+  };
+  var defineBuiltInAccessor$1 = function(target, name, descriptor) {
+    return require$$0$r.f(target, name, descriptor);
+  };
+  var defineBuiltIns$1 = function(target, src, options) {
+    for (var key2 in src) {
+      if (options && options.unsafe && target[key2]) target[key2] = src[key2];
+      else defineBuiltIn(target, key2, src[key2], options);
+    }
+    return target;
+  };
+  var defineBuiltInAccessor = defineBuiltInAccessor$1;
+  var SPECIES$2 = wellKnownSymbol("species");
+  var setSpecies$1 = function(CONSTRUCTOR_NAME) {
+    var Constructor = getBuiltIn(CONSTRUCTOR_NAME);
+    if (DESCRIPTORS && Constructor && !Constructor[SPECIES$2]) {
+      defineBuiltInAccessor(Constructor, SPECIES$2, {
+        configurable: true,
+        get: function() {
+          return this;
+        }
+      });
+    }
+  };
+  var defineBuiltIns = defineBuiltIns$1;
+  var setSpecies = setSpecies$1;
+  var fastKey = require$$0$p.fastKey;
+  var setInternalState$2 = InternalStateModule.set;
+  var internalStateGetterFor = InternalStateModule.getterFor;
+  var collectionStrong$1 = {
+    getConstructor: function(wrapper, CONSTRUCTOR_NAME, IS_MAP, ADDER) {
+      var Constructor = wrapper(function(that, iterable) {
+        anInstance(that, Prototype);
+        setInternalState$2(that, {
+          type: CONSTRUCTOR_NAME,
+          index: nativeObjectCreate(null),
+          first: null,
+          last: null,
+          size: 0
+        });
+        if (!DESCRIPTORS) that.size = 0;
+        if (!isNullOrUndefined(iterable)) iterate$1(iterable, that[ADDER], { that, AS_ENTRIES: IS_MAP });
+      });
+      var Prototype = Constructor.prototype;
+      var getInternalState2 = internalStateGetterFor(CONSTRUCTOR_NAME);
+      var define3 = function(that, key2, value) {
+        var state = getInternalState2(that);
+        var entry = getEntry(that, key2);
+        var previous, index2;
+        if (entry) {
+          entry.value = value;
+        } else {
+          state.last = entry = {
+            index: index2 = fastKey(key2, true),
+            key: key2,
+            value,
+            previous: previous = state.last,
+            next: null,
+            removed: false
+          };
+          if (!state.first) state.first = entry;
+          if (previous) previous.next = entry;
+          if (DESCRIPTORS) state.size++;
+          else that.size++;
+          if (index2 !== "F") state.index[index2] = entry;
+        }
+        return that;
+      };
+      var getEntry = function(that, key2) {
+        var state = getInternalState2(that);
+        var index2 = fastKey(key2);
+        var entry;
+        if (index2 !== "F") return state.index[index2];
+        for (entry = state.first; entry; entry = entry.next) {
+          if (entry.key === key2) return entry;
+        }
+      };
+      defineBuiltIns(Prototype, {
+        // `{ Map, Set }.prototype.clear()` methods
+        // https://tc39.es/ecma262/#sec-map.prototype.clear
+        // https://tc39.es/ecma262/#sec-set.prototype.clear
+        clear: function clear2() {
+          var that = this;
+          var state = getInternalState2(that);
+          var entry = state.first;
+          while (entry) {
+            entry.removed = true;
+            if (entry.previous) entry.previous = entry.previous.next = null;
+            entry = entry.next;
+          }
+          state.first = state.last = null;
+          state.index = nativeObjectCreate(null);
+          if (DESCRIPTORS) state.size = 0;
+          else that.size = 0;
+        },
+        // `{ Map, Set }.prototype.delete(key)` methods
+        // https://tc39.es/ecma262/#sec-map.prototype.delete
+        // https://tc39.es/ecma262/#sec-set.prototype.delete
+        "delete": function(key2) {
+          var that = this;
+          var state = getInternalState2(that);
+          var entry = getEntry(that, key2);
+          if (entry) {
+            var next = entry.next;
+            var prev = entry.previous;
+            delete state.index[entry.index];
+            entry.removed = true;
+            if (prev) prev.next = next;
+            if (next) next.previous = prev;
+            if (state.first === entry) state.first = next;
+            if (state.last === entry) state.last = prev;
+            if (DESCRIPTORS) state.size--;
+            else that.size--;
+          }
+          return !!entry;
+        },
+        // `{ Map, Set }.prototype.forEach(callbackfn, thisArg = undefined)` methods
+        // https://tc39.es/ecma262/#sec-map.prototype.foreach
+        // https://tc39.es/ecma262/#sec-set.prototype.foreach
+        forEach: function forEach2(callbackfn) {
+          var state = getInternalState2(this);
+          var boundFunction = bind$5(callbackfn, arguments.length > 1 ? arguments[1] : void 0);
+          var entry;
+          while (entry = entry ? entry.next : state.first) {
+            boundFunction(entry.value, entry.key, this);
+            while (entry && entry.removed) entry = entry.previous;
+          }
+        },
+        // `{ Map, Set}.prototype.has(key)` methods
+        // https://tc39.es/ecma262/#sec-map.prototype.has
+        // https://tc39.es/ecma262/#sec-set.prototype.has
+        has: function has2(key2) {
+          return !!getEntry(this, key2);
+        }
+      });
+      defineBuiltIns(Prototype, IS_MAP ? {
+        // `Map.prototype.get(key)` method
+        // https://tc39.es/ecma262/#sec-map.prototype.get
+        get: function get2(key2) {
+          var entry = getEntry(this, key2);
+          return entry && entry.value;
+        },
+        // `Map.prototype.set(key, value)` method
+        // https://tc39.es/ecma262/#sec-map.prototype.set
+        set: function set2(key2, value) {
+          return define3(this, key2 === 0 ? 0 : key2, value);
+        }
+      } : {
+        // `Set.prototype.add(value)` method
+        // https://tc39.es/ecma262/#sec-set.prototype.add
+        add: function add2(value) {
+          return define3(this, value = value === 0 ? 0 : value, value);
+        }
+      });
+      if (DESCRIPTORS) defineBuiltInAccessor(Prototype, "size", {
+        configurable: true,
+        get: function() {
+          return getInternalState2(this).size;
+        }
+      });
+      return Constructor;
+    },
+    setStrong: function(Constructor, CONSTRUCTOR_NAME, IS_MAP) {
+      var ITERATOR_NAME = CONSTRUCTOR_NAME + " Iterator";
+      var getInternalCollectionState = internalStateGetterFor(CONSTRUCTOR_NAME);
+      var getInternalIteratorState = internalStateGetterFor(ITERATOR_NAME);
+      defineIterator(Constructor, CONSTRUCTOR_NAME, function(iterated, kind) {
+        setInternalState$2(this, {
+          type: ITERATOR_NAME,
+          target: iterated,
+          state: getInternalCollectionState(iterated),
+          kind,
+          last: null
+        });
+      }, function() {
+        var state = getInternalIteratorState(this);
+        var kind = state.kind;
+        var entry = state.last;
+        while (entry && entry.removed) entry = entry.previous;
+        if (!state.target || !(state.last = entry = entry ? entry.next : state.state.first)) {
+          state.target = null;
+          return createIterResultObject(void 0, true);
+        }
+        if (kind === "keys") return createIterResultObject(entry.key, false);
+        if (kind === "values") return createIterResultObject(entry.value, false);
+        return createIterResultObject([entry.key, entry.value], false);
+      }, IS_MAP ? "entries" : "values", !IS_MAP, true);
+      setSpecies(CONSTRUCTOR_NAME);
+    }
+  };
+  var collection = collection$1;
+  var collectionStrong = collectionStrong$1;
+  collection("Map", function(init) {
+    return function Map2() {
+      return init(this, arguments.length ? arguments[0] : void 0);
+    };
+  }, collectionStrong);
+  var caller$1 = function(methodName, numArgs) {
+    return numArgs === 1 ? function(object, arg) {
+      return object[methodName](arg);
+    } : function(object, arg1, arg2) {
+      return object[methodName](arg1, arg2);
+    };
+  };
+  var caller = caller$1;
+  var Map$2 = getBuiltIn("Map");
+  var mapHelpers = {
+    Map: Map$2,
+    set: caller("set", 2),
+    get: caller("get", 1),
+    has: caller("has", 1),
+    remove: caller("delete", 1),
+    proto: Map$2.prototype
+  };
+  var MapHelpers = mapHelpers;
+  var Map$1 = MapHelpers.Map;
+  var has$5 = MapHelpers.has;
+  var get$2 = MapHelpers.get;
+  var set$3 = MapHelpers.set;
+  var push$8 = uncurryThis$1([].push);
+  $({ target: "Map", stat: true, forced: IS_PURE }, {
+    groupBy: function groupBy(items, callbackfn) {
+      requireObjectCoercible(items);
+      aCallable(callbackfn);
+      var map2 = new Map$1();
+      var k2 = 0;
+      iterate$1(items, function(value) {
+        var key2 = callbackfn(value, k2++);
+        if (!has$5(map2, key2)) set$3(map2, key2, [value]);
+        else push$8(get$2(map2, key2), value);
+      });
+      return map2;
+    }
+  });
+  var $String$1 = String;
+  var toString$1$1 = function(argument) {
+    if (classof(argument) === "Symbol") throw new TypeError("Cannot convert a Symbol value to a string");
+    return $String$1(argument);
+  };
+  var toString$6 = toString$1$1;
+  var charAt$2 = uncurryThis$1("".charAt);
+  var charCodeAt$1 = uncurryThis$1("".charCodeAt);
+  var stringSlice$1 = uncurryThis$1("".slice);
+  var createMethod$1 = function(CONVERT_TO_STRING) {
+    return function($this, pos) {
+      var S2 = toString$6(requireObjectCoercible($this));
+      var position = toIntegerOrInfinity(pos);
+      var size2 = S2.length;
+      var first, second;
+      if (position < 0 || position >= size2) return CONVERT_TO_STRING ? "" : void 0;
+      first = charCodeAt$1(S2, position);
+      return first < 55296 || first > 56319 || position + 1 === size2 || (second = charCodeAt$1(S2, position + 1)) < 56320 || second > 57343 ? CONVERT_TO_STRING ? charAt$2(S2, position) : first : CONVERT_TO_STRING ? stringSlice$1(S2, position, position + 2) : (first - 55296 << 10) + (second - 56320) + 65536;
+    };
+  };
+  var stringMultibyte = {
+    // `String.prototype.codePointAt` method
+    // https://tc39.es/ecma262/#sec-string.prototype.codepointat
+    codeAt: createMethod$1(false),
+    // `String.prototype.at` method
+    // https://github.com/mathiasbynens/String.prototype.at
+    charAt: createMethod$1(true)
+  };
+  var require$$0$n = stringMultibyte;
+  var charAt$1 = require$$0$n.charAt;
+  var STRING_ITERATOR = "String Iterator";
+  var setInternalState$1 = InternalStateModule.set;
+  var getInternalState$1 = InternalStateModule.getterFor(STRING_ITERATOR);
+  defineIterator(String, "String", function(iterated) {
+    setInternalState$1(this, {
+      type: STRING_ITERATOR,
+      string: toString$6(iterated),
+      index: 0
+    });
+  }, function next() {
+    var state = getInternalState$1(this);
+    var string = state.string;
+    var index2 = state.index;
+    var point;
+    if (index2 >= string.length) return createIterResultObject(void 0, true);
+    point = charAt$1(string, index2);
+    state.index += point.length;
+    return createIterResultObject(point, false);
+  });
+  var map$2 = path.Map;
+  var domIterables = {
+    CSSRuleList: 0,
+    CSSStyleDeclaration: 0,
+    CSSValueList: 0,
+    ClientRectList: 0,
+    DOMRectList: 0,
+    DOMStringList: 0,
+    DOMTokenList: 1,
+    DataTransferItemList: 0,
+    FileList: 0,
+    HTMLAllCollection: 0,
+    HTMLCollection: 0,
+    HTMLFormElement: 0,
+    HTMLSelectElement: 0,
+    MediaList: 0,
+    MimeTypeArray: 0,
+    NamedNodeMap: 0,
+    NodeList: 1,
+    PaintRequestList: 0,
+    Plugin: 0,
+    PluginArray: 0,
+    SVGLengthList: 0,
+    SVGNumberList: 0,
+    SVGPathSegList: 0,
+    SVGPointList: 0,
+    SVGStringList: 0,
+    SVGTransformList: 0,
+    SourceBufferList: 0,
+    StyleSheetList: 0,
+    TextTrackCueList: 0,
+    TextTrackList: 0,
+    TouchList: 0
+  };
+  var DOMIterables$3 = domIterables;
+  for (var COLLECTION_NAME in DOMIterables$3) {
+    setToStringTag(globalThis$1[COLLECTION_NAME], COLLECTION_NAME);
+    Iterators[COLLECTION_NAME] = Iterators.Array;
+  }
+  var parent$B = map$2;
+  var map$1 = parent$B;
+  var require$$0$m = map$1;
+  var map = require$$0$m;
+  var ariaPropsMap_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var _map = interopRequireDefault(map);
+    var ariaPropsMap2 = new _map.default([["aria-activedescendant", {
+      "type": "id"
+    }], ["aria-atomic", {
+      "type": "boolean"
+    }], ["aria-autocomplete", {
+      "type": "token",
+      "values": ["inline", "list", "both", "none"]
+    }], ["aria-busy", {
+      "type": "boolean"
+    }], ["aria-checked", {
+      "type": "tristate"
+    }], ["aria-colcount", {
+      type: "integer"
+    }], ["aria-colindex", {
+      type: "integer"
+    }], ["aria-colspan", {
+      type: "integer"
+    }], ["aria-controls", {
+      "type": "idlist"
+    }], ["aria-current", {
+      type: "token",
+      values: ["page", "step", "location", "date", "time", true, false]
+    }], ["aria-describedby", {
+      "type": "idlist"
+    }], ["aria-details", {
+      "type": "id"
+    }], ["aria-disabled", {
+      "type": "boolean"
+    }], ["aria-dropeffect", {
+      "type": "tokenlist",
+      "values": ["copy", "execute", "link", "move", "none", "popup"]
+    }], ["aria-errormessage", {
+      "type": "id"
+    }], ["aria-expanded", {
+      "type": "boolean",
+      "allowundefined": true
+    }], ["aria-flowto", {
+      "type": "idlist"
+    }], ["aria-grabbed", {
+      "type": "boolean",
+      "allowundefined": true
+    }], ["aria-haspopup", {
+      "type": "token",
+      "values": [false, true, "menu", "listbox", "tree", "grid", "dialog"]
+    }], ["aria-hidden", {
+      "type": "boolean",
+      "allowundefined": true
+    }], ["aria-invalid", {
+      "type": "token",
+      "values": ["grammar", false, "spelling", true]
+    }], ["aria-keyshortcuts", {
+      type: "string"
+    }], ["aria-label", {
+      "type": "string"
+    }], ["aria-labelledby", {
+      "type": "idlist"
+    }], ["aria-level", {
+      "type": "integer"
+    }], ["aria-live", {
+      "type": "token",
+      "values": ["assertive", "off", "polite"]
+    }], ["aria-modal", {
+      type: "boolean"
+    }], ["aria-multiline", {
+      "type": "boolean"
+    }], ["aria-multiselectable", {
+      "type": "boolean"
+    }], ["aria-orientation", {
+      "type": "token",
+      "values": ["vertical", "undefined", "horizontal"]
+    }], ["aria-owns", {
+      "type": "idlist"
+    }], ["aria-placeholder", {
+      type: "string"
+    }], ["aria-posinset", {
+      "type": "integer"
+    }], ["aria-pressed", {
+      "type": "tristate"
+    }], ["aria-readonly", {
+      "type": "boolean"
+    }], ["aria-relevant", {
+      "type": "tokenlist",
+      "values": ["additions", "all", "removals", "text"]
+    }], ["aria-required", {
+      "type": "boolean"
+    }], ["aria-roledescription", {
+      type: "string"
+    }], ["aria-rowcount", {
+      type: "integer"
+    }], ["aria-rowindex", {
+      type: "integer"
+    }], ["aria-rowspan", {
+      type: "integer"
+    }], ["aria-selected", {
+      "type": "boolean",
+      "allowundefined": true
+    }], ["aria-setsize", {
+      "type": "integer"
+    }], ["aria-sort", {
+      "type": "token",
+      "values": ["ascending", "descending", "none", "other"]
+    }], ["aria-valuemax", {
+      "type": "number"
+    }], ["aria-valuemin", {
+      "type": "number"
+    }], ["aria-valuenow", {
+      "type": "number"
+    }], ["aria-valuetext", {
+      "type": "string"
+    }]]);
+    var _default2 = ariaPropsMap2;
+    exports2.default = _default2;
+  });
+  var domMap_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var _map = interopRequireDefault(map);
+    var domMap2 = new _map.default([["a", {
+      reserved: false
+    }], ["abbr", {
+      reserved: false
+    }], ["acronym", {
+      reserved: false
+    }], ["address", {
+      reserved: false
+    }], ["applet", {
+      reserved: false
+    }], ["area", {
+      reserved: false
+    }], ["article", {
+      reserved: false
+    }], ["aside", {
+      reserved: false
+    }], ["audio", {
+      reserved: false
+    }], ["b", {
+      reserved: false
+    }], ["base", {
+      reserved: true
+    }], ["bdi", {
+      reserved: false
+    }], ["bdo", {
+      reserved: false
+    }], ["big", {
+      reserved: false
+    }], ["blink", {
+      reserved: false
+    }], ["blockquote", {
+      reserved: false
+    }], ["body", {
+      reserved: false
+    }], ["br", {
+      reserved: false
+    }], ["button", {
+      reserved: false
+    }], ["canvas", {
+      reserved: false
+    }], ["caption", {
+      reserved: false
+    }], ["center", {
+      reserved: false
+    }], ["cite", {
+      reserved: false
+    }], ["code", {
+      reserved: false
+    }], ["col", {
+      reserved: true
+    }], ["colgroup", {
+      reserved: true
+    }], ["content", {
+      reserved: false
+    }], ["data", {
+      reserved: false
+    }], ["datalist", {
+      reserved: false
+    }], ["dd", {
+      reserved: false
+    }], ["del", {
+      reserved: false
+    }], ["details", {
+      reserved: false
+    }], ["dfn", {
+      reserved: false
+    }], ["dialog", {
+      reserved: false
+    }], ["dir", {
+      reserved: false
+    }], ["div", {
+      reserved: false
+    }], ["dl", {
+      reserved: false
+    }], ["dt", {
+      reserved: false
+    }], ["em", {
+      reserved: false
+    }], ["embed", {
+      reserved: false
+    }], ["fieldset", {
+      reserved: false
+    }], ["figcaption", {
+      reserved: false
+    }], ["figure", {
+      reserved: false
+    }], ["font", {
+      reserved: false
+    }], ["footer", {
+      reserved: false
+    }], ["form", {
+      reserved: false
+    }], ["frame", {
+      reserved: false
+    }], ["frameset", {
+      reserved: false
+    }], ["h1", {
+      reserved: false
+    }], ["h2", {
+      reserved: false
+    }], ["h3", {
+      reserved: false
+    }], ["h4", {
+      reserved: false
+    }], ["h5", {
+      reserved: false
+    }], ["h6", {
+      reserved: false
+    }], ["head", {
+      reserved: true
+    }], ["header", {
+      reserved: false
+    }], ["hgroup", {
+      reserved: false
+    }], ["hr", {
+      reserved: false
+    }], ["html", {
+      reserved: true
+    }], ["i", {
+      reserved: false
+    }], ["iframe", {
+      reserved: false
+    }], ["img", {
+      reserved: false
+    }], ["input", {
+      reserved: false
+    }], ["ins", {
+      reserved: false
+    }], ["kbd", {
+      reserved: false
+    }], ["keygen", {
+      reserved: false
+    }], ["label", {
+      reserved: false
+    }], ["legend", {
+      reserved: false
+    }], ["li", {
+      reserved: false
+    }], ["link", {
+      reserved: true
+    }], ["main", {
+      reserved: false
+    }], ["map", {
+      reserved: false
+    }], ["mark", {
+      reserved: false
+    }], ["marquee", {
+      reserved: false
+    }], ["menu", {
+      reserved: false
+    }], ["menuitem", {
+      reserved: false
+    }], ["meta", {
+      reserved: true
+    }], ["meter", {
+      reserved: false
+    }], ["nav", {
+      reserved: false
+    }], ["noembed", {
+      reserved: true
+    }], ["noscript", {
+      reserved: true
+    }], ["object", {
+      reserved: false
+    }], ["ol", {
+      reserved: false
+    }], ["optgroup", {
+      reserved: false
+    }], ["option", {
+      reserved: false
+    }], ["output", {
+      reserved: false
+    }], ["p", {
+      reserved: false
+    }], ["param", {
+      reserved: true
+    }], ["picture", {
+      reserved: true
+    }], ["pre", {
+      reserved: false
+    }], ["progress", {
+      reserved: false
+    }], ["q", {
+      reserved: false
+    }], ["rp", {
+      reserved: false
+    }], ["rt", {
+      reserved: false
+    }], ["rtc", {
+      reserved: false
+    }], ["ruby", {
+      reserved: false
+    }], ["s", {
+      reserved: false
+    }], ["samp", {
+      reserved: false
+    }], ["script", {
+      reserved: true
+    }], ["section", {
+      reserved: false
+    }], ["select", {
+      reserved: false
+    }], ["small", {
+      reserved: false
+    }], ["source", {
+      reserved: true
+    }], ["spacer", {
+      reserved: false
+    }], ["span", {
+      reserved: false
+    }], ["strike", {
+      reserved: false
+    }], ["strong", {
+      reserved: false
+    }], ["style", {
+      reserved: true
+    }], ["sub", {
+      reserved: false
+    }], ["summary", {
+      reserved: false
+    }], ["sup", {
+      reserved: false
+    }], ["table", {
+      reserved: false
+    }], ["tbody", {
+      reserved: false
+    }], ["td", {
+      reserved: false
+    }], ["textarea", {
+      reserved: false
+    }], ["tfoot", {
+      reserved: false
+    }], ["th", {
+      reserved: false
+    }], ["thead", {
+      reserved: false
+    }], ["time", {
+      reserved: false
+    }], ["title", {
+      reserved: true
+    }], ["tr", {
+      reserved: false
+    }], ["track", {
+      reserved: true
+    }], ["tt", {
+      reserved: false
+    }], ["u", {
+      reserved: false
+    }], ["ul", {
+      reserved: false
+    }], ["var", {
+      reserved: false
+    }], ["video", {
+      reserved: false
+    }], ["wbr", {
+      reserved: false
+    }], ["xmp", {
+      reserved: false
+    }]]);
+    var _default2 = domMap2;
+    exports2.default = _default2;
+  });
+  var getIterator_1 = getIterator$5;
+  var parent$A = getIterator_1;
+  var getIterator$4 = parent$A;
+  var parent$z = getIterator$4;
+  var getIterator$3 = parent$z;
+  var parent$y = getIterator$3;
+  var getIterator$2 = parent$y;
+  var require$$0$l = getIterator$2;
+  var getIterator$1 = require$$0$l;
+  var require$$0$k = getIterator$1;
+  var getIterator$7 = require$$0$k;
+  $({ target: "Array", stat: true }, {
+    isArray: isArray$6
+  });
+  var isArray$5 = path.Array.isArray;
+  var parent$x = isArray$5;
+  var isArray$4 = parent$x;
+  var parent$w = isArray$4;
+  var isArray$3 = parent$w;
+  var getIteratorMethod_1 = getIteratorMethod$5;
+  var parent$v = getIteratorMethod_1;
+  var getIteratorMethod$4 = parent$v;
+  var parent$u = getIteratorMethod$4;
+  var getIteratorMethod$3 = parent$u;
+  var parent$t = getIteratorMethod$3;
+  var getIteratorMethod$2 = parent$t;
+  var require$$0$j = getIteratorMethod$2;
+  var getIteratorMethod$1 = require$$0$j;
+  var _getIteratorMethod = getIteratorMethod$1;
+  var getIteratorMethod = _getIteratorMethod;
+  var $TypeError$3$1 = TypeError;
+  var MAX_SAFE_INTEGER = 9007199254740991;
+  var doesNotExceedSafeInteger$1 = function(it) {
+    if (it > MAX_SAFE_INTEGER) throw $TypeError$3$1("Maximum allowed index exceeded");
+    return it;
+  };
+  var createProperty$1 = function(object, key2, value) {
+    if (DESCRIPTORS) require$$0$r.f(object, key2, createPropertyDescriptor(0, value));
+    else object[key2] = value;
+  };
+  var SPECIES$1 = wellKnownSymbol("species");
+  var arrayMethodHasSpeciesSupport$1 = function(METHOD_NAME) {
+    return V8_VERSION >= 51 || !fails(function() {
+      var array = [];
+      var constructor = array.constructor = {};
+      constructor[SPECIES$1] = function() {
+        return { foo: 1 };
+      };
+      return array[METHOD_NAME](Boolean).foo !== 1;
+    });
+  };
+  var doesNotExceedSafeInteger = doesNotExceedSafeInteger$1;
+  var createProperty = createProperty$1;
+  var arrayMethodHasSpeciesSupport = arrayMethodHasSpeciesSupport$1;
+  var IS_CONCAT_SPREADABLE = wellKnownSymbol("isConcatSpreadable");
+  var IS_CONCAT_SPREADABLE_SUPPORT = V8_VERSION >= 51 || !fails(function() {
+    var array = [];
+    array[IS_CONCAT_SPREADABLE] = false;
+    return array.concat()[0] !== array;
+  });
+  var isConcatSpreadable = function(O2) {
+    if (!isObject(O2)) return false;
+    var spreadable = O2[IS_CONCAT_SPREADABLE];
+    return spreadable !== void 0 ? !!spreadable : isArray$6(O2);
+  };
+  var FORCED$3 = !IS_CONCAT_SPREADABLE_SUPPORT || !arrayMethodHasSpeciesSupport("concat");
+  $({ target: "Array", proto: true, arity: 1, forced: FORCED$3 }, {
+    // eslint-disable-next-line no-unused-vars -- required for `.length`
+    concat: function concat2(arg) {
+      var O2 = toObject$1(this);
+      var A2 = arraySpeciesCreate(O2, 0);
+      var n2 = 0;
+      var i2, k2, length, len, E2;
+      for (i2 = -1, length = arguments.length; i2 < length; i2++) {
+        E2 = i2 === -1 ? O2 : arguments[i2];
+        if (isConcatSpreadable(E2)) {
+          len = lengthOfArrayLike(E2);
+          doesNotExceedSafeInteger(n2 + len);
+          for (k2 = 0; k2 < len; k2++, n2++) if (k2 in E2) createProperty(A2, n2, E2[k2]);
+        } else {
+          doesNotExceedSafeInteger(n2 + 1);
+          createProperty(A2, n2++, E2);
+        }
+      }
+      A2.length = n2;
+      return A2;
+    }
+  });
+  var f$1 = Object.getOwnPropertySymbols;
+  var objectGetOwnPropertySymbols = {
+    f: f$1
+  };
+  var f$9 = wellKnownSymbol;
+  var wellKnownSymbolWrapped = {
+    f: f$9
+  };
+  var WrappedWellKnownSymbolModule = wellKnownSymbolWrapped;
+  var defineProperty$6 = require$$0$r.f;
+  var wellKnownSymbolDefine = function(NAME) {
+    var Symbol2 = path.Symbol || (path.Symbol = {});
+    if (!hasOwn$4(Symbol2, NAME)) defineProperty$6(Symbol2, NAME, {
+      value: WrappedWellKnownSymbolModule.f(NAME)
+    });
+  };
+  var symbolDefineToPrimitive = function() {
+    var Symbol2 = getBuiltIn("Symbol");
+    var SymbolPrototype2 = Symbol2 && Symbol2.prototype;
+    var valueOf = SymbolPrototype2 && SymbolPrototype2.valueOf;
+    var TO_PRIMITIVE2 = wellKnownSymbol("toPrimitive");
+    if (SymbolPrototype2 && !SymbolPrototype2[TO_PRIMITIVE2]) {
+      defineBuiltIn(SymbolPrototype2, TO_PRIMITIVE2, function(hint) {
+        return call$4(valueOf, this);
+      }, { arity: 1 });
+    }
+  };
+  var getOwnPropertySymbolsModule = objectGetOwnPropertySymbols;
+  var defineWellKnownSymbol = wellKnownSymbolDefine;
+  var defineSymbolToPrimitive = symbolDefineToPrimitive;
+  var $forEach$1 = require$$0$o.forEach;
+  var HIDDEN = sharedKey("hidden");
+  var SYMBOL = "Symbol";
+  var PROTOTYPE = "prototype";
+  var setInternalState = InternalStateModule.set;
+  var getInternalState = InternalStateModule.getterFor(SYMBOL);
+  var ObjectPrototype = Object[PROTOTYPE];
+  var $Symbol = globalThis$1.Symbol;
+  var SymbolPrototype = $Symbol && $Symbol[PROTOTYPE];
+  var RangeError$1 = globalThis$1.RangeError;
+  var TypeError$1 = globalThis$1.TypeError;
+  var QObject = globalThis$1.QObject;
+  var nativeGetOwnPropertyDescriptor = getOwnPropertyDescriptorModule.f;
+  var nativeDefineProperty = require$$0$r.f;
+  var nativeGetOwnPropertyNames = getOwnPropertyNamesExternal.f;
+  var nativePropertyIsEnumerable = propertyIsEnumerableModule.f;
+  var push$7 = uncurryThis$1([].push);
+  var AllSymbols = shared$1("symbols");
+  var ObjectPrototypeSymbols = shared$1("op-symbols");
+  var WellKnownSymbolsStore$1 = shared$1("wks");
+  var USE_SETTER = !QObject || !QObject[PROTOTYPE] || !QObject[PROTOTYPE].findChild;
+  var fallbackDefineProperty = function(O2, P2, Attributes) {
+    var ObjectPrototypeDescriptor = nativeGetOwnPropertyDescriptor(ObjectPrototype, P2);
+    if (ObjectPrototypeDescriptor) delete ObjectPrototype[P2];
+    nativeDefineProperty(O2, P2, Attributes);
+    if (ObjectPrototypeDescriptor && O2 !== ObjectPrototype) {
+      nativeDefineProperty(ObjectPrototype, P2, ObjectPrototypeDescriptor);
+    }
+  };
+  var setSymbolDescriptor = DESCRIPTORS && fails(function() {
+    return nativeObjectCreate(nativeDefineProperty({}, "a", {
+      get: function() {
+        return nativeDefineProperty(this, "a", { value: 7 }).a;
+      }
+    })).a !== 7;
+  }) ? fallbackDefineProperty : nativeDefineProperty;
+  var wrap = function(tag, description) {
+    var symbol2 = AllSymbols[tag] = nativeObjectCreate(SymbolPrototype);
+    setInternalState(symbol2, {
+      type: SYMBOL,
+      tag,
+      description
+    });
+    if (!DESCRIPTORS) symbol2.description = description;
+    return symbol2;
+  };
+  var $defineProperty$4 = function defineProperty2(O2, P2, Attributes) {
+    if (O2 === ObjectPrototype) $defineProperty$4(ObjectPrototypeSymbols, P2, Attributes);
+    anObject(O2);
+    var key2 = toPropertyKey(P2);
+    anObject(Attributes);
+    if (hasOwn$4(AllSymbols, key2)) {
+      if (!Attributes.enumerable) {
+        if (!hasOwn$4(O2, HIDDEN)) nativeDefineProperty(O2, HIDDEN, createPropertyDescriptor(1, nativeObjectCreate(null)));
+        O2[HIDDEN][key2] = true;
+      } else {
+        if (hasOwn$4(O2, HIDDEN) && O2[HIDDEN][key2]) O2[HIDDEN][key2] = false;
+        Attributes = nativeObjectCreate(Attributes, { enumerable: createPropertyDescriptor(0, false) });
+      }
+      return setSymbolDescriptor(O2, key2, Attributes);
+    }
+    return nativeDefineProperty(O2, key2, Attributes);
+  };
+  var $defineProperties = function defineProperties2(O2, Properties) {
+    anObject(O2);
+    var properties2 = toIndexedObject(Properties);
+    var keys2 = nativeKeys(properties2).concat($getOwnPropertySymbols(properties2));
+    $forEach$1(keys2, function(key2) {
+      if (!DESCRIPTORS || call$4($propertyIsEnumerable, properties2, key2)) $defineProperty$4(O2, key2, properties2[key2]);
+    });
+    return O2;
+  };
+  var $create = function create(O2, Properties) {
+    return Properties === void 0 ? nativeObjectCreate(O2) : $defineProperties(nativeObjectCreate(O2), Properties);
+  };
+  var $propertyIsEnumerable = function propertyIsEnumerable(V2) {
+    var P2 = toPropertyKey(V2);
+    var enumerable = call$4(nativePropertyIsEnumerable, this, P2);
+    if (this === ObjectPrototype && hasOwn$4(AllSymbols, P2) && !hasOwn$4(ObjectPrototypeSymbols, P2)) return false;
+    return enumerable || !hasOwn$4(this, P2) || !hasOwn$4(AllSymbols, P2) || hasOwn$4(this, HIDDEN) && this[HIDDEN][P2] ? enumerable : true;
+  };
+  var $getOwnPropertyDescriptor = function getOwnPropertyDescriptor2(O2, P2) {
+    var it = toIndexedObject(O2);
+    var key2 = toPropertyKey(P2);
+    if (it === ObjectPrototype && hasOwn$4(AllSymbols, key2) && !hasOwn$4(ObjectPrototypeSymbols, key2)) return;
+    var descriptor = nativeGetOwnPropertyDescriptor(it, key2);
+    if (descriptor && hasOwn$4(AllSymbols, key2) && !(hasOwn$4(it, HIDDEN) && it[HIDDEN][key2])) {
+      descriptor.enumerable = true;
+    }
+    return descriptor;
+  };
+  var $getOwnPropertyNames = function getOwnPropertyNames2(O2) {
+    var names = nativeGetOwnPropertyNames(toIndexedObject(O2));
+    var result = [];
+    $forEach$1(names, function(key2) {
+      if (!hasOwn$4(AllSymbols, key2) && !hasOwn$4(hiddenKeys$1, key2)) push$7(result, key2);
+    });
+    return result;
+  };
+  var $getOwnPropertySymbols = function(O2) {
+    var IS_OBJECT_PROTOTYPE = O2 === ObjectPrototype;
+    var names = nativeGetOwnPropertyNames(IS_OBJECT_PROTOTYPE ? ObjectPrototypeSymbols : toIndexedObject(O2));
+    var result = [];
+    $forEach$1(names, function(key2) {
+      if (hasOwn$4(AllSymbols, key2) && (!IS_OBJECT_PROTOTYPE || hasOwn$4(ObjectPrototype, key2))) {
+        push$7(result, AllSymbols[key2]);
+      }
+    });
+    return result;
+  };
+  if (!NATIVE_SYMBOL) {
+    $Symbol = function Symbol2() {
+      if (isPrototypeOf(SymbolPrototype, this)) throw new TypeError$1("Symbol is not a constructor");
+      var description = !arguments.length || arguments[0] === void 0 ? void 0 : toString$6(arguments[0]);
+      var tag = uid(description);
+      var setter = function(value) {
+        var $this = this === void 0 ? globalThis$1 : this;
+        if ($this === ObjectPrototype) call$4(setter, ObjectPrototypeSymbols, value);
+        if (hasOwn$4($this, HIDDEN) && hasOwn$4($this[HIDDEN], tag)) $this[HIDDEN][tag] = false;
+        var descriptor = createPropertyDescriptor(1, value);
+        try {
+          setSymbolDescriptor($this, tag, descriptor);
+        } catch (error) {
+          if (!(error instanceof RangeError$1)) throw error;
+          fallbackDefineProperty($this, tag, descriptor);
+        }
+      };
+      if (DESCRIPTORS && USE_SETTER) setSymbolDescriptor(ObjectPrototype, tag, { configurable: true, set: setter });
+      return wrap(tag, description);
+    };
+    SymbolPrototype = $Symbol[PROTOTYPE];
+    defineBuiltIn(SymbolPrototype, "toString", function toString2() {
+      return getInternalState(this).tag;
+    });
+    defineBuiltIn($Symbol, "withoutSetter", function(description) {
+      return wrap(uid(description), description);
+    });
+    propertyIsEnumerableModule.f = $propertyIsEnumerable;
+    require$$0$r.f = $defineProperty$4;
+    definePropertiesModule.f = $defineProperties;
+    getOwnPropertyDescriptorModule.f = $getOwnPropertyDescriptor;
+    getOwnPropertyNamesModule.f = getOwnPropertyNamesExternal.f = $getOwnPropertyNames;
+    getOwnPropertySymbolsModule.f = $getOwnPropertySymbols;
+    WrappedWellKnownSymbolModule.f = function(name) {
+      return wrap(wellKnownSymbol(name), name);
+    };
+    if (DESCRIPTORS) {
+      defineBuiltInAccessor(SymbolPrototype, "description", {
+        configurable: true,
+        get: function description() {
+          return getInternalState(this).description;
+        }
+      });
+    }
+  }
+  $({ global: true, constructor: true, wrap: true, forced: !NATIVE_SYMBOL, sham: !NATIVE_SYMBOL }, {
+    Symbol: $Symbol
+  });
+  $forEach$1(nativeKeys(WellKnownSymbolsStore$1), function(name) {
+    defineWellKnownSymbol(name);
+  });
+  $({ target: SYMBOL, stat: true, forced: !NATIVE_SYMBOL }, {
+    useSetter: function() {
+      USE_SETTER = true;
+    },
+    useSimple: function() {
+      USE_SETTER = false;
+    }
+  });
+  $({ target: "Object", stat: true, forced: !NATIVE_SYMBOL, sham: !DESCRIPTORS }, {
+    // `Object.create` method
+    // https://tc39.es/ecma262/#sec-object.create
+    create: $create,
+    // `Object.defineProperty` method
+    // https://tc39.es/ecma262/#sec-object.defineproperty
+    defineProperty: $defineProperty$4,
+    // `Object.defineProperties` method
+    // https://tc39.es/ecma262/#sec-object.defineproperties
+    defineProperties: $defineProperties,
+    // `Object.getOwnPropertyDescriptor` method
+    // https://tc39.es/ecma262/#sec-object.getownpropertydescriptors
+    getOwnPropertyDescriptor: $getOwnPropertyDescriptor
+  });
+  $({ target: "Object", stat: true, forced: !NATIVE_SYMBOL }, {
+    // `Object.getOwnPropertyNames` method
+    // https://tc39.es/ecma262/#sec-object.getownpropertynames
+    getOwnPropertyNames: $getOwnPropertyNames
+  });
+  defineSymbolToPrimitive();
+  setToStringTag($Symbol, SYMBOL);
+  hiddenKeys$1[HIDDEN] = true;
+  var symbolRegistryDetection = NATIVE_SYMBOL && !!Symbol["for"] && !!Symbol.keyFor;
+  var NATIVE_SYMBOL_REGISTRY = symbolRegistryDetection;
+  var StringToSymbolRegistry = shared$1("string-to-symbol-registry");
+  var SymbolToStringRegistry$1 = shared$1("symbol-to-string-registry");
+  $({ target: "Symbol", stat: true, forced: !NATIVE_SYMBOL_REGISTRY }, {
+    "for": function(key2) {
+      var string = toString$6(key2);
+      if (hasOwn$4(StringToSymbolRegistry, string)) return StringToSymbolRegistry[string];
+      var symbol2 = getBuiltIn("Symbol")(string);
+      StringToSymbolRegistry[string] = symbol2;
+      SymbolToStringRegistry$1[symbol2] = string;
+      return symbol2;
+    }
+  });
+  var SymbolToStringRegistry = shared$1("symbol-to-string-registry");
+  $({ target: "Symbol", stat: true, forced: !NATIVE_SYMBOL_REGISTRY }, {
+    keyFor: function keyFor2(sym) {
+      if (!isSymbol$3(sym)) throw new TypeError(tryToString(sym) + " is not a symbol");
+      if (hasOwn$4(SymbolToStringRegistry, sym)) return SymbolToStringRegistry[sym];
+    }
+  });
+  var push$6 = uncurryThis$1([].push);
+  var getJsonReplacerFunction = function(replacer) {
+    if (isCallable$3(replacer)) return replacer;
+    if (!isArray$6(replacer)) return;
+    var rawLength = replacer.length;
+    var keys2 = [];
+    for (var i2 = 0; i2 < rawLength; i2++) {
+      var element = replacer[i2];
+      if (typeof element == "string") push$6(keys2, element);
+      else if (typeof element == "number" || classof$2(element) === "Number" || classof$2(element) === "String") push$6(keys2, toString$6(element));
+    }
+    var keysLength = keys2.length;
+    var root = true;
+    return function(key2, value) {
+      if (root) {
+        root = false;
+        return value;
+      }
+      if (isArray$6(this)) return value;
+      for (var j = 0; j < keysLength; j++) if (keys2[j] === key2) return value;
+    };
+  };
+  var getReplacerFunction = getJsonReplacerFunction;
+  var $String = String;
+  var $stringify = getBuiltIn("JSON", "stringify");
+  var exec = uncurryThis$1(/./.exec);
+  var charAt = uncurryThis$1("".charAt);
+  var charCodeAt = uncurryThis$1("".charCodeAt);
+  var replace = uncurryThis$1("".replace);
+  var numberToString = uncurryThis$1(1 .toString);
+  var tester = /[\uD800-\uDFFF]/g;
+  var low = /^[\uD800-\uDBFF]$/;
+  var hi = /^[\uDC00-\uDFFF]$/;
+  var WRONG_SYMBOLS_CONVERSION = !NATIVE_SYMBOL || fails(function() {
+    var symbol2 = getBuiltIn("Symbol")("stringify detection");
+    return $stringify([symbol2]) !== "[null]" || $stringify({ a: symbol2 }) !== "{}" || $stringify(Object(symbol2)) !== "{}";
+  });
+  var ILL_FORMED_UNICODE = fails(function() {
+    return $stringify("\uDF06\uD834") !== '"\\udf06\\ud834"' || $stringify("\uDEAD") !== '"\\udead"';
+  });
+  var stringifyWithSymbolsFix = function(it, replacer) {
+    var args = nativeSlice(arguments);
+    var $replacer = getReplacerFunction(replacer);
+    if (!isCallable$3($replacer) && (it === void 0 || isSymbol$3(it))) return;
+    args[1] = function(key2, value) {
+      if (isCallable$3($replacer)) value = call$4($replacer, this, $String(key2), value);
+      if (!isSymbol$3(value)) return value;
+    };
+    return apply($stringify, null, args);
+  };
+  var fixIllFormed = function(match2, offset, string) {
+    var prev = charAt(string, offset - 1);
+    var next = charAt(string, offset + 1);
+    if (exec(low, match2) && !exec(hi, next) || exec(hi, match2) && !exec(low, prev)) {
+      return "\\u" + numberToString(charCodeAt(match2, 0), 16);
+    }
+    return match2;
+  };
+  if ($stringify) {
+    $({ target: "JSON", stat: true, arity: 3, forced: WRONG_SYMBOLS_CONVERSION || ILL_FORMED_UNICODE }, {
+      // eslint-disable-next-line no-unused-vars -- required for `.length`
+      stringify: function stringify2(it, replacer, space) {
+        var args = nativeSlice(arguments);
+        var result = apply(WRONG_SYMBOLS_CONVERSION ? stringifyWithSymbolsFix : $stringify, null, args);
+        return ILL_FORMED_UNICODE && typeof result == "string" ? replace(result, tester, fixIllFormed) : result;
+      }
+    });
+  }
+  var FORCED$2 = !NATIVE_SYMBOL || fails(function() {
+    getOwnPropertySymbolsModule.f(1);
+  });
+  $({ target: "Object", stat: true, forced: FORCED$2 }, {
+    getOwnPropertySymbols: function getOwnPropertySymbols2(it) {
+      var $getOwnPropertySymbols2 = getOwnPropertySymbolsModule.f;
+      return $getOwnPropertySymbols2 ? $getOwnPropertySymbols2(toObject$1(it)) : [];
+    }
+  });
+  defineWellKnownSymbol("asyncIterator");
+  defineWellKnownSymbol("hasInstance");
+  defineWellKnownSymbol("isConcatSpreadable");
+  defineWellKnownSymbol("iterator");
+  defineWellKnownSymbol("match");
+  defineWellKnownSymbol("matchAll");
+  defineWellKnownSymbol("replace");
+  defineWellKnownSymbol("search");
+  defineWellKnownSymbol("species");
+  defineWellKnownSymbol("split");
+  defineWellKnownSymbol("toPrimitive");
+  defineSymbolToPrimitive();
+  defineWellKnownSymbol("toStringTag");
+  setToStringTag(getBuiltIn("Symbol"), "Symbol");
+  defineWellKnownSymbol("unscopables");
+  setToStringTag(globalThis$1.JSON, "JSON", true);
+  var symbol$5 = path.Symbol;
+  var parent$s = symbol$5;
+  var symbol$4 = parent$s;
+  var parent$r = symbol$4;
+  var symbol$3 = parent$r;
+  var callWithSafeIterationClosing$1 = function(iterator2, fn2, value, ENTRIES2) {
+    try {
+      return ENTRIES2 ? fn2(anObject(value)[0], value[1]) : fn2(value);
+    } catch (error) {
+      iteratorClose(iterator2, "throw", error);
+    }
+  };
+  var callWithSafeIterationClosing = callWithSafeIterationClosing$1;
+  var $Array$1 = Array;
+  var arrayFrom$2 = function from2(arrayLike) {
+    var O2 = toObject$1(arrayLike);
+    var IS_CONSTRUCTOR = isConstructor(this);
+    var argumentsLength = arguments.length;
+    var mapfn = argumentsLength > 1 ? arguments[1] : void 0;
+    var mapping = mapfn !== void 0;
+    if (mapping) mapfn = bind$5(mapfn, argumentsLength > 2 ? arguments[2] : void 0);
+    var iteratorMethod = getIteratorMethod$5(O2);
+    var index2 = 0;
+    var length, result, step, iterator2, next, value;
+    if (iteratorMethod && !(this === $Array$1 && isArrayIteratorMethod(iteratorMethod))) {
+      result = IS_CONSTRUCTOR ? new this() : [];
+      iterator2 = getIterator$5(O2, iteratorMethod);
+      next = iterator2.next;
+      for (; !(step = call$4(next, iterator2)).done; index2++) {
+        value = mapping ? callWithSafeIterationClosing(iterator2, mapfn, [step.value, index2], true) : step.value;
+        createProperty(result, index2, value);
+      }
+    } else {
+      length = lengthOfArrayLike(O2);
+      result = IS_CONSTRUCTOR ? new this(length) : $Array$1(length);
+      for (; length > index2; index2++) {
+        value = mapping ? mapfn(O2[index2], index2) : O2[index2];
+        createProperty(result, index2, value);
+      }
+    }
+    result.length = index2;
+    return result;
+  };
+  var ITERATOR = wellKnownSymbol("iterator");
+  var SAFE_CLOSING = false;
+  try {
+    var called = 0;
+    var iteratorWithReturn = {
+      next: function() {
+        return { done: !!called++ };
+      },
+      "return": function() {
+        SAFE_CLOSING = true;
+      }
+    };
+    iteratorWithReturn[ITERATOR] = function() {
+      return this;
+    };
+    Array.from(iteratorWithReturn, function() {
+      throw 2;
+    });
+  } catch (error) {
+  }
+  var checkCorrectnessOfIteration$1 = function(exec2, SKIP_CLOSING) {
+    try {
+      if (!SKIP_CLOSING && !SAFE_CLOSING) return false;
+    } catch (error) {
+      return false;
+    }
+    var ITERATION_SUPPORT = false;
+    try {
+      var object = {};
+      object[ITERATOR] = function() {
+        return {
+          next: function() {
+            return { done: ITERATION_SUPPORT = true };
+          }
+        };
+      };
+      exec2(object);
+    } catch (error) {
+    }
+    return ITERATION_SUPPORT;
+  };
+  var from$6 = arrayFrom$2;
+  var checkCorrectnessOfIteration = checkCorrectnessOfIteration$1;
+  var INCORRECT_ITERATION = !checkCorrectnessOfIteration(function(iterable) {
+    Array.from(iterable);
+  });
+  $({ target: "Array", stat: true, forced: INCORRECT_ITERATION }, {
+    from: from$6
+  });
+  var from$5 = path.Array.from;
+  var parent$q = from$5;
+  var from$4 = parent$q;
+  var parent$p = from$4;
+  var from$3 = parent$p;
+  var HAS_SPECIES_SUPPORT = arrayMethodHasSpeciesSupport("slice");
+  var SPECIES = wellKnownSymbol("species");
+  var $Array = Array;
+  var max$1$1 = Math.max;
+  $({ target: "Array", proto: true, forced: !HAS_SPECIES_SUPPORT }, {
+    slice: function slice2(start, end) {
+      var O2 = toIndexedObject(this);
+      var length = lengthOfArrayLike(O2);
+      var k2 = toAbsoluteIndex(start, length);
+      var fin = toAbsoluteIndex(end === void 0 ? length : end, length);
+      var Constructor, result, n2;
+      if (isArray$6(O2)) {
+        Constructor = O2.constructor;
+        if (isConstructor(Constructor) && (Constructor === $Array || isArray$6(Constructor.prototype))) {
+          Constructor = void 0;
+        } else if (isObject(Constructor)) {
+          Constructor = Constructor[SPECIES];
+          if (Constructor === null) Constructor = void 0;
+        }
+        if (Constructor === $Array || Constructor === void 0) {
+          return nativeSlice(O2, k2, fin);
+        }
+      }
+      result = new (Constructor === void 0 ? $Array : Constructor)(max$1$1(fin - k2, 0));
+      for (n2 = 0; k2 < fin; k2++, n2++) if (k2 in O2) createProperty(result, n2, O2[k2]);
+      result.length = n2;
+      return result;
+    }
+  });
+  var getBuiltInPrototypeMethod$1 = function(CONSTRUCTOR, METHOD) {
+    var Namespace = path[CONSTRUCTOR + "Prototype"];
+    var pureMethod = Namespace && Namespace[METHOD];
+    if (pureMethod) return pureMethod;
+    var NativeConstructor = globalThis$1[CONSTRUCTOR];
+    var NativePrototype = NativeConstructor && NativeConstructor.prototype;
+    return NativePrototype && NativePrototype[METHOD];
+  };
+  var getBuiltInPrototypeMethod = getBuiltInPrototypeMethod$1;
+  var slice$6 = getBuiltInPrototypeMethod("Array", "slice");
+  var method$6 = slice$6;
+  var ArrayPrototype$6 = Array.prototype;
+  var slice$5 = function(it) {
+    var own = it.slice;
+    return it === ArrayPrototype$6 || isPrototypeOf(ArrayPrototype$6, it) && own === ArrayPrototype$6.slice ? method$6 : own;
+  };
+  var parent$o = slice$5;
+  var slice$4 = parent$o;
+  var parent$n = slice$4;
+  var slice$3 = parent$n;
+  var defineProperty$5 = parent$C;
+  var parent$m = defineProperty$5;
+  var defineProperty$4 = parent$m;
+  var require$$0$i = defineProperty$4;
+  var defineProperty$3 = require$$0$i;
+  var defineProperty$2 = require$$0$r.f;
+  var METADATA = wellKnownSymbol("metadata");
+  var FunctionPrototype = Function.prototype;
+  if (FunctionPrototype[METADATA] === void 0) {
+    defineProperty$2(FunctionPrototype, METADATA, {
+      value: null
+    });
+  }
+  defineWellKnownSymbol("asyncDispose");
+  defineWellKnownSymbol("dispose");
+  defineWellKnownSymbol("metadata");
+  var symbol$2 = parent$r;
+  var Symbol$2$1 = getBuiltIn("Symbol");
+  var keyFor = Symbol$2$1.keyFor;
+  var thisSymbolValue$1 = uncurryThis$1(Symbol$2$1.prototype.valueOf);
+  var symbolIsRegistered = Symbol$2$1.isRegisteredSymbol || function isRegisteredSymbol2(value) {
+    try {
+      return keyFor(thisSymbolValue$1(value)) !== void 0;
+    } catch (error) {
+      return false;
+    }
+  };
+  var isRegisteredSymbol = symbolIsRegistered;
+  $({ target: "Symbol", stat: true }, {
+    isRegisteredSymbol
+  });
+  var Symbol$1$1 = getBuiltIn("Symbol");
+  var $isWellKnownSymbol = Symbol$1$1.isWellKnownSymbol;
+  var getOwnPropertyNames = getBuiltIn("Object", "getOwnPropertyNames");
+  var thisSymbolValue = uncurryThis$1(Symbol$1$1.prototype.valueOf);
+  var WellKnownSymbolsStore = shared$1("wks");
+  for (var i$2 = 0, symbolKeys = getOwnPropertyNames(Symbol$1$1), symbolKeysLength = symbolKeys.length; i$2 < symbolKeysLength; i$2++) {
+    try {
+      var symbolKey = symbolKeys[i$2];
+      if (isSymbol$3(Symbol$1$1[symbolKey])) wellKnownSymbol(symbolKey);
+    } catch (error) {
+    }
+  }
+  var symbolIsWellKnown = function isWellKnownSymbol2(value) {
+    if ($isWellKnownSymbol && $isWellKnownSymbol(value)) return true;
+    try {
+      var symbol2 = thisSymbolValue(value);
+      for (var j = 0, keys2 = getOwnPropertyNames(WellKnownSymbolsStore), keysLength = keys2.length; j < keysLength; j++) {
+        if (WellKnownSymbolsStore[keys2[j]] == symbol2) return true;
+      }
+    } catch (error) {
+    }
+    return false;
+  };
+  var isWellKnownSymbol = symbolIsWellKnown;
+  $({ target: "Symbol", stat: true, forced: true }, {
+    isWellKnownSymbol
+  });
+  defineWellKnownSymbol("customMatcher");
+  defineWellKnownSymbol("observable");
+  $({ target: "Symbol", stat: true, name: "isRegisteredSymbol" }, {
+    isRegistered: isRegisteredSymbol
+  });
+  $({ target: "Symbol", stat: true, name: "isWellKnownSymbol", forced: true }, {
+    isWellKnown: isWellKnownSymbol
+  });
+  defineWellKnownSymbol("matcher");
+  defineWellKnownSymbol("metadataKey");
+  defineWellKnownSymbol("patternMatch");
+  defineWellKnownSymbol("replaceAll");
+  var parent$l = symbol$2;
+  var symbol$1 = parent$l;
+  var require$$0$h = symbol$1;
+  var symbol = require$$0$h;
+  var iterator$4 = WrappedWellKnownSymbolModule.f("iterator");
+  var parent$k = iterator$4;
+  var iterator$3 = parent$k;
+  var parent$j = iterator$3;
+  var iterator$2 = parent$j;
+  var parent$i = iterator$2;
+  var iterator$1 = parent$i;
+  var require$$0$g = iterator$1;
+  var iterator = require$$0$g;
+  var _Symbol = symbol;
+  var _Symbol$iterator = iterator;
+  var _typeof_1 = createCommonjsModule(function(module2) {
+    function _typeof2(o) {
+      "@babel/helpers - typeof";
+      return module2.exports = _typeof2 = "function" == typeof _Symbol && "symbol" == typeof _Symbol$iterator ? function(o2) {
+        return typeof o2;
+      } : function(o2) {
+        return o2 && "function" == typeof _Symbol && o2.constructor === _Symbol && o2 !== _Symbol.prototype ? "symbol" : typeof o2;
+      }, module2.exports.__esModule = true, module2.exports["default"] = module2.exports, _typeof2(o);
+    }
+    module2.exports = _typeof2, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+  });
+  var toPrimitive$4 = WrappedWellKnownSymbolModule.f("toPrimitive");
+  var parent$h = toPrimitive$4;
+  var toPrimitive$3 = parent$h;
+  var parent$g = toPrimitive$3;
+  var toPrimitive$2 = parent$g;
+  var parent$f = toPrimitive$2;
+  var toPrimitive$1 = parent$f;
+  var require$$0$f = toPrimitive$1;
+  var toPrimitive = require$$0$f;
+  var _Symbol$toPrimitive = toPrimitive;
+  var toPrimitive_1 = createCommonjsModule(function(module2) {
+    var _typeof2 = _typeof_1["default"];
+    function toPrimitive2(t2, r2) {
+      if ("object" != _typeof2(t2) || !t2) return t2;
+      var e2 = t2[_Symbol$toPrimitive];
+      if (void 0 !== e2) {
+        var i2 = e2.call(t2, r2 || "default");
+        if ("object" != _typeof2(i2)) return i2;
+        throw new TypeError("@@toPrimitive must return a primitive value.");
+      }
+      return ("string" === r2 ? String : Number)(t2);
+    }
+    module2.exports = toPrimitive2, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+  });
+  var toPropertyKey_1 = createCommonjsModule(function(module2) {
+    var _typeof2 = _typeof_1["default"];
+    function toPropertyKey2(t2) {
+      var i2 = toPrimitive_1(t2, "string");
+      return "symbol" == _typeof2(i2) ? i2 : i2 + "";
+    }
+    module2.exports = toPropertyKey2, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+  });
+  var _Object$defineProperty = defineProperty$3;
+  var defineProperty$1$1 = createCommonjsModule(function(module2) {
+    function _defineProperty2(e2, r2, t2) {
+      return (r2 = toPropertyKey_1(r2)) in e2 ? _Object$defineProperty(e2, r2, {
+        value: t2,
+        enumerable: true,
+        configurable: true,
+        writable: true
+      }) : e2[r2] = t2, e2;
+    }
+    module2.exports = _defineProperty2, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+  });
+  var $assign = Object.assign;
+  var defineProperty$8 = Object.defineProperty;
+  var concat$4 = uncurryThis$1([].concat);
+  var objectAssign$1 = !$assign || fails(function() {
+    if (DESCRIPTORS && $assign({ b: 1 }, $assign(defineProperty$8({}, "a", {
+      enumerable: true,
+      get: function() {
+        defineProperty$8(this, "b", {
+          value: 3,
+          enumerable: false
+        });
+      }
+    }), { b: 2 })).b !== 1) return true;
+    var A2 = {};
+    var B2 = {};
+    var symbol2 = Symbol("assign detection");
+    var alphabet = "abcdefghijklmnopqrst";
+    A2[symbol2] = 7;
+    alphabet.split("").forEach(function(chr) {
+      B2[chr] = chr;
+    });
+    return $assign({}, A2)[symbol2] !== 7 || nativeKeys($assign({}, B2)).join("") !== alphabet;
+  }) ? function assign2(target, source) {
+    var T2 = toObject$1(target);
+    var argumentsLength = arguments.length;
+    var index2 = 1;
+    var getOwnPropertySymbols2 = getOwnPropertySymbolsModule.f;
+    var propertyIsEnumerable = propertyIsEnumerableModule.f;
+    while (argumentsLength > index2) {
+      var S2 = IndexedObject(arguments[index2++]);
+      var keys2 = getOwnPropertySymbols2 ? concat$4(nativeKeys(S2), getOwnPropertySymbols2(S2)) : nativeKeys(S2);
+      var length = keys2.length;
+      var j = 0;
+      var key2;
+      while (length > j) {
+        key2 = keys2[j++];
+        if (!DESCRIPTORS || call$4(propertyIsEnumerable, S2, key2)) T2[key2] = S2[key2];
+      }
+    }
+    return T2;
+  } : $assign;
+  var assign$3 = objectAssign$1;
+  $({ target: "Object", stat: true, arity: 2, forced: Object.assign !== assign$3 }, {
+    assign: assign$3
+  });
+  var assign$2 = path.Object.assign;
+  var parent$e = assign$2;
+  var assign$1 = parent$e;
+  var require$$0$e = assign$1;
+  var assign$4 = require$$0$e;
+  var FAILS_ON_PRIMITIVES = fails(function() {
+    nativeKeys(1);
+  });
+  $({ target: "Object", stat: true, forced: FAILS_ON_PRIMITIVES }, {
+    keys: function keys2(it) {
+      return nativeKeys(toObject$1(it));
+    }
+  });
+  var keys$6 = path.Object.keys;
+  var parent$d = keys$6;
+  var keys$5 = parent$d;
+  var require$$0$d = keys$5;
+  var keys$4 = require$$0$d;
+  var arrayMethodIsStrict$1 = function(METHOD_NAME, argument) {
+    var method2 = [][METHOD_NAME];
+    return !!method2 && fails(function() {
+      method2.call(null, argument || function() {
+        return 1;
+      }, 1);
+    });
+  };
+  var arrayMethodIsStrict = arrayMethodIsStrict$1;
+  var $forEach = require$$0$o.forEach;
+  var STRICT_METHOD = arrayMethodIsStrict("forEach");
+  var arrayForEach = !STRICT_METHOD ? function forEach2(callbackfn) {
+    return $forEach(this, callbackfn, arguments.length > 1 ? arguments[1] : void 0);
+  } : [].forEach;
+  var forEach$4 = arrayForEach;
+  $({ target: "Array", proto: true, forced: [].forEach !== forEach$4 }, {
+    forEach: forEach$4
+  });
+  var forEach$3 = getBuiltInPrototypeMethod("Array", "forEach");
+  var parent$c = forEach$3;
+  var forEach$2 = parent$c;
+  var method$5 = forEach$2;
+  var ArrayPrototype$5 = Array.prototype;
+  var DOMIterables$2 = {
+    DOMTokenList: true,
+    NodeList: true
+  };
+  var forEach$1$1 = function(it) {
+    var own = it.forEach;
+    return it === ArrayPrototype$5 || isPrototypeOf(ArrayPrototype$5, it) && own === ArrayPrototype$5.forEach || hasOwn$4(DOMIterables$2, classof(it)) ? method$5 : own;
+  };
+  var require$$0$c = forEach$1$1;
+  var forEach$6 = require$$0$c;
+  var commandRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var commandRole2 = {
+      abstract: true,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "menuitem"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "widget"]]
+    };
+    var _default2 = commandRole2;
+    exports2.default = _default2;
+  });
+  var compositeRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var compositeRole2 = {
+      abstract: true,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-activedescendant": null,
+        "aria-disabled": null
+      },
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "widget"]]
+    };
+    var _default2 = compositeRole2;
+    exports2.default = _default2;
+  });
+  var inputRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var inputRole2 = {
+      abstract: true,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "input"
+        },
+        module: "XForms"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "widget"]]
+    };
+    var _default2 = inputRole2;
+    exports2.default = _default2;
+  });
+  var landmarkRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var landmarkRole2 = {
+      abstract: true,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = landmarkRole2;
+    exports2.default = _default2;
+  });
+  var rangeRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var rangeRole2 = {
+      abstract: true,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-valuemax": null,
+        "aria-valuemin": null,
+        "aria-valuenow": null,
+        "aria-valuetext": null
+      },
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure"]]
+    };
+    var _default2 = rangeRole2;
+    exports2.default = _default2;
+  });
+  var roletypeRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var roletypeRole2 = {
+      abstract: true,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: [],
+      prohibitedProps: [],
+      props: {
+        "aria-atomic": null,
+        "aria-busy": null,
+        "aria-controls": null,
+        "aria-current": null,
+        "aria-describedby": null,
+        "aria-details": null,
+        "aria-dropeffect": null,
+        "aria-flowto": null,
+        "aria-grabbed": null,
+        "aria-hidden": null,
+        "aria-keyshortcuts": null,
+        "aria-label": null,
+        "aria-labelledby": null,
+        "aria-live": null,
+        "aria-owns": null,
+        "aria-relevant": null,
+        "aria-roledescription": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "rel"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "role"
+        },
+        module: "XHTML"
+      }, {
+        concept: {
+          name: "type"
+        },
+        module: "Dublin Core"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: []
+    };
+    var _default2 = roletypeRole2;
+    exports2.default = _default2;
+  });
+  var sectionRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var sectionRole2 = {
+      abstract: true,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: [],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "frontmatter"
+        },
+        module: "DTB"
+      }, {
+        concept: {
+          name: "level"
+        },
+        module: "DTB"
+      }, {
+        concept: {
+          name: "level"
+        },
+        module: "SMIL"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure"]]
+    };
+    var _default2 = sectionRole2;
+    exports2.default = _default2;
+  });
+  var sectionheadRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var sectionheadRole2 = {
+      abstract: true,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure"]]
+    };
+    var _default2 = sectionheadRole2;
+    exports2.default = _default2;
+  });
+  var selectRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var selectRole2 = {
+      abstract: true,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-orientation": null
+      },
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "composite"], ["roletype", "structure", "section", "group"]]
+    };
+    var _default2 = selectRole2;
+    exports2.default = _default2;
+  });
+  var structureRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var structureRole2 = {
+      abstract: true,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: [],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype"]]
+    };
+    var _default2 = structureRole2;
+    exports2.default = _default2;
+  });
+  var widgetRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var widgetRole2 = {
+      abstract: true,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: [],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype"]]
+    };
+    var _default2 = widgetRole2;
+    exports2.default = _default2;
+  });
+  var windowRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var windowRole2 = {
+      abstract: true,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-modal": null
+      },
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype"]]
+    };
+    var _default2 = windowRole2;
+    exports2.default = _default2;
+  });
+  var ariaAbstractRoles_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var _map = interopRequireDefault(map);
+    var _commandRole2 = interopRequireDefault(commandRole_1);
+    var _compositeRole2 = interopRequireDefault(compositeRole_1);
+    var _inputRole2 = interopRequireDefault(inputRole_1);
+    var _landmarkRole2 = interopRequireDefault(landmarkRole_1);
+    var _rangeRole2 = interopRequireDefault(rangeRole_1);
+    var _roletypeRole2 = interopRequireDefault(roletypeRole_1);
+    var _sectionRole2 = interopRequireDefault(sectionRole_1);
+    var _sectionheadRole2 = interopRequireDefault(sectionheadRole_1);
+    var _selectRole2 = interopRequireDefault(selectRole_1);
+    var _structureRole2 = interopRequireDefault(structureRole_1);
+    var _widgetRole2 = interopRequireDefault(widgetRole_1);
+    var _windowRole2 = interopRequireDefault(windowRole_1);
+    var ariaAbstractRoles2 = new _map.default([["command", _commandRole2.default], ["composite", _compositeRole2.default], ["input", _inputRole2.default], ["landmark", _landmarkRole2.default], ["range", _rangeRole2.default], ["roletype", _roletypeRole2.default], ["section", _sectionRole2.default], ["sectionhead", _sectionheadRole2.default], ["select", _selectRole2.default], ["structure", _structureRole2.default], ["widget", _widgetRole2.default], ["window", _windowRole2.default]]);
+    var _default2 = ariaAbstractRoles2;
+    exports2.default = _default2;
+  });
+  var alertRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var alertRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-atomic": "true",
+        "aria-live": "assertive"
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "alert"
+        },
+        module: "XForms"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = alertRole2;
+    exports2.default = _default2;
+  });
+  var alertdialogRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var alertdialogRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "alert"
+        },
+        module: "XForms"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "alert"], ["roletype", "window", "dialog"]]
+    };
+    var _default2 = alertdialogRole2;
+    exports2.default = _default2;
+  });
+  var applicationRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var applicationRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-activedescendant": null,
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "Device Independence Delivery Unit"
+        }
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure"]]
+    };
+    var _default2 = applicationRole2;
+    exports2.default = _default2;
+  });
+  var articleRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var articleRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-posinset": null,
+        "aria-setsize": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "article"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "document"]]
+    };
+    var _default2 = articleRole2;
+    exports2.default = _default2;
+  });
+  var bannerRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var bannerRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          constraints: ["direct descendant of document"],
+          name: "header"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = bannerRole2;
+    exports2.default = _default2;
+  });
+  var blockquoteRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var blockquoteRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = blockquoteRole2;
+    exports2.default = _default2;
+  });
+  var buttonRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var buttonRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: true,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-pressed": null
+      },
+      relatedConcepts: [{
+        concept: {
+          attributes: [{
+            constraints: ["set"],
+            name: "aria-pressed"
+          }, {
+            name: "type",
+            value: "checkbox"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            name: "aria-expanded",
+            value: "false"
+          }],
+          name: "summary"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            name: "aria-expanded",
+            value: "true"
+          }],
+          constraints: ["direct descendant of details element with the open attribute defined"],
+          name: "summary"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            name: "type",
+            value: "button"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            name: "type",
+            value: "image"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            name: "type",
+            value: "reset"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            name: "type",
+            value: "submit"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "button"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "trigger"
+        },
+        module: "XForms"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "command"]]
+    };
+    var _default2 = buttonRole2;
+    exports2.default = _default2;
+  });
+  var captionRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var captionRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["prohibited"],
+      prohibitedProps: ["aria-label", "aria-labelledby"],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: ["figure", "grid", "table"],
+      requiredContextRole: ["figure", "grid", "table"],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = captionRole2;
+    exports2.default = _default2;
+  });
+  var cellRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var cellRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {
+        "aria-colindex": null,
+        "aria-colspan": null,
+        "aria-rowindex": null,
+        "aria-rowspan": null
+      },
+      relatedConcepts: [{
+        concept: {
+          constraints: ["descendant of table"],
+          name: "td"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: ["row"],
+      requiredContextRole: ["row"],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = cellRole2;
+    exports2.default = _default2;
+  });
+  var checkboxRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var checkboxRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: true,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {
+        "aria-checked": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-invalid": null,
+        "aria-readonly": null,
+        "aria-required": null
+      },
+      relatedConcepts: [{
+        concept: {
+          attributes: [{
+            name: "type",
+            value: "checkbox"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "option"
+        },
+        module: "ARIA"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {
+        "aria-checked": null
+      },
+      superClass: [["roletype", "widget", "input"]]
+    };
+    var _default2 = checkboxRole2;
+    exports2.default = _default2;
+  });
+  var codeRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var codeRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["prohibited"],
+      prohibitedProps: ["aria-label", "aria-labelledby"],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = codeRole2;
+    exports2.default = _default2;
+  });
+  var columnheaderRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var columnheaderRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {
+        "aria-sort": null
+      },
+      relatedConcepts: [{
+        attributes: [{
+          name: "scope",
+          value: "col"
+        }],
+        concept: {
+          name: "th"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: ["row"],
+      requiredContextRole: ["row"],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "cell"], ["roletype", "structure", "section", "cell", "gridcell"], ["roletype", "widget", "gridcell"], ["roletype", "structure", "sectionhead"]]
+    };
+    var _default2 = columnheaderRole2;
+    exports2.default = _default2;
+  });
+  var comboboxRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var comboboxRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-activedescendant": null,
+        "aria-autocomplete": null,
+        "aria-errormessage": null,
+        "aria-invalid": null,
+        "aria-readonly": null,
+        "aria-required": null,
+        "aria-expanded": "false",
+        "aria-haspopup": "listbox"
+      },
+      relatedConcepts: [{
+        concept: {
+          attributes: [{
+            constraints: ["set"],
+            name: "list"
+          }, {
+            name: "type",
+            value: "email"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            constraints: ["set"],
+            name: "list"
+          }, {
+            name: "type",
+            value: "search"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            constraints: ["set"],
+            name: "list"
+          }, {
+            name: "type",
+            value: "tel"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            constraints: ["set"],
+            name: "list"
+          }, {
+            name: "type",
+            value: "text"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            constraints: ["set"],
+            name: "list"
+          }, {
+            name: "type",
+            value: "url"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            constraints: ["set"],
+            name: "list"
+          }, {
+            name: "type",
+            value: "url"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            constraints: ["undefined"],
+            name: "multiple"
+          }, {
+            constraints: ["undefined"],
+            name: "size"
+          }],
+          name: "select"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            constraints: ["undefined"],
+            name: "multiple"
+          }, {
+            name: "size",
+            value: 1
+          }],
+          name: "select"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "select"
+        },
+        module: "XForms"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {
+        "aria-controls": null,
+        "aria-expanded": "false"
+      },
+      superClass: [["roletype", "widget", "input"]]
+    };
+    var _default2 = comboboxRole2;
+    exports2.default = _default2;
+  });
+  var complementaryRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var complementaryRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "aside"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = complementaryRole2;
+    exports2.default = _default2;
+  });
+  var contentinfoRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var contentinfoRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          constraints: ["direct descendant of document"],
+          name: "footer"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = contentinfoRole2;
+    exports2.default = _default2;
+  });
+  var definitionRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var definitionRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "dd"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = definitionRole2;
+    exports2.default = _default2;
+  });
+  var deletionRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var deletionRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["prohibited"],
+      prohibitedProps: ["aria-label", "aria-labelledby"],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = deletionRole2;
+    exports2.default = _default2;
+  });
+  var dialogRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var dialogRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "dialog"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "window"]]
+    };
+    var _default2 = dialogRole2;
+    exports2.default = _default2;
+  });
+  var directoryRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var directoryRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        module: "DAISY Guide"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "list"]]
+    };
+    var _default2 = directoryRole2;
+    exports2.default = _default2;
+  });
+  var documentRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var documentRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "Device Independence Delivery Unit"
+        }
+      }, {
+        concept: {
+          name: "body"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure"]]
+    };
+    var _default2 = documentRole2;
+    exports2.default = _default2;
+  });
+  var emphasisRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var emphasisRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["prohibited"],
+      prohibitedProps: ["aria-label", "aria-labelledby"],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = emphasisRole2;
+    exports2.default = _default2;
+  });
+  var feedRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var feedRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [["article"]],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "list"]]
+    };
+    var _default2 = feedRole2;
+    exports2.default = _default2;
+  });
+  var figureRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var figureRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "figure"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = figureRole2;
+    exports2.default = _default2;
+  });
+  var formRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var formRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          attributes: [{
+            constraints: ["set"],
+            name: "aria-label"
+          }],
+          name: "form"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            constraints: ["set"],
+            name: "aria-labelledby"
+          }],
+          name: "form"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            constraints: ["set"],
+            name: "name"
+          }],
+          name: "form"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = formRole2;
+    exports2.default = _default2;
+  });
+  var genericRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var genericRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["prohibited"],
+      prohibitedProps: ["aria-label", "aria-labelledby"],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "span"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "div"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure"]]
+    };
+    var _default2 = genericRole2;
+    exports2.default = _default2;
+  });
+  var gridRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var gridRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-multiselectable": null,
+        "aria-readonly": null
+      },
+      relatedConcepts: [{
+        concept: {
+          attributes: [{
+            name: "role",
+            value: "grid"
+          }],
+          name: "table"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [["row"], ["row", "rowgroup"]],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "composite"], ["roletype", "structure", "section", "table"]]
+    };
+    var _default2 = gridRole2;
+    exports2.default = _default2;
+  });
+  var gridcellRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var gridcellRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null,
+        "aria-readonly": null,
+        "aria-required": null,
+        "aria-selected": null
+      },
+      relatedConcepts: [{
+        concept: {
+          attributes: [{
+            name: "role",
+            value: "gridcell"
+          }],
+          name: "td"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: ["row"],
+      requiredContextRole: ["row"],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "cell"], ["roletype", "widget"]]
+    };
+    var _default2 = gridcellRole2;
+    exports2.default = _default2;
+  });
+  var groupRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var groupRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-activedescendant": null,
+        "aria-disabled": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "details"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "fieldset"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "optgroup"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = groupRole2;
+    exports2.default = _default2;
+  });
+  var headingRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var headingRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {
+        "aria-level": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "h1"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "h2"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "h3"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "h4"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "h5"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "h6"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {
+        "aria-level": 2
+      },
+      superClass: [["roletype", "structure", "sectionhead"]]
+    };
+    var _default2 = headingRole2;
+    exports2.default = _default2;
+  });
+  var imgRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var imgRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: true,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          attributes: [{
+            constraints: ["set"],
+            name: "alt"
+          }],
+          name: "img"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            constraints: ["undefined"],
+            name: "alt"
+          }],
+          name: "img"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "imggroup"
+        },
+        module: "DTB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = imgRole2;
+    exports2.default = _default2;
+  });
+  var insertionRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var insertionRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["prohibited"],
+      prohibitedProps: ["aria-label", "aria-labelledby"],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = insertionRole2;
+    exports2.default = _default2;
+  });
+  var linkRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var linkRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-expanded": null
+      },
+      relatedConcepts: [{
+        concept: {
+          attributes: [{
+            name: "href"
+          }],
+          name: "a"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            name: "href"
+          }],
+          name: "area"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            name: "href"
+          }],
+          name: "link"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "command"]]
+    };
+    var _default2 = linkRole2;
+    exports2.default = _default2;
+  });
+  var listRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var listRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "menu"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "ol"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "ul"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [["listitem"]],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = listRole2;
+    exports2.default = _default2;
+  });
+  var listboxRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var listboxRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-invalid": null,
+        "aria-multiselectable": null,
+        "aria-readonly": null,
+        "aria-required": null,
+        "aria-orientation": "vertical"
+      },
+      relatedConcepts: [{
+        concept: {
+          attributes: [{
+            constraints: [">1"],
+            name: "size"
+          }, {
+            name: "multiple"
+          }],
+          name: "select"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            constraints: [">1"],
+            name: "size"
+          }],
+          name: "select"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            name: "multiple"
+          }],
+          name: "select"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "datalist"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "list"
+        },
+        module: "ARIA"
+      }, {
+        concept: {
+          name: "select"
+        },
+        module: "XForms"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [["option", "group"], ["option"]],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "composite", "select"], ["roletype", "structure", "section", "group", "select"]]
+    };
+    var _default2 = listboxRole2;
+    exports2.default = _default2;
+  });
+  var listitemRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var listitemRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-level": null,
+        "aria-posinset": null,
+        "aria-setsize": null
+      },
+      relatedConcepts: [{
+        concept: {
+          constraints: ["direct descendant of ol, ul or menu"],
+          name: "li"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "item"
+        },
+        module: "XForms"
+      }],
+      requireContextRole: ["directory", "list"],
+      requiredContextRole: ["directory", "list"],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = listitemRole2;
+    exports2.default = _default2;
+  });
+  var logRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var logRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-live": "polite"
+      },
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = logRole2;
+    exports2.default = _default2;
+  });
+  var mainRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var mainRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "main"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = mainRole2;
+    exports2.default = _default2;
+  });
+  var marqueeRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var marqueeRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = marqueeRole2;
+    exports2.default = _default2;
+  });
+  var mathRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var mathRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "math"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = mathRole2;
+    exports2.default = _default2;
+  });
+  var menuRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var menuRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-orientation": "vertical"
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "MENU"
+        },
+        module: "JAPI"
+      }, {
+        concept: {
+          name: "list"
+        },
+        module: "ARIA"
+      }, {
+        concept: {
+          name: "select"
+        },
+        module: "XForms"
+      }, {
+        concept: {
+          name: "sidebar"
+        },
+        module: "DTB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [["menuitem", "group"], ["menuitemradio", "group"], ["menuitemcheckbox", "group"], ["menuitem"], ["menuitemcheckbox"], ["menuitemradio"]],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "composite", "select"], ["roletype", "structure", "section", "group", "select"]]
+    };
+    var _default2 = menuRole2;
+    exports2.default = _default2;
+  });
+  var menubarRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var menubarRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-orientation": "horizontal"
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "toolbar"
+        },
+        module: "ARIA"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [["menuitem", "group"], ["menuitemradio", "group"], ["menuitemcheckbox", "group"], ["menuitem"], ["menuitemcheckbox"], ["menuitemradio"]],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "composite", "select", "menu"], ["roletype", "structure", "section", "group", "select", "menu"]]
+    };
+    var _default2 = menubarRole2;
+    exports2.default = _default2;
+  });
+  var menuitemRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var menuitemRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-posinset": null,
+        "aria-setsize": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "MENU_ITEM"
+        },
+        module: "JAPI"
+      }, {
+        concept: {
+          name: "listitem"
+        },
+        module: "ARIA"
+      }, {
+        concept: {
+          name: "menuitem"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "option"
+        },
+        module: "ARIA"
+      }],
+      requireContextRole: ["group", "menu", "menubar"],
+      requiredContextRole: ["group", "menu", "menubar"],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "command"]]
+    };
+    var _default2 = menuitemRole2;
+    exports2.default = _default2;
+  });
+  var menuitemcheckboxRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var menuitemcheckboxRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: true,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "menuitem"
+        },
+        module: "ARIA"
+      }],
+      requireContextRole: ["group", "menu", "menubar"],
+      requiredContextRole: ["group", "menu", "menubar"],
+      requiredOwnedElements: [],
+      requiredProps: {
+        "aria-checked": null
+      },
+      superClass: [["roletype", "widget", "input", "checkbox"], ["roletype", "widget", "command", "menuitem"]]
+    };
+    var _default2 = menuitemcheckboxRole2;
+    exports2.default = _default2;
+  });
+  var menuitemradioRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var menuitemradioRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: true,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "menuitem"
+        },
+        module: "ARIA"
+      }],
+      requireContextRole: ["group", "menu", "menubar"],
+      requiredContextRole: ["group", "menu", "menubar"],
+      requiredOwnedElements: [],
+      requiredProps: {
+        "aria-checked": null
+      },
+      superClass: [["roletype", "widget", "input", "checkbox", "menuitemcheckbox"], ["roletype", "widget", "command", "menuitem", "menuitemcheckbox"], ["roletype", "widget", "input", "radio"]]
+    };
+    var _default2 = menuitemradioRole2;
+    exports2.default = _default2;
+  });
+  var meterRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var meterRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: true,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {
+        "aria-valuemax": null,
+        "aria-valuemin": null,
+        "aria-valuenow": null
+      },
+      superClass: [["roletype", "structure", "range"]]
+    };
+    var _default2 = meterRole2;
+    exports2.default = _default2;
+  });
+  var navigationRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var navigationRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "nav"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = navigationRole2;
+    exports2.default = _default2;
+  });
+  var noneRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var noneRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: [],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: []
+    };
+    var _default2 = noneRole2;
+    exports2.default = _default2;
+  });
+  var noteRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var noteRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = noteRole2;
+    exports2.default = _default2;
+  });
+  var optionRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var optionRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: true,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {
+        "aria-checked": null,
+        "aria-posinset": null,
+        "aria-setsize": null,
+        "aria-selected": "false"
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "item"
+        },
+        module: "XForms"
+      }, {
+        concept: {
+          name: "listitem"
+        },
+        module: "ARIA"
+      }, {
+        concept: {
+          name: "option"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {
+        "aria-selected": "false"
+      },
+      superClass: [["roletype", "widget", "input"]]
+    };
+    var _default2 = optionRole2;
+    exports2.default = _default2;
+  });
+  var paragraphRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var paragraphRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["prohibited"],
+      prohibitedProps: ["aria-label", "aria-labelledby"],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = paragraphRole2;
+    exports2.default = _default2;
+  });
+  var presentationRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var presentationRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["prohibited"],
+      prohibitedProps: ["aria-label", "aria-labelledby"],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure"]]
+    };
+    var _default2 = presentationRole2;
+    exports2.default = _default2;
+  });
+  var progressbarRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var progressbarRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: true,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "progress"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "status"
+        },
+        module: "ARIA"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "range"], ["roletype", "widget"]]
+    };
+    var _default2 = progressbarRole2;
+    exports2.default = _default2;
+  });
+  var radioRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var radioRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: true,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {
+        "aria-checked": null,
+        "aria-posinset": null,
+        "aria-setsize": null
+      },
+      relatedConcepts: [{
+        concept: {
+          attributes: [{
+            name: "type",
+            value: "radio"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {
+        "aria-checked": null
+      },
+      superClass: [["roletype", "widget", "input"]]
+    };
+    var _default2 = radioRole2;
+    exports2.default = _default2;
+  });
+  var radiogroupRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var radiogroupRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-errormessage": null,
+        "aria-invalid": null,
+        "aria-readonly": null,
+        "aria-required": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "list"
+        },
+        module: "ARIA"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [["radio"]],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "composite", "select"], ["roletype", "structure", "section", "group", "select"]]
+    };
+    var _default2 = radiogroupRole2;
+    exports2.default = _default2;
+  });
+  var regionRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var regionRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          attributes: [{
+            constraints: ["set"],
+            name: "aria-label"
+          }],
+          name: "section"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            constraints: ["set"],
+            name: "aria-labelledby"
+          }],
+          name: "section"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "Device Independence Glossart perceivable unit"
+        }
+      }, {
+        concept: {
+          name: "frame"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = regionRole2;
+    exports2.default = _default2;
+  });
+  var rowRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var rowRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {
+        "aria-colindex": null,
+        "aria-expanded": null,
+        "aria-level": null,
+        "aria-posinset": null,
+        "aria-rowindex": null,
+        "aria-selected": null,
+        "aria-setsize": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "tr"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: ["grid", "rowgroup", "table", "treegrid"],
+      requiredContextRole: ["grid", "rowgroup", "table", "treegrid"],
+      requiredOwnedElements: [["cell"], ["columnheader"], ["gridcell"], ["rowheader"]],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "group"], ["roletype", "widget"]]
+    };
+    var _default2 = rowRole2;
+    exports2.default = _default2;
+  });
+  var rowgroupRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var rowgroupRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "tbody"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "tfoot"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "thead"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: ["grid", "table", "treegrid"],
+      requiredContextRole: ["grid", "table", "treegrid"],
+      requiredOwnedElements: [["row"]],
+      requiredProps: {},
+      superClass: [["roletype", "structure"]]
+    };
+    var _default2 = rowgroupRole2;
+    exports2.default = _default2;
+  });
+  var rowheaderRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var rowheaderRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {
+        "aria-sort": null
+      },
+      relatedConcepts: [{
+        concept: {
+          attributes: [{
+            name: "scope",
+            value: "row"
+          }],
+          name: "th"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: ["row"],
+      requiredContextRole: ["row"],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "cell"], ["roletype", "structure", "section", "cell", "gridcell"], ["roletype", "widget", "gridcell"], ["roletype", "structure", "sectionhead"]]
+    };
+    var _default2 = rowheaderRole2;
+    exports2.default = _default2;
+  });
+  var scrollbarRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var scrollbarRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: true,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-orientation": "vertical",
+        "aria-valuemax": "100",
+        "aria-valuemin": "0"
+      },
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {
+        "aria-controls": null,
+        "aria-valuenow": null
+      },
+      superClass: [["roletype", "structure", "range"], ["roletype", "widget"]]
+    };
+    var _default2 = scrollbarRole2;
+    exports2.default = _default2;
+  });
+  var searchRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var searchRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = searchRole2;
+    exports2.default = _default2;
+  });
+  var searchboxRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var searchboxRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          attributes: [{
+            constraints: ["undefined"],
+            name: "list"
+          }, {
+            name: "type",
+            value: "search"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "input", "textbox"]]
+    };
+    var _default2 = searchboxRole2;
+    exports2.default = _default2;
+  });
+  var separatorRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var separatorRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: true,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-valuetext": null,
+        "aria-orientation": "horizontal",
+        "aria-valuemax": "100",
+        "aria-valuemin": "0"
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "hr"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure"]]
+    };
+    var _default2 = separatorRole2;
+    exports2.default = _default2;
+  });
+  var sliderRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var sliderRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: true,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-errormessage": null,
+        "aria-haspopup": null,
+        "aria-invalid": null,
+        "aria-readonly": null,
+        "aria-orientation": "horizontal",
+        "aria-valuemax": "100",
+        "aria-valuemin": "0"
+      },
+      relatedConcepts: [{
+        concept: {
+          attributes: [{
+            name: "type",
+            value: "range"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {
+        "aria-valuenow": null
+      },
+      superClass: [["roletype", "widget", "input"], ["roletype", "structure", "range"]]
+    };
+    var _default2 = sliderRole2;
+    exports2.default = _default2;
+  });
+  var spinbuttonRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var spinbuttonRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-errormessage": null,
+        "aria-invalid": null,
+        "aria-readonly": null,
+        "aria-required": null,
+        "aria-valuenow": "0"
+      },
+      relatedConcepts: [{
+        concept: {
+          attributes: [{
+            name: "type",
+            value: "number"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "composite"], ["roletype", "widget", "input"], ["roletype", "structure", "range"]]
+    };
+    var _default2 = spinbuttonRole2;
+    exports2.default = _default2;
+  });
+  var statusRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var statusRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-atomic": "true",
+        "aria-live": "polite"
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "output"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = statusRole2;
+    exports2.default = _default2;
+  });
+  var strongRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var strongRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["prohibited"],
+      prohibitedProps: ["aria-label", "aria-labelledby"],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = strongRole2;
+    exports2.default = _default2;
+  });
+  var subscriptRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var subscriptRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["prohibited"],
+      prohibitedProps: ["aria-label", "aria-labelledby"],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = subscriptRole2;
+    exports2.default = _default2;
+  });
+  var superscriptRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var superscriptRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["prohibited"],
+      prohibitedProps: ["aria-label", "aria-labelledby"],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = superscriptRole2;
+    exports2.default = _default2;
+  });
+  var switchRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var switchRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: true,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "button"
+        },
+        module: "ARIA"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {
+        "aria-checked": null
+      },
+      superClass: [["roletype", "widget", "input", "checkbox"]]
+    };
+    var _default2 = switchRole2;
+    exports2.default = _default2;
+  });
+  var tabRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var tabRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: true,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-posinset": null,
+        "aria-setsize": null,
+        "aria-selected": "false"
+      },
+      relatedConcepts: [],
+      requireContextRole: ["tablist"],
+      requiredContextRole: ["tablist"],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "sectionhead"], ["roletype", "widget"]]
+    };
+    var _default2 = tabRole2;
+    exports2.default = _default2;
+  });
+  var tableRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var tableRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-colcount": null,
+        "aria-rowcount": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "table"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [["row"], ["row", "rowgroup"]],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = tableRole2;
+    exports2.default = _default2;
+  });
+  var tablistRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var tablistRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-level": null,
+        "aria-multiselectable": null,
+        "aria-orientation": "horizontal"
+      },
+      relatedConcepts: [{
+        module: "DAISY",
+        concept: {
+          name: "guide"
+        }
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [["tab"]],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "composite"]]
+    };
+    var _default2 = tablistRole2;
+    exports2.default = _default2;
+  });
+  var tabpanelRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var tabpanelRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = tabpanelRole2;
+    exports2.default = _default2;
+  });
+  var termRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var termRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "dfn"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = termRole2;
+    exports2.default = _default2;
+  });
+  var textboxRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var textboxRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-activedescendant": null,
+        "aria-autocomplete": null,
+        "aria-errormessage": null,
+        "aria-haspopup": null,
+        "aria-invalid": null,
+        "aria-multiline": null,
+        "aria-placeholder": null,
+        "aria-readonly": null,
+        "aria-required": null
+      },
+      relatedConcepts: [{
+        concept: {
+          attributes: [{
+            constraints: ["undefined"],
+            name: "type"
+          }, {
+            constraints: ["undefined"],
+            name: "list"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            constraints: ["undefined"],
+            name: "list"
+          }, {
+            name: "type",
+            value: "email"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            constraints: ["undefined"],
+            name: "list"
+          }, {
+            name: "type",
+            value: "tel"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            constraints: ["undefined"],
+            name: "list"
+          }, {
+            name: "type",
+            value: "text"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          attributes: [{
+            constraints: ["undefined"],
+            name: "list"
+          }, {
+            name: "type",
+            value: "url"
+          }],
+          name: "input"
+        },
+        module: "HTML"
+      }, {
+        concept: {
+          name: "input"
+        },
+        module: "XForms"
+      }, {
+        concept: {
+          name: "textarea"
+        },
+        module: "HTML"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "input"]]
+    };
+    var _default2 = textboxRole2;
+    exports2.default = _default2;
+  });
+  var timeRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var timeRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = timeRole2;
+    exports2.default = _default2;
+  });
+  var timerRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var timerRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "status"]]
+    };
+    var _default2 = timerRole2;
+    exports2.default = _default2;
+  });
+  var toolbarRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var toolbarRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-orientation": "horizontal"
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "menubar"
+        },
+        module: "ARIA"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "group"]]
+    };
+    var _default2 = toolbarRole2;
+    exports2.default = _default2;
+  });
+  var tooltipRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var tooltipRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = tooltipRole2;
+    exports2.default = _default2;
+  });
+  var treeRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var treeRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-errormessage": null,
+        "aria-invalid": null,
+        "aria-multiselectable": null,
+        "aria-required": null,
+        "aria-orientation": "vertical"
+      },
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [["treeitem", "group"], ["treeitem"]],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "composite", "select"], ["roletype", "structure", "section", "group", "select"]]
+    };
+    var _default2 = treeRole2;
+    exports2.default = _default2;
+  });
+  var treegridRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var treegridRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [["row"], ["row", "rowgroup"]],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "composite", "grid"], ["roletype", "structure", "section", "table", "grid"], ["roletype", "widget", "composite", "select", "tree"], ["roletype", "structure", "section", "group", "select", "tree"]]
+    };
+    var _default2 = treegridRole2;
+    exports2.default = _default2;
+  });
+  var treeitemRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var treeitemRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {
+        "aria-expanded": null,
+        "aria-haspopup": null
+      },
+      relatedConcepts: [],
+      requireContextRole: ["group", "tree"],
+      requiredContextRole: ["group", "tree"],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "listitem"], ["roletype", "widget", "input", "option"]]
+    };
+    var _default2 = treeitemRole2;
+    exports2.default = _default2;
+  });
+  var ariaLiteralRoles_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var _map = interopRequireDefault(map);
+    var _alertRole2 = interopRequireDefault(alertRole_1);
+    var _alertdialogRole2 = interopRequireDefault(alertdialogRole_1);
+    var _applicationRole2 = interopRequireDefault(applicationRole_1);
+    var _articleRole2 = interopRequireDefault(articleRole_1);
+    var _bannerRole2 = interopRequireDefault(bannerRole_1);
+    var _blockquoteRole2 = interopRequireDefault(blockquoteRole_1);
+    var _buttonRole2 = interopRequireDefault(buttonRole_1);
+    var _captionRole2 = interopRequireDefault(captionRole_1);
+    var _cellRole2 = interopRequireDefault(cellRole_1);
+    var _checkboxRole2 = interopRequireDefault(checkboxRole_1);
+    var _codeRole2 = interopRequireDefault(codeRole_1);
+    var _columnheaderRole2 = interopRequireDefault(columnheaderRole_1);
+    var _comboboxRole2 = interopRequireDefault(comboboxRole_1);
+    var _complementaryRole2 = interopRequireDefault(complementaryRole_1);
+    var _contentinfoRole2 = interopRequireDefault(contentinfoRole_1);
+    var _definitionRole2 = interopRequireDefault(definitionRole_1);
+    var _deletionRole2 = interopRequireDefault(deletionRole_1);
+    var _dialogRole2 = interopRequireDefault(dialogRole_1);
+    var _directoryRole2 = interopRequireDefault(directoryRole_1);
+    var _documentRole2 = interopRequireDefault(documentRole_1);
+    var _emphasisRole2 = interopRequireDefault(emphasisRole_1);
+    var _feedRole2 = interopRequireDefault(feedRole_1);
+    var _figureRole2 = interopRequireDefault(figureRole_1);
+    var _formRole2 = interopRequireDefault(formRole_1);
+    var _genericRole2 = interopRequireDefault(genericRole_1);
+    var _gridRole2 = interopRequireDefault(gridRole_1);
+    var _gridcellRole2 = interopRequireDefault(gridcellRole_1);
+    var _groupRole2 = interopRequireDefault(groupRole_1);
+    var _headingRole2 = interopRequireDefault(headingRole_1);
+    var _imgRole2 = interopRequireDefault(imgRole_1);
+    var _insertionRole2 = interopRequireDefault(insertionRole_1);
+    var _linkRole2 = interopRequireDefault(linkRole_1);
+    var _listRole2 = interopRequireDefault(listRole_1);
+    var _listboxRole2 = interopRequireDefault(listboxRole_1);
+    var _listitemRole2 = interopRequireDefault(listitemRole_1);
+    var _logRole2 = interopRequireDefault(logRole_1);
+    var _mainRole2 = interopRequireDefault(mainRole_1);
+    var _marqueeRole2 = interopRequireDefault(marqueeRole_1);
+    var _mathRole2 = interopRequireDefault(mathRole_1);
+    var _menuRole2 = interopRequireDefault(menuRole_1);
+    var _menubarRole2 = interopRequireDefault(menubarRole_1);
+    var _menuitemRole2 = interopRequireDefault(menuitemRole_1);
+    var _menuitemcheckboxRole2 = interopRequireDefault(menuitemcheckboxRole_1);
+    var _menuitemradioRole2 = interopRequireDefault(menuitemradioRole_1);
+    var _meterRole2 = interopRequireDefault(meterRole_1);
+    var _navigationRole2 = interopRequireDefault(navigationRole_1);
+    var _noneRole2 = interopRequireDefault(noneRole_1);
+    var _noteRole2 = interopRequireDefault(noteRole_1);
+    var _optionRole2 = interopRequireDefault(optionRole_1);
+    var _paragraphRole2 = interopRequireDefault(paragraphRole_1);
+    var _presentationRole2 = interopRequireDefault(presentationRole_1);
+    var _progressbarRole2 = interopRequireDefault(progressbarRole_1);
+    var _radioRole2 = interopRequireDefault(radioRole_1);
+    var _radiogroupRole2 = interopRequireDefault(radiogroupRole_1);
+    var _regionRole2 = interopRequireDefault(regionRole_1);
+    var _rowRole2 = interopRequireDefault(rowRole_1);
+    var _rowgroupRole2 = interopRequireDefault(rowgroupRole_1);
+    var _rowheaderRole2 = interopRequireDefault(rowheaderRole_1);
+    var _scrollbarRole2 = interopRequireDefault(scrollbarRole_1);
+    var _searchRole2 = interopRequireDefault(searchRole_1);
+    var _searchboxRole2 = interopRequireDefault(searchboxRole_1);
+    var _separatorRole2 = interopRequireDefault(separatorRole_1);
+    var _sliderRole2 = interopRequireDefault(sliderRole_1);
+    var _spinbuttonRole2 = interopRequireDefault(spinbuttonRole_1);
+    var _statusRole2 = interopRequireDefault(statusRole_1);
+    var _strongRole2 = interopRequireDefault(strongRole_1);
+    var _subscriptRole2 = interopRequireDefault(subscriptRole_1);
+    var _superscriptRole2 = interopRequireDefault(superscriptRole_1);
+    var _switchRole2 = interopRequireDefault(switchRole_1);
+    var _tabRole2 = interopRequireDefault(tabRole_1);
+    var _tableRole2 = interopRequireDefault(tableRole_1);
+    var _tablistRole2 = interopRequireDefault(tablistRole_1);
+    var _tabpanelRole2 = interopRequireDefault(tabpanelRole_1);
+    var _termRole2 = interopRequireDefault(termRole_1);
+    var _textboxRole2 = interopRequireDefault(textboxRole_1);
+    var _timeRole2 = interopRequireDefault(timeRole_1);
+    var _timerRole2 = interopRequireDefault(timerRole_1);
+    var _toolbarRole2 = interopRequireDefault(toolbarRole_1);
+    var _tooltipRole2 = interopRequireDefault(tooltipRole_1);
+    var _treeRole2 = interopRequireDefault(treeRole_1);
+    var _treegridRole2 = interopRequireDefault(treegridRole_1);
+    var _treeitemRole2 = interopRequireDefault(treeitemRole_1);
+    var ariaLiteralRoles2 = new _map.default([["alert", _alertRole2.default], ["alertdialog", _alertdialogRole2.default], ["application", _applicationRole2.default], ["article", _articleRole2.default], ["banner", _bannerRole2.default], ["blockquote", _blockquoteRole2.default], ["button", _buttonRole2.default], ["caption", _captionRole2.default], ["cell", _cellRole2.default], ["checkbox", _checkboxRole2.default], ["code", _codeRole2.default], ["columnheader", _columnheaderRole2.default], ["combobox", _comboboxRole2.default], ["complementary", _complementaryRole2.default], ["contentinfo", _contentinfoRole2.default], ["definition", _definitionRole2.default], ["deletion", _deletionRole2.default], ["dialog", _dialogRole2.default], ["directory", _directoryRole2.default], ["document", _documentRole2.default], ["emphasis", _emphasisRole2.default], ["feed", _feedRole2.default], ["figure", _figureRole2.default], ["form", _formRole2.default], ["generic", _genericRole2.default], ["grid", _gridRole2.default], ["gridcell", _gridcellRole2.default], ["group", _groupRole2.default], ["heading", _headingRole2.default], ["img", _imgRole2.default], ["insertion", _insertionRole2.default], ["link", _linkRole2.default], ["list", _listRole2.default], ["listbox", _listboxRole2.default], ["listitem", _listitemRole2.default], ["log", _logRole2.default], ["main", _mainRole2.default], ["marquee", _marqueeRole2.default], ["math", _mathRole2.default], ["menu", _menuRole2.default], ["menubar", _menubarRole2.default], ["menuitem", _menuitemRole2.default], ["menuitemcheckbox", _menuitemcheckboxRole2.default], ["menuitemradio", _menuitemradioRole2.default], ["meter", _meterRole2.default], ["navigation", _navigationRole2.default], ["none", _noneRole2.default], ["note", _noteRole2.default], ["option", _optionRole2.default], ["paragraph", _paragraphRole2.default], ["presentation", _presentationRole2.default], ["progressbar", _progressbarRole2.default], ["radio", _radioRole2.default], ["radiogroup", _radiogroupRole2.default], ["region", _regionRole2.default], ["row", _rowRole2.default], ["rowgroup", _rowgroupRole2.default], ["rowheader", _rowheaderRole2.default], ["scrollbar", _scrollbarRole2.default], ["search", _searchRole2.default], ["searchbox", _searchboxRole2.default], ["separator", _separatorRole2.default], ["slider", _sliderRole2.default], ["spinbutton", _spinbuttonRole2.default], ["status", _statusRole2.default], ["strong", _strongRole2.default], ["subscript", _subscriptRole2.default], ["superscript", _superscriptRole2.default], ["switch", _switchRole2.default], ["tab", _tabRole2.default], ["table", _tableRole2.default], ["tablist", _tablistRole2.default], ["tabpanel", _tabpanelRole2.default], ["term", _termRole2.default], ["textbox", _textboxRole2.default], ["time", _timeRole2.default], ["timer", _timerRole2.default], ["toolbar", _toolbarRole2.default], ["tooltip", _tooltipRole2.default], ["tree", _treeRole2.default], ["treegrid", _treegridRole2.default], ["treeitem", _treeitemRole2.default]]);
+    var _default2 = ariaLiteralRoles2;
+    exports2.default = _default2;
+  });
+  var docAbstractRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docAbstractRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "abstract [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = docAbstractRole2;
+    exports2.default = _default2;
+  });
+  var docAcknowledgmentsRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docAcknowledgmentsRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "acknowledgments [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = docAcknowledgmentsRole2;
+    exports2.default = _default2;
+  });
+  var docAfterwordRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docAfterwordRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "afterword [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = docAfterwordRole2;
+    exports2.default = _default2;
+  });
+  var docAppendixRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docAppendixRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "appendix [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = docAppendixRole2;
+    exports2.default = _default2;
+  });
+  var docBacklinkRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docBacklinkRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author", "content"],
+      prohibitedProps: [],
+      props: {
+        "aria-errormessage": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "referrer [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "command", "link"]]
+    };
+    var _default2 = docBacklinkRole2;
+    exports2.default = _default2;
+  });
+  var docBiblioentryRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docBiblioentryRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "EPUB biblioentry [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: ["doc-bibliography"],
+      requiredContextRole: ["doc-bibliography"],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "listitem"]]
+    };
+    var _default2 = docBiblioentryRole2;
+    exports2.default = _default2;
+  });
+  var docBibliographyRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docBibliographyRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "bibliography [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [["doc-biblioentry"]],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = docBibliographyRole2;
+    exports2.default = _default2;
+  });
+  var docBibliorefRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docBibliorefRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {
+        "aria-errormessage": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "biblioref [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "command", "link"]]
+    };
+    var _default2 = docBibliorefRole2;
+    exports2.default = _default2;
+  });
+  var docChapterRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docChapterRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "chapter [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = docChapterRole2;
+    exports2.default = _default2;
+  });
+  var docColophonRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docColophonRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "colophon [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = docColophonRole2;
+    exports2.default = _default2;
+  });
+  var docConclusionRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docConclusionRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "conclusion [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = docConclusionRole2;
+    exports2.default = _default2;
+  });
+  var docCoverRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docCoverRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "cover [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "img"]]
+    };
+    var _default2 = docCoverRole2;
+    exports2.default = _default2;
+  });
+  var docCreditRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docCreditRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "credit [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = docCreditRole2;
+    exports2.default = _default2;
+  });
+  var docCreditsRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docCreditsRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "credits [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = docCreditsRole2;
+    exports2.default = _default2;
+  });
+  var docDedicationRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docDedicationRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "dedication [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = docDedicationRole2;
+    exports2.default = _default2;
+  });
+  var docEndnoteRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docEndnoteRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "rearnote [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: ["doc-endnotes"],
+      requiredContextRole: ["doc-endnotes"],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "listitem"]]
+    };
+    var _default2 = docEndnoteRole2;
+    exports2.default = _default2;
+  });
+  var docEndnotesRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docEndnotesRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "rearnotes [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [["doc-endnote"]],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = docEndnotesRole2;
+    exports2.default = _default2;
+  });
+  var docEpigraphRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docEpigraphRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "epigraph [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = docEpigraphRole2;
+    exports2.default = _default2;
+  });
+  var docEpilogueRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docEpilogueRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "epilogue [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = docEpilogueRole2;
+    exports2.default = _default2;
+  });
+  var docErrataRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docErrataRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "errata [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = docErrataRole2;
+    exports2.default = _default2;
+  });
+  var docExampleRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docExampleRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = docExampleRole2;
+    exports2.default = _default2;
+  });
+  var docFootnoteRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docFootnoteRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "footnote [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = docFootnoteRole2;
+    exports2.default = _default2;
+  });
+  var docForewordRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docForewordRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "foreword [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = docForewordRole2;
+    exports2.default = _default2;
+  });
+  var docGlossaryRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docGlossaryRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "glossary [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [["definition"], ["term"]],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = docGlossaryRole2;
+    exports2.default = _default2;
+  });
+  var docGlossrefRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docGlossrefRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {
+        "aria-errormessage": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "glossref [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "command", "link"]]
+    };
+    var _default2 = docGlossrefRole2;
+    exports2.default = _default2;
+  });
+  var docIndexRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docIndexRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "index [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark", "navigation"]]
+    };
+    var _default2 = docIndexRole2;
+    exports2.default = _default2;
+  });
+  var docIntroductionRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docIntroductionRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "introduction [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = docIntroductionRole2;
+    exports2.default = _default2;
+  });
+  var docNoterefRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docNoterefRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author", "contents"],
+      prohibitedProps: [],
+      props: {
+        "aria-errormessage": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "noteref [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "widget", "command", "link"]]
+    };
+    var _default2 = docNoterefRole2;
+    exports2.default = _default2;
+  });
+  var docNoticeRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docNoticeRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "notice [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "note"]]
+    };
+    var _default2 = docNoticeRole2;
+    exports2.default = _default2;
+  });
+  var docPagebreakRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docPagebreakRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: true,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "pagebreak [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "separator"]]
+    };
+    var _default2 = docPagebreakRole2;
+    exports2.default = _default2;
+  });
+  var docPagelistRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docPagelistRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "page-list [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark", "navigation"]]
+    };
+    var _default2 = docPagelistRole2;
+    exports2.default = _default2;
+  });
+  var docPartRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docPartRole2 = {
+      abstract: false,
+      accessibleNameRequired: true,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "part [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = docPartRole2;
+    exports2.default = _default2;
+  });
+  var docPrefaceRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docPrefaceRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "preface [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = docPrefaceRole2;
+    exports2.default = _default2;
+  });
+  var docPrologueRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docPrologueRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "prologue [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark"]]
+    };
+    var _default2 = docPrologueRole2;
+    exports2.default = _default2;
+  });
+  var docPullquoteRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docPullquoteRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {},
+      relatedConcepts: [{
+        concept: {
+          name: "pullquote [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["none"]]
+    };
+    var _default2 = docPullquoteRole2;
+    exports2.default = _default2;
+  });
+  var docQnaRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docQnaRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "qna [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section"]]
+    };
+    var _default2 = docQnaRole2;
+    exports2.default = _default2;
+  });
+  var docSubtitleRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docSubtitleRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "subtitle [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "sectionhead"]]
+    };
+    var _default2 = docSubtitleRole2;
+    exports2.default = _default2;
+  });
+  var docTipRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docTipRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "help [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "note"]]
+    };
+    var _default2 = docTipRole2;
+    exports2.default = _default2;
+  });
+  var docTocRole_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var docTocRole2 = {
+      abstract: false,
+      accessibleNameRequired: false,
+      baseConcepts: [],
+      childrenPresentational: false,
+      nameFrom: ["author"],
+      prohibitedProps: [],
+      props: {
+        "aria-disabled": null,
+        "aria-errormessage": null,
+        "aria-expanded": null,
+        "aria-haspopup": null,
+        "aria-invalid": null
+      },
+      relatedConcepts: [{
+        concept: {
+          name: "toc [EPUB-SSV]"
+        },
+        module: "EPUB"
+      }],
+      requireContextRole: [],
+      requiredContextRole: [],
+      requiredOwnedElements: [],
+      requiredProps: {},
+      superClass: [["roletype", "structure", "section", "landmark", "navigation"]]
+    };
+    var _default2 = docTocRole2;
+    exports2.default = _default2;
+  });
+  var ariaDpubRoles_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var _map = interopRequireDefault(map);
+    var _docAbstractRole2 = interopRequireDefault(docAbstractRole_1);
+    var _docAcknowledgmentsRole2 = interopRequireDefault(docAcknowledgmentsRole_1);
+    var _docAfterwordRole2 = interopRequireDefault(docAfterwordRole_1);
+    var _docAppendixRole2 = interopRequireDefault(docAppendixRole_1);
+    var _docBacklinkRole2 = interopRequireDefault(docBacklinkRole_1);
+    var _docBiblioentryRole2 = interopRequireDefault(docBiblioentryRole_1);
+    var _docBibliographyRole2 = interopRequireDefault(docBibliographyRole_1);
+    var _docBibliorefRole2 = interopRequireDefault(docBibliorefRole_1);
+    var _docChapterRole2 = interopRequireDefault(docChapterRole_1);
+    var _docColophonRole2 = interopRequireDefault(docColophonRole_1);
+    var _docConclusionRole2 = interopRequireDefault(docConclusionRole_1);
+    var _docCoverRole2 = interopRequireDefault(docCoverRole_1);
+    var _docCreditRole2 = interopRequireDefault(docCreditRole_1);
+    var _docCreditsRole2 = interopRequireDefault(docCreditsRole_1);
+    var _docDedicationRole2 = interopRequireDefault(docDedicationRole_1);
+    var _docEndnoteRole2 = interopRequireDefault(docEndnoteRole_1);
+    var _docEndnotesRole2 = interopRequireDefault(docEndnotesRole_1);
+    var _docEpigraphRole2 = interopRequireDefault(docEpigraphRole_1);
+    var _docEpilogueRole2 = interopRequireDefault(docEpilogueRole_1);
+    var _docErrataRole2 = interopRequireDefault(docErrataRole_1);
+    var _docExampleRole2 = interopRequireDefault(docExampleRole_1);
+    var _docFootnoteRole2 = interopRequireDefault(docFootnoteRole_1);
+    var _docForewordRole2 = interopRequireDefault(docForewordRole_1);
+    var _docGlossaryRole2 = interopRequireDefault(docGlossaryRole_1);
+    var _docGlossrefRole2 = interopRequireDefault(docGlossrefRole_1);
+    var _docIndexRole2 = interopRequireDefault(docIndexRole_1);
+    var _docIntroductionRole2 = interopRequireDefault(docIntroductionRole_1);
+    var _docNoterefRole2 = interopRequireDefault(docNoterefRole_1);
+    var _docNoticeRole2 = interopRequireDefault(docNoticeRole_1);
+    var _docPagebreakRole2 = interopRequireDefault(docPagebreakRole_1);
+    var _docPagelistRole2 = interopRequireDefault(docPagelistRole_1);
+    var _docPartRole2 = interopRequireDefault(docPartRole_1);
+    var _docPrefaceRole2 = interopRequireDefault(docPrefaceRole_1);
+    var _docPrologueRole2 = interopRequireDefault(docPrologueRole_1);
+    var _docPullquoteRole2 = interopRequireDefault(docPullquoteRole_1);
+    var _docQnaRole2 = interopRequireDefault(docQnaRole_1);
+    var _docSubtitleRole2 = interopRequireDefault(docSubtitleRole_1);
+    var _docTipRole2 = interopRequireDefault(docTipRole_1);
+    var _docTocRole2 = interopRequireDefault(docTocRole_1);
+    var ariaDpubRoles2 = new _map.default([["doc-abstract", _docAbstractRole2.default], ["doc-acknowledgments", _docAcknowledgmentsRole2.default], ["doc-afterword", _docAfterwordRole2.default], ["doc-appendix", _docAppendixRole2.default], ["doc-backlink", _docBacklinkRole2.default], ["doc-biblioentry", _docBiblioentryRole2.default], ["doc-bibliography", _docBibliographyRole2.default], ["doc-biblioref", _docBibliorefRole2.default], ["doc-chapter", _docChapterRole2.default], ["doc-colophon", _docColophonRole2.default], ["doc-conclusion", _docConclusionRole2.default], ["doc-cover", _docCoverRole2.default], ["doc-credit", _docCreditRole2.default], ["doc-credits", _docCreditsRole2.default], ["doc-dedication", _docDedicationRole2.default], ["doc-endnote", _docEndnoteRole2.default], ["doc-endnotes", _docEndnotesRole2.default], ["doc-epigraph", _docEpigraphRole2.default], ["doc-epilogue", _docEpilogueRole2.default], ["doc-errata", _docErrataRole2.default], ["doc-example", _docExampleRole2.default], ["doc-footnote", _docFootnoteRole2.default], ["doc-foreword", _docForewordRole2.default], ["doc-glossary", _docGlossaryRole2.default], ["doc-glossref", _docGlossrefRole2.default], ["doc-index", _docIndexRole2.default], ["doc-introduction", _docIntroductionRole2.default], ["doc-noteref", _docNoterefRole2.default], ["doc-notice", _docNoticeRole2.default], ["doc-pagebreak", _docPagebreakRole2.default], ["doc-pagelist", _docPagelistRole2.default], ["doc-part", _docPartRole2.default], ["doc-preface", _docPrefaceRole2.default], ["doc-prologue", _docPrologueRole2.default], ["doc-pullquote", _docPullquoteRole2.default], ["doc-qna", _docQnaRole2.default], ["doc-subtitle", _docSubtitleRole2.default], ["doc-tip", _docTipRole2.default], ["doc-toc", _docTocRole2.default]]);
+    var _default2 = ariaDpubRoles2;
+    exports2.default = _default2;
+  });
+  var rolesMap_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var _getIterator2 = interopRequireDefault(getIterator$7);
+    var _isArray = interopRequireDefault(isArray$3);
+    var _getIteratorMethod2 = interopRequireDefault(getIteratorMethod);
+    var _symbol = interopRequireDefault(symbol$3);
+    var _from = interopRequireDefault(from$3);
+    var _slice = interopRequireDefault(slice$3);
+    var _defineProperty2 = interopRequireDefault(defineProperty$1$1);
+    var _assign = interopRequireDefault(assign$4);
+    var _keys = interopRequireDefault(keys$4);
+    var _forEach = interopRequireDefault(forEach$6);
+    var _map = interopRequireDefault(map);
+    var _ariaAbstractRoles2 = interopRequireDefault(ariaAbstractRoles_1);
+    var _ariaLiteralRoles2 = interopRequireDefault(ariaLiteralRoles_1);
+    var _ariaDpubRoles2 = interopRequireDefault(ariaDpubRoles_1);
+    var _context;
+    function _createForOfIteratorHelper2(o, allowArrayLike) {
+      var it;
+      if (typeof _symbol.default === "undefined" || (0, _getIteratorMethod2.default)(o) == null) {
+        if ((0, _isArray.default)(o) || (it = _unsupportedIterableToArray2(o)) || allowArrayLike) {
+          if (it) o = it;
+          var i2 = 0;
+          var F2 = function F3() {
+          };
+          return { s: F2, n: function n2() {
+            if (i2 >= o.length) return { done: true };
+            return { done: false, value: o[i2++] };
+          }, e: function e2(_e) {
+            throw _e;
+          }, f: F2 };
+        }
+        throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+      }
+      var normalCompletion = true, didErr = false, err;
+      return { s: function s() {
+        it = (0, _getIterator2.default)(o);
+      }, n: function n2() {
+        var step = it.next();
+        normalCompletion = step.done;
+        return step;
+      }, e: function e2(_e2) {
+        didErr = true;
+        err = _e2;
+      }, f: function f2() {
+        try {
+          if (!normalCompletion && it.return != null) it.return();
+        } finally {
+          if (didErr) throw err;
+        }
+      } };
+    }
+    function _unsupportedIterableToArray2(o, minLen) {
+      var _context2;
+      if (!o) return;
+      if (typeof o === "string") return _arrayLikeToArray2(o, minLen);
+      var n2 = (0, _slice.default)(_context2 = Object.prototype.toString.call(o)).call(_context2, 8, -1);
+      if (n2 === "Object" && o.constructor) n2 = o.constructor.name;
+      if (n2 === "Map" || n2 === "Set") return (0, _from.default)(o);
+      if (n2 === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n2)) return _arrayLikeToArray2(o, minLen);
+    }
+    function _arrayLikeToArray2(arr, len) {
+      if (len == null || len > arr.length) len = arr.length;
+      for (var i2 = 0, arr2 = new Array(len); i2 < len; i2++) {
+        arr2[i2] = arr[i2];
+      }
+      return arr2;
+    }
+    var rolesMap2 = new _map.default([]);
+    (0, _forEach.default)(_context = [_ariaAbstractRoles2.default, _ariaLiteralRoles2.default, _ariaDpubRoles2.default]).call(_context, function(roleSet) {
+      (0, _forEach.default)(roleSet).call(roleSet, function(roleDefinition, name) {
+        return rolesMap2.set(name, roleDefinition);
+      });
+    });
+    (0, _forEach.default)(rolesMap2).call(rolesMap2, function(roleDefinition, name) {
+      var _iterator = _createForOfIteratorHelper2(roleDefinition.superClass), _step;
+      try {
+        for (_iterator.s(); !(_step = _iterator.n()).done; ) {
+          var superClassIter = _step.value;
+          var _iterator2 = _createForOfIteratorHelper2(superClassIter), _step2;
+          try {
+            for (_iterator2.s(); !(_step2 = _iterator2.n()).done; ) {
+              var superClassName = _step2.value;
+              var superClassDefinition = rolesMap2.get(superClassName);
+              if (superClassDefinition) {
+                for (var _i = 0, _Object$keys = (0, _keys.default)(superClassDefinition.props); _i < _Object$keys.length; _i++) {
+                  var prop = _Object$keys[_i];
+                  if (!Object.prototype.hasOwnProperty.call(roleDefinition.props, prop)) {
+                    (0, _assign.default)(roleDefinition.props, (0, _defineProperty2.default)({}, prop, superClassDefinition.props[prop]));
+                  }
+                }
+              }
+            }
+          } catch (err) {
+            _iterator2.e(err);
+          } finally {
+            _iterator2.f();
+          }
+        }
+      } catch (err) {
+        _iterator.e(err);
+      } finally {
+        _iterator.f();
+      }
+    });
+    var _default2 = rolesMap2;
+    exports2.default = _default2;
+  });
+  collection("Set", function(init) {
+    return function Set2() {
+      return init(this, arguments.length ? arguments[0] : void 0);
+    };
+  }, collectionStrong);
+  var $TypeError$2$1 = TypeError;
+  var aSet$1 = function(it) {
+    if (typeof it == "object" && "size" in it && "has" in it && "add" in it && "delete" in it && "keys" in it) return it;
+    throw new $TypeError$2$1(tryToString(it) + " is not a set");
+  };
+  var Set$3 = getBuiltIn("Set");
+  var SetPrototype = Set$3.prototype;
+  var setHelpers = {
+    Set: Set$3,
+    add: caller("add", 1),
+    has: caller("has", 1),
+    remove: caller("delete", 1),
+    proto: SetPrototype
+  };
+  var iterateSimple$1 = function(record, fn2, ITERATOR_INSTEAD_OF_RECORD) {
+    var iterator2 = ITERATOR_INSTEAD_OF_RECORD ? record : record.iterator;
+    var next = record.next;
+    var step, result;
+    while (!(step = call$4(next, iterator2)).done) {
+      result = fn2(step.value);
+      if (result !== void 0) return result;
+    }
+  };
+  var iterateSimple = iterateSimple$1;
+  var setIterate = function(set2, fn2, interruptible) {
+    return interruptible ? iterateSimple(set2.keys(), fn2, true) : set2.forEach(fn2);
+  };
+  var require$$0$b = setHelpers;
+  var iterate = setIterate;
+  var Set$2 = require$$0$b.Set;
+  var add$3 = require$$0$b.add;
+  var setClone = function(set2) {
+    var result = new Set$2();
+    iterate(set2, function(it) {
+      add$3(result, it);
+    });
+    return result;
+  };
+  var setSize$1 = function(set2) {
+    return set2.size;
+  };
+  var getIteratorDirect$1 = function(obj) {
+    return {
+      iterator: obj,
+      next: obj.next,
+      done: false
+    };
+  };
+  var getIteratorDirect = getIteratorDirect$1;
+  var INVALID_SIZE = "Invalid size";
+  var $RangeError$2 = RangeError;
+  var $TypeError$1$1 = TypeError;
+  var max$3 = Math.max;
+  var SetRecord = function(set2, intSize) {
+    this.set = set2;
+    this.size = max$3(intSize, 0);
+    this.has = aCallable(set2.has);
+    this.keys = aCallable(set2.keys);
+  };
+  SetRecord.prototype = {
+    getIterator: function() {
+      return getIteratorDirect(anObject(call$4(this.keys, this.set)));
+    },
+    includes: function(it) {
+      return call$4(this.has, this.set, it);
+    }
+  };
+  var getSetRecord$1 = function(obj) {
+    anObject(obj);
+    var numSize = +obj.size;
+    if (numSize !== numSize) throw new $TypeError$1$1(INVALID_SIZE);
+    var intSize = toIntegerOrInfinity(numSize);
+    if (intSize < 0) throw new $RangeError$2(INVALID_SIZE);
+    return new SetRecord(obj, intSize);
+  };
+  var aSet = aSet$1;
+  var clone = setClone;
+  var size = setSize$1;
+  var getSetRecord = getSetRecord$1;
+  var has$4 = require$$0$b.has;
+  var remove$1 = require$$0$b.remove;
+  var setDifference = function difference2(other) {
+    var O2 = aSet(this);
+    var otherRec = getSetRecord(other);
+    var result = clone(O2);
+    if (size(O2) <= otherRec.size) iterate(O2, function(e2) {
+      if (otherRec.includes(e2)) remove$1(result, e2);
+    });
+    else iterateSimple(otherRec.getIterator(), function(e2) {
+      if (has$4(O2, e2)) remove$1(result, e2);
+    });
+    return result;
+  };
+  var setMethodAcceptSetLike$1 = function() {
+    return false;
+  };
+  var difference = setDifference;
+  var setMethodAcceptSetLike = setMethodAcceptSetLike$1;
+  var INCORRECT$4 = !setMethodAcceptSetLike();
+  $({ target: "Set", proto: true, real: true, forced: INCORRECT$4 }, {
+    difference
+  });
+  var Set$1 = require$$0$b.Set;
+  var add$2 = require$$0$b.add;
+  var has$3 = require$$0$b.has;
+  var setIntersection = function intersection2(other) {
+    var O2 = aSet(this);
+    var otherRec = getSetRecord(other);
+    var result = new Set$1();
+    if (size(O2) > otherRec.size) {
+      iterateSimple(otherRec.getIterator(), function(e2) {
+        if (has$3(O2, e2)) add$2(result, e2);
+      });
+    } else {
+      iterate(O2, function(e2) {
+        if (otherRec.includes(e2)) add$2(result, e2);
+      });
+    }
+    return result;
+  };
+  var intersection = setIntersection;
+  var INCORRECT$3 = !setMethodAcceptSetLike();
+  $({ target: "Set", proto: true, real: true, forced: INCORRECT$3 }, {
+    intersection
+  });
+  var has$2 = require$$0$b.has;
+  var setIsDisjointFrom = function isDisjointFrom2(other) {
+    var O2 = aSet(this);
+    var otherRec = getSetRecord(other);
+    if (size(O2) <= otherRec.size) return iterate(O2, function(e2) {
+      if (otherRec.includes(e2)) return false;
+    }, true) !== false;
+    var iterator2 = otherRec.getIterator();
+    return iterateSimple(iterator2, function(e2) {
+      if (has$2(O2, e2)) return iteratorClose(iterator2, "normal", false);
+    }) !== false;
+  };
+  var isDisjointFrom = setIsDisjointFrom;
+  var INCORRECT$2 = !setMethodAcceptSetLike();
+  $({ target: "Set", proto: true, real: true, forced: INCORRECT$2 }, {
+    isDisjointFrom
+  });
+  var setIsSubsetOf = function isSubsetOf2(other) {
+    var O2 = aSet(this);
+    var otherRec = getSetRecord(other);
+    if (size(O2) > otherRec.size) return false;
+    return iterate(O2, function(e2) {
+      if (!otherRec.includes(e2)) return false;
+    }, true) !== false;
+  };
+  var isSubsetOf = setIsSubsetOf;
+  var INCORRECT$1 = !setMethodAcceptSetLike();
+  $({ target: "Set", proto: true, real: true, forced: INCORRECT$1 }, {
+    isSubsetOf
+  });
+  var has$1 = require$$0$b.has;
+  var setIsSupersetOf = function isSupersetOf2(other) {
+    var O2 = aSet(this);
+    var otherRec = getSetRecord(other);
+    if (size(O2) < otherRec.size) return false;
+    var iterator2 = otherRec.getIterator();
+    return iterateSimple(iterator2, function(e2) {
+      if (!has$1(O2, e2)) return iteratorClose(iterator2, "normal", false);
+    }) !== false;
+  };
+  var isSupersetOf = setIsSupersetOf;
+  var INCORRECT = !setMethodAcceptSetLike();
+  $({ target: "Set", proto: true, real: true, forced: INCORRECT }, {
+    isSupersetOf
+  });
+  var add$1 = require$$0$b.add;
+  var has$7 = require$$0$b.has;
+  var remove = require$$0$b.remove;
+  var setSymmetricDifference = function symmetricDifference2(other) {
+    var O2 = aSet(this);
+    var keysIter = getSetRecord(other).getIterator();
+    var result = clone(O2);
+    iterateSimple(keysIter, function(e2) {
+      if (has$7(O2, e2)) remove(result, e2);
+      else add$1(result, e2);
+    });
+    return result;
+  };
+  var symmetricDifference = setSymmetricDifference;
+  $({ target: "Set", proto: true, real: true, forced: !setMethodAcceptSetLike() }, {
+    symmetricDifference
+  });
+  var add = require$$0$b.add;
+  var setUnion = function union2(other) {
+    var O2 = aSet(this);
+    var keysIter = getSetRecord(other).getIterator();
+    var result = clone(O2);
+    iterateSimple(keysIter, function(it) {
+      add(result, it);
+    });
+    return result;
+  };
+  var union = setUnion;
+  $({ target: "Set", proto: true, real: true, forced: !setMethodAcceptSetLike() }, {
+    union
+  });
+  var set$2 = path.Set;
+  var parent$b = set$2;
+  var set$1 = parent$b;
+  var require$$0$a = set$1;
+  var set = require$$0$a;
+  var isArray$2$1 = parent$w;
+  var parent$a = isArray$2$1;
+  var isArray$1$1 = parent$a;
+  var require$$0$9 = isArray$1$1;
+  var isArray$8 = require$$0$9;
+  var _Array$isArray = isArray$8;
+  var arrayWithHoles = createCommonjsModule(function(module2) {
+    function _arrayWithHoles2(r2) {
+      if (_Array$isArray(r2)) return r2;
+    }
+    module2.exports = _arrayWithHoles2, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+  });
+  var $TypeError$e = TypeError;
+  var getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+  var SILENT_ON_NON_WRITABLE_LENGTH_SET = DESCRIPTORS && !function() {
+    if (this !== void 0) return true;
+    try {
+      Object.defineProperty([], "length", { writable: false }).length = 1;
+    } catch (error) {
+      return error instanceof TypeError;
+    }
+  }();
+  var arraySetLength = SILENT_ON_NON_WRITABLE_LENGTH_SET ? function(O2, length) {
+    if (isArray$6(O2) && !getOwnPropertyDescriptor(O2, "length").writable) {
+      throw new $TypeError$e("Cannot set read only .length");
+    }
+    return O2.length = length;
+  } : function(O2, length) {
+    return O2.length = length;
+  };
+  var setArrayLength = arraySetLength;
+  var INCORRECT_TO_LENGTH = fails(function() {
+    return [].push.call({ length: 4294967296 }, 1) !== 4294967297;
+  });
+  var properErrorOnNonWritableLength = function() {
+    try {
+      Object.defineProperty([], "length", { writable: false }).push();
+    } catch (error) {
+      return error instanceof TypeError;
+    }
+  };
+  var FORCED$1 = INCORRECT_TO_LENGTH || !properErrorOnNonWritableLength();
+  $({ target: "Array", proto: true, arity: 1, forced: FORCED$1 }, {
+    // eslint-disable-next-line no-unused-vars -- required for `.length`
+    push: function push2(item) {
+      var O2 = toObject$1(this);
+      var len = lengthOfArrayLike(O2);
+      var argCount = arguments.length;
+      doesNotExceedSafeInteger(len + argCount);
+      for (var i2 = 0; i2 < argCount; i2++) {
+        O2[len] = arguments[i2];
+        len++;
+      }
+      setArrayLength(O2, len);
+      return len;
+    }
+  });
+  var push$5 = getBuiltInPrototypeMethod("Array", "push");
+  var method$4 = push$5;
+  var ArrayPrototype$4 = Array.prototype;
+  var push$4 = function(it) {
+    var own = it.push;
+    return it === ArrayPrototype$4 || isPrototypeOf(ArrayPrototype$4, it) && own === ArrayPrototype$4.push ? method$4 : own;
+  };
+  var parent$9 = push$4;
+  var push$3 = parent$9;
+  var parent$8 = push$3;
+  var push$2 = parent$8;
+  var parent$7 = push$2;
+  var push$1 = parent$7;
+  var require$$0$8 = push$1;
+  var push = require$$0$8;
+  var _pushInstanceProperty = push;
+  var iterableToArrayLimit = createCommonjsModule(function(module2) {
+    function _iterableToArrayLimit2(r2, l2) {
+      var t2 = null == r2 ? null : "undefined" != typeof _Symbol && _getIteratorMethod(r2) || r2["@@iterator"];
+      if (null != t2) {
+        var e2, n2, i2, u2, a = [], f2 = true, o = false;
+        try {
+          if (i2 = (t2 = t2.call(r2)).next, 0 === l2) {
+            if (Object(t2) !== t2) return;
+            f2 = false;
+          } else for (; !(f2 = (e2 = i2.call(t2)).done) && (_pushInstanceProperty(a).call(a, e2.value), a.length !== l2); f2 = true) ;
+        } catch (r3) {
+          o = true, n2 = r3;
+        } finally {
+          try {
+            if (!f2 && null != t2["return"] && (u2 = t2["return"](), Object(u2) !== u2)) return;
+          } finally {
+            if (o) throw n2;
+          }
+        }
+        return a;
+      }
+    }
+    module2.exports = _iterableToArrayLimit2, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+  });
+  var slice$2 = parent$n;
+  var parent$6 = slice$2;
+  var slice$1 = parent$6;
+  var require$$0$7 = slice$1;
+  var slice$7 = require$$0$7;
+  var from$2 = parent$p;
+  var parent$5 = from$2;
+  var from$1 = parent$5;
+  var require$$0$6 = from$1;
+  var from = require$$0$6;
+  var arrayLikeToArray = createCommonjsModule(function(module2) {
+    function _arrayLikeToArray2(r2, a) {
+      (null == a || a > r2.length) && (a = r2.length);
+      for (var e2 = 0, n2 = Array(a); e2 < a; e2++) n2[e2] = r2[e2];
+      return n2;
+    }
+    module2.exports = _arrayLikeToArray2, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+  });
+  var _sliceInstanceProperty = slice$7;
+  var _Array$from = from;
+  var unsupportedIterableToArray = createCommonjsModule(function(module2) {
+    function _unsupportedIterableToArray2(r2, a) {
+      if (r2) {
+        var _context;
+        if ("string" == typeof r2) return arrayLikeToArray(r2, a);
+        var t2 = _sliceInstanceProperty(_context = {}.toString.call(r2)).call(_context, 8, -1);
+        return "Object" === t2 && r2.constructor && (t2 = r2.constructor.name), "Map" === t2 || "Set" === t2 ? _Array$from(r2) : "Arguments" === t2 || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t2) ? arrayLikeToArray(r2, a) : void 0;
+      }
+    }
+    module2.exports = _unsupportedIterableToArray2, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+  });
+  var nonIterableRest = createCommonjsModule(function(module2) {
+    function _nonIterableRest2() {
+      throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+    }
+    module2.exports = _nonIterableRest2, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+  });
+  var slicedToArray = createCommonjsModule(function(module2) {
+    function _slicedToArray2(r2, e2) {
+      return arrayWithHoles(r2) || iterableToArrayLimit(r2, e2) || unsupportedIterableToArray(r2, e2) || nonIterableRest();
+    }
+    module2.exports = _slicedToArray2, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+  });
+  var entries$3 = getBuiltInPrototypeMethod("Array", "entries");
+  var parent$4 = entries$3;
+  var entries$2 = parent$4;
+  var method$3 = entries$2;
+  var ArrayPrototype$3 = Array.prototype;
+  var DOMIterables$1 = {
+    DOMTokenList: true,
+    NodeList: true
+  };
+  var entries$1 = function(it) {
+    var own = it.entries;
+    return it === ArrayPrototype$3 || isPrototypeOf(ArrayPrototype$3, it) && own === ArrayPrototype$3.entries || hasOwn$4(DOMIterables$1, classof(it)) ? method$3 : own;
+  };
+  var require$$0$5 = entries$1;
+  var entries = require$$0$5;
+  var $find = require$$0$o.find;
+  var FIND = "find";
+  var SKIPS_HOLES = true;
+  if (FIND in []) Array(1)[FIND](function() {
+    SKIPS_HOLES = false;
+  });
+  $({ target: "Array", proto: true, forced: SKIPS_HOLES }, {
+    find: function find2(callbackfn) {
+      return $find(this, callbackfn, arguments.length > 1 ? arguments[1] : void 0);
+    }
+  });
+  var find$3 = getBuiltInPrototypeMethod("Array", "find");
+  var method$2 = find$3;
+  var ArrayPrototype$2 = Array.prototype;
+  var find$2 = function(it) {
+    var own = it.find;
+    return it === ArrayPrototype$2 || isPrototypeOf(ArrayPrototype$2, it) && own === ArrayPrototype$2.find ? method$2 : own;
+  };
+  var parent$3 = find$2;
+  var find$1 = parent$3;
+  var require$$0$4 = find$1;
+  var find = require$$0$4;
+  var $RangeError$1 = RangeError;
+  var stringRepeat = function repeat2(count) {
+    var str = toString$6(requireObjectCoercible(this));
+    var result = "";
+    var n2 = toIntegerOrInfinity(count);
+    if (n2 < 0 || n2 === Infinity) throw new $RangeError$1("Wrong number of repetitions");
+    for (; n2 > 0; (n2 >>>= 1) && (str += str)) if (n2 & 1) result += str;
+    return result;
+  };
+  var $repeat = stringRepeat;
+  var repeat = uncurryThis$1($repeat);
+  var stringSlice = uncurryThis$1("".slice);
+  var ceil = Math.ceil;
+  var createMethod = function(IS_END) {
+    return function($this, maxLength2, fillString) {
+      var S2 = toString$6(requireObjectCoercible($this));
+      var intMaxLength = toLength$3(maxLength2);
+      var stringLength = S2.length;
+      var fillStr = fillString === void 0 ? " " : toString$6(fillString);
+      var fillLen, stringFiller;
+      if (intMaxLength <= stringLength || fillStr === "") return S2;
+      fillLen = intMaxLength - stringLength;
+      stringFiller = repeat(fillStr, ceil(fillLen / fillStr.length));
+      if (stringFiller.length > fillLen) stringFiller = stringSlice(stringFiller, 0, fillLen);
+      return IS_END ? S2 + stringFiller : stringFiller + S2;
+    };
+  };
+  var stringPad = {
+    // `String.prototype.padStart` method
+    // https://tc39.es/ecma262/#sec-string.prototype.padstart
+    start: createMethod(false),
+    // `String.prototype.padEnd` method
+    // https://tc39.es/ecma262/#sec-string.prototype.padend
+    end: createMethod(true)
+  };
+  var require$$0$3 = stringPad;
+  var padStart = require$$0$3.start;
+  var $RangeError$3 = RangeError;
+  var $isFinite = isFinite;
+  var abs$2 = Math.abs;
+  var DatePrototype = Date.prototype;
+  var nativeDateToISOString = DatePrototype.toISOString;
+  var thisTimeValue = uncurryThis$1(DatePrototype.getTime);
+  var getUTCDate = uncurryThis$1(DatePrototype.getUTCDate);
+  var getUTCFullYear = uncurryThis$1(DatePrototype.getUTCFullYear);
+  var getUTCHours = uncurryThis$1(DatePrototype.getUTCHours);
+  var getUTCMilliseconds = uncurryThis$1(DatePrototype.getUTCMilliseconds);
+  var getUTCMinutes = uncurryThis$1(DatePrototype.getUTCMinutes);
+  var getUTCMonth = uncurryThis$1(DatePrototype.getUTCMonth);
+  var getUTCSeconds = uncurryThis$1(DatePrototype.getUTCSeconds);
+  var dateToIsoString = fails(function() {
+    return nativeDateToISOString.call(new Date(-5e13 - 1)) !== "0385-07-25T07:06:39.999Z";
+  }) || !fails(function() {
+    nativeDateToISOString.call(/* @__PURE__ */ new Date(NaN));
+  }) ? function toISOString2() {
+    if (!$isFinite(thisTimeValue(this))) throw new $RangeError$3("Invalid time value");
+    var date = this;
+    var year = getUTCFullYear(date);
+    var milliseconds = getUTCMilliseconds(date);
+    var sign = year < 0 ? "-" : year > 9999 ? "+" : "";
+    return sign + padStart(abs$2(year), sign ? 6 : 4, 0) + "-" + padStart(getUTCMonth(date) + 1, 2, 0) + "-" + padStart(getUTCDate(date), 2, 0) + "T" + padStart(getUTCHours(date), 2, 0) + ":" + padStart(getUTCMinutes(date), 2, 0) + ":" + padStart(getUTCSeconds(date), 2, 0) + "." + padStart(milliseconds, 3, 0) + "Z";
+  } : nativeDateToISOString;
+  var toISOString$2 = dateToIsoString;
+  var FORCED = fails(function() {
+    return (/* @__PURE__ */ new Date(NaN)).toJSON() !== null || call$4(Date.prototype.toJSON, { toISOString: function() {
+      return 1;
+    } }) !== 1;
+  });
+  $({ target: "Date", proto: true, forced: FORCED }, {
+    // eslint-disable-next-line no-unused-vars -- required for `.length`
+    toJSON: function toJSON(key2) {
+      var O2 = toObject$1(this);
+      var pv = toPrimitive$5(O2, "number");
+      return typeof pv == "number" && !isFinite(pv) ? null : !("toISOString" in O2) && classof$2(O2) === "Date" ? call$4(toISOString$2, O2) : O2.toISOString();
+    }
+  });
+  if (!path.JSON) path.JSON = { stringify: JSON.stringify };
+  var stringify$2 = function stringify2(it, replacer, space) {
+    return apply(path.JSON.stringify, null, arguments);
+  };
+  var parent$2 = stringify$2;
+  var stringify$1 = parent$2;
+  var require$$0$2 = stringify$1;
+  var stringify = require$$0$2;
+  var concat$3 = getBuiltInPrototypeMethod("Array", "concat");
+  var method$1 = concat$3;
+  var ArrayPrototype$1 = Array.prototype;
+  var concat$2 = function(it) {
+    var own = it.concat;
+    return it === ArrayPrototype$1 || isPrototypeOf(ArrayPrototype$1, it) && own === ArrayPrototype$1.concat ? method$1 : own;
+  };
+  var parent$1 = concat$2;
+  var concat$1 = parent$1;
+  var require$$0$1$1 = concat$1;
+  var concat$5 = require$$0$1$1;
+  var keys$3 = getBuiltInPrototypeMethod("Array", "keys");
+  var parent = keys$3;
+  var keys$2$1 = parent;
+  var method = keys$2$1;
+  var ArrayPrototype = Array.prototype;
+  var DOMIterables = {
+    DOMTokenList: true,
+    NodeList: true
+  };
+  var keys$1$1 = function(it) {
+    var own = it.keys;
+    return it === ArrayPrototype || isPrototypeOf(ArrayPrototype, it) && own === ArrayPrototype.keys || hasOwn$4(DOMIterables, classof(it)) ? method : own;
+  };
+  var require$$0$s = keys$1$1;
+  var keys$8 = require$$0$s;
+  var arrayWithoutHoles = createCommonjsModule(function(module2) {
+    function _arrayWithoutHoles(r2) {
+      if (_Array$isArray(r2)) return arrayLikeToArray(r2);
+    }
+    module2.exports = _arrayWithoutHoles, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+  });
+  var iterableToArray = createCommonjsModule(function(module2) {
+    function _iterableToArray(r2) {
+      if ("undefined" != typeof _Symbol && null != _getIteratorMethod(r2) || null != r2["@@iterator"]) return _Array$from(r2);
+    }
+    module2.exports = _iterableToArray, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+  });
+  var nonIterableSpread = createCommonjsModule(function(module2) {
+    function _nonIterableSpread() {
+      throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+    }
+    module2.exports = _nonIterableSpread, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+  });
+  var toConsumableArray = createCommonjsModule(function(module2) {
+    function _toConsumableArray(r2) {
+      return arrayWithoutHoles(r2) || iterableToArray(r2) || unsupportedIterableToArray(r2) || nonIterableSpread();
+    }
+    module2.exports = _toConsumableArray, module2.exports.__esModule = true, module2.exports["default"] = module2.exports;
+  });
+  var elementRoleMap_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var _set = interopRequireDefault(set);
+    var _slicedToArray2 = interopRequireDefault(slicedToArray);
+    var _entries = interopRequireDefault(entries);
+    var _find = interopRequireDefault(find);
+    var _stringify = interopRequireDefault(stringify);
+    var _concat = interopRequireDefault(concat$5);
+    var _keys = interopRequireDefault(keys$8);
+    var _toConsumableArray2 = interopRequireDefault(toConsumableArray);
+    var _forEach = interopRequireDefault(forEach$6);
+    var _map = interopRequireDefault(map);
+    var _rolesMap2 = interopRequireDefault(rolesMap_1);
+    var _context;
+    var elementRoleMap2 = new _map.default([]);
+    (0, _forEach.default)(_context = (0, _toConsumableArray2.default)((0, _keys.default)(_rolesMap2.default).call(_rolesMap2.default))).call(_context, function(key2) {
+      var role2 = _rolesMap2.default.get(key2);
+      if (role2) {
+        var _context2, _context3;
+        (0, _forEach.default)(_context2 = (0, _concat.default)(_context3 = []).call(_context3, (0, _toConsumableArray2.default)(role2.baseConcepts), (0, _toConsumableArray2.default)(role2.relatedConcepts))).call(_context2, function(relation2) {
+          if (relation2.module === "HTML") {
+            var concept2 = relation2.concept;
+            if (concept2) {
+              var _context4;
+              var conceptStr = (0, _stringify.default)(concept2);
+              var roles2 = ((0, _find.default)(_context4 = (0, _toConsumableArray2.default)((0, _entries.default)(elementRoleMap2).call(elementRoleMap2))).call(_context4, function(_ref) {
+                var _ref2 = (0, _slicedToArray2.default)(_ref, 2), key3 = _ref2[0];
+                _ref2[1];
+                return (0, _stringify.default)(key3) === conceptStr;
+              }) || [])[1];
+              if (!roles2) {
+                roles2 = new _set.default([]);
+              }
+              roles2.add(key2);
+              elementRoleMap2.set(concept2, roles2);
+            }
+          }
+        });
+      }
+    });
+    var _default2 = elementRoleMap2;
+    exports2.default = _default2;
+  });
+  var roleElementMap_1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    var _set = interopRequireDefault(set);
+    var _concat = interopRequireDefault(concat$5);
+    var _keys = interopRequireDefault(keys$8);
+    var _toConsumableArray2 = interopRequireDefault(toConsumableArray);
+    var _forEach = interopRequireDefault(forEach$6);
+    var _map = interopRequireDefault(map);
+    var _rolesMap2 = interopRequireDefault(rolesMap_1);
+    var _context;
+    var roleElementMap2 = new _map.default([]);
+    (0, _forEach.default)(_context = (0, _toConsumableArray2.default)((0, _keys.default)(_rolesMap2.default).call(_rolesMap2.default))).call(_context, function(key2) {
+      var role2 = _rolesMap2.default.get(key2);
+      if (role2) {
+        var _context2, _context3;
+        (0, _forEach.default)(_context2 = (0, _concat.default)(_context3 = []).call(_context3, (0, _toConsumableArray2.default)(role2.baseConcepts), (0, _toConsumableArray2.default)(role2.relatedConcepts))).call(_context2, function(relation2) {
+          if (relation2.module === "HTML") {
+            var concept2 = relation2.concept;
+            if (concept2) {
+              var relationConcepts = roleElementMap2.get(key2) || new _set.default([]);
+              relationConcepts.add(concept2);
+              roleElementMap2.set(key2, relationConcepts);
+            }
+          }
+        });
+      }
+    });
+    var _default2 = roleElementMap2;
+    exports2.default = _default2;
+  });
+  var lib$1 = createCommonjsModule(function(module2, exports2) {
+    defineProperty$a(exports2, "__esModule", {
+      value: true
+    });
+    exports2.roleElements = exports2.elementRoles = exports2.roles = exports2.dom = exports2.aria = void 0;
+    var _ariaPropsMap2 = interopRequireDefault(ariaPropsMap_1);
+    var _domMap2 = interopRequireDefault(domMap_1);
+    var _rolesMap2 = interopRequireDefault(rolesMap_1);
+    var _elementRoleMap2 = interopRequireDefault(elementRoleMap_1);
+    var _roleElementMap2 = interopRequireDefault(roleElementMap_1);
+    var aria2 = _ariaPropsMap2.default;
+    exports2.aria = aria2;
+    var dom2 = _domMap2.default;
+    exports2.dom = dom2;
+    var roles2 = _rolesMap2.default;
+    exports2.roles = roles2;
+    var elementRoles2 = _elementRoleMap2.default;
+    exports2.elementRoles = elementRoles2;
+    var roleElements2 = _roleElementMap2.default;
+    exports2.roleElements = roleElements2;
+  });
+  function _objectWithoutPropertiesLoose(r2, e2) {
+    if (null == r2) return {};
+    var t2 = {};
+    for (var n2 in r2) if ({}.hasOwnProperty.call(r2, n2)) {
+      if (-1 !== e2.indexOf(n2)) continue;
+      t2[n2] = r2[n2];
+    }
+    return t2;
+  }
+  var lzString$2 = createCommonjsModule(function(module2) {
+    var LZString = function() {
+      var f2 = String.fromCharCode;
+      var keyStrBase64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+      var keyStrUriSafe = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-$";
+      var baseReverseDic = {};
+      function getBaseValue(alphabet, character2) {
+        if (!baseReverseDic[alphabet]) {
+          baseReverseDic[alphabet] = {};
+          for (var i2 = 0; i2 < alphabet.length; i2++) {
+            baseReverseDic[alphabet][alphabet.charAt(i2)] = i2;
+          }
+        }
+        return baseReverseDic[alphabet][character2];
+      }
+      var LZString2 = {
+        compressToBase64: function(input) {
+          if (input == null) return "";
+          var res = LZString2._compress(input, 6, function(a) {
+            return keyStrBase64.charAt(a);
+          });
+          switch (res.length % 4) {
+            default:
+            case 0:
+              return res;
+            case 1:
+              return res + "===";
+            case 2:
+              return res + "==";
+            case 3:
+              return res + "=";
+          }
+        },
+        decompressFromBase64: function(input) {
+          if (input == null) return "";
+          if (input == "") return null;
+          return LZString2._decompress(input.length, 32, function(index2) {
+            return getBaseValue(keyStrBase64, input.charAt(index2));
+          });
+        },
+        compressToUTF16: function(input) {
+          if (input == null) return "";
+          return LZString2._compress(input, 15, function(a) {
+            return f2(a + 32);
+          }) + " ";
+        },
+        decompressFromUTF16: function(compressed) {
+          if (compressed == null) return "";
+          if (compressed == "") return null;
+          return LZString2._decompress(compressed.length, 16384, function(index2) {
+            return compressed.charCodeAt(index2) - 32;
+          });
+        },
+        //compress into uint8array (UCS-2 big endian format)
+        compressToUint8Array: function(uncompressed) {
+          var compressed = LZString2.compress(uncompressed);
+          var buf = new Uint8Array(compressed.length * 2);
+          for (var i2 = 0, TotalLen = compressed.length; i2 < TotalLen; i2++) {
+            var current_value = compressed.charCodeAt(i2);
+            buf[i2 * 2] = current_value >>> 8;
+            buf[i2 * 2 + 1] = current_value % 256;
+          }
+          return buf;
+        },
+        //decompress from uint8array (UCS-2 big endian format)
+        decompressFromUint8Array: function(compressed) {
+          if (compressed === null || compressed === void 0) {
+            return LZString2.decompress(compressed);
+          } else {
+            var buf = new Array(compressed.length / 2);
+            for (var i2 = 0, TotalLen = buf.length; i2 < TotalLen; i2++) {
+              buf[i2] = compressed[i2 * 2] * 256 + compressed[i2 * 2 + 1];
+            }
+            var result = [];
+            buf.forEach(function(c2) {
+              result.push(f2(c2));
+            });
+            return LZString2.decompress(result.join(""));
+          }
+        },
+        //compress into a string that is already URI encoded
+        compressToEncodedURIComponent: function(input) {
+          if (input == null) return "";
+          return LZString2._compress(input, 6, function(a) {
+            return keyStrUriSafe.charAt(a);
+          });
+        },
+        //decompress from an output of compressToEncodedURIComponent
+        decompressFromEncodedURIComponent: function(input) {
+          if (input == null) return "";
+          if (input == "") return null;
+          input = input.replace(/ /g, "+");
+          return LZString2._decompress(input.length, 32, function(index2) {
+            return getBaseValue(keyStrUriSafe, input.charAt(index2));
+          });
+        },
+        compress: function(uncompressed) {
+          return LZString2._compress(uncompressed, 16, function(a) {
+            return f2(a);
+          });
+        },
+        _compress: function(uncompressed, bitsPerChar, getCharFromInt) {
+          if (uncompressed == null) return "";
+          var i2, value, context_dictionary = {}, context_dictionaryToCreate = {}, context_c = "", context_wc = "", context_w = "", context_enlargeIn = 2, context_dictSize = 3, context_numBits = 2, context_data = [], context_data_val = 0, context_data_position = 0, ii;
+          for (ii = 0; ii < uncompressed.length; ii += 1) {
+            context_c = uncompressed.charAt(ii);
+            if (!Object.prototype.hasOwnProperty.call(context_dictionary, context_c)) {
+              context_dictionary[context_c] = context_dictSize++;
+              context_dictionaryToCreate[context_c] = true;
+            }
+            context_wc = context_w + context_c;
+            if (Object.prototype.hasOwnProperty.call(context_dictionary, context_wc)) {
+              context_w = context_wc;
+            } else {
+              if (Object.prototype.hasOwnProperty.call(context_dictionaryToCreate, context_w)) {
+                if (context_w.charCodeAt(0) < 256) {
+                  for (i2 = 0; i2 < context_numBits; i2++) {
+                    context_data_val = context_data_val << 1;
+                    if (context_data_position == bitsPerChar - 1) {
+                      context_data_position = 0;
+                      context_data.push(getCharFromInt(context_data_val));
+                      context_data_val = 0;
+                    } else {
+                      context_data_position++;
+                    }
+                  }
+                  value = context_w.charCodeAt(0);
+                  for (i2 = 0; i2 < 8; i2++) {
+                    context_data_val = context_data_val << 1 | value & 1;
+                    if (context_data_position == bitsPerChar - 1) {
+                      context_data_position = 0;
+                      context_data.push(getCharFromInt(context_data_val));
+                      context_data_val = 0;
+                    } else {
+                      context_data_position++;
+                    }
+                    value = value >> 1;
+                  }
+                } else {
+                  value = 1;
+                  for (i2 = 0; i2 < context_numBits; i2++) {
+                    context_data_val = context_data_val << 1 | value;
+                    if (context_data_position == bitsPerChar - 1) {
+                      context_data_position = 0;
+                      context_data.push(getCharFromInt(context_data_val));
+                      context_data_val = 0;
+                    } else {
+                      context_data_position++;
+                    }
+                    value = 0;
+                  }
+                  value = context_w.charCodeAt(0);
+                  for (i2 = 0; i2 < 16; i2++) {
+                    context_data_val = context_data_val << 1 | value & 1;
+                    if (context_data_position == bitsPerChar - 1) {
+                      context_data_position = 0;
+                      context_data.push(getCharFromInt(context_data_val));
+                      context_data_val = 0;
+                    } else {
+                      context_data_position++;
+                    }
+                    value = value >> 1;
+                  }
+                }
+                context_enlargeIn--;
+                if (context_enlargeIn == 0) {
+                  context_enlargeIn = Math.pow(2, context_numBits);
+                  context_numBits++;
+                }
+                delete context_dictionaryToCreate[context_w];
+              } else {
+                value = context_dictionary[context_w];
+                for (i2 = 0; i2 < context_numBits; i2++) {
+                  context_data_val = context_data_val << 1 | value & 1;
+                  if (context_data_position == bitsPerChar - 1) {
+                    context_data_position = 0;
+                    context_data.push(getCharFromInt(context_data_val));
+                    context_data_val = 0;
+                  } else {
+                    context_data_position++;
+                  }
+                  value = value >> 1;
+                }
+              }
+              context_enlargeIn--;
+              if (context_enlargeIn == 0) {
+                context_enlargeIn = Math.pow(2, context_numBits);
+                context_numBits++;
+              }
+              context_dictionary[context_wc] = context_dictSize++;
+              context_w = String(context_c);
+            }
+          }
+          if (context_w !== "") {
+            if (Object.prototype.hasOwnProperty.call(context_dictionaryToCreate, context_w)) {
+              if (context_w.charCodeAt(0) < 256) {
+                for (i2 = 0; i2 < context_numBits; i2++) {
+                  context_data_val = context_data_val << 1;
+                  if (context_data_position == bitsPerChar - 1) {
+                    context_data_position = 0;
+                    context_data.push(getCharFromInt(context_data_val));
+                    context_data_val = 0;
+                  } else {
+                    context_data_position++;
+                  }
+                }
+                value = context_w.charCodeAt(0);
+                for (i2 = 0; i2 < 8; i2++) {
+                  context_data_val = context_data_val << 1 | value & 1;
+                  if (context_data_position == bitsPerChar - 1) {
+                    context_data_position = 0;
+                    context_data.push(getCharFromInt(context_data_val));
+                    context_data_val = 0;
+                  } else {
+                    context_data_position++;
+                  }
+                  value = value >> 1;
+                }
+              } else {
+                value = 1;
+                for (i2 = 0; i2 < context_numBits; i2++) {
+                  context_data_val = context_data_val << 1 | value;
+                  if (context_data_position == bitsPerChar - 1) {
+                    context_data_position = 0;
+                    context_data.push(getCharFromInt(context_data_val));
+                    context_data_val = 0;
+                  } else {
+                    context_data_position++;
+                  }
+                  value = 0;
+                }
+                value = context_w.charCodeAt(0);
+                for (i2 = 0; i2 < 16; i2++) {
+                  context_data_val = context_data_val << 1 | value & 1;
+                  if (context_data_position == bitsPerChar - 1) {
+                    context_data_position = 0;
+                    context_data.push(getCharFromInt(context_data_val));
+                    context_data_val = 0;
+                  } else {
+                    context_data_position++;
+                  }
+                  value = value >> 1;
+                }
+              }
+              context_enlargeIn--;
+              if (context_enlargeIn == 0) {
+                context_enlargeIn = Math.pow(2, context_numBits);
+                context_numBits++;
+              }
+              delete context_dictionaryToCreate[context_w];
+            } else {
+              value = context_dictionary[context_w];
+              for (i2 = 0; i2 < context_numBits; i2++) {
+                context_data_val = context_data_val << 1 | value & 1;
+                if (context_data_position == bitsPerChar - 1) {
+                  context_data_position = 0;
+                  context_data.push(getCharFromInt(context_data_val));
+                  context_data_val = 0;
+                } else {
+                  context_data_position++;
+                }
+                value = value >> 1;
+              }
+            }
+            context_enlargeIn--;
+            if (context_enlargeIn == 0) {
+              context_enlargeIn = Math.pow(2, context_numBits);
+              context_numBits++;
+            }
+          }
+          value = 2;
+          for (i2 = 0; i2 < context_numBits; i2++) {
+            context_data_val = context_data_val << 1 | value & 1;
+            if (context_data_position == bitsPerChar - 1) {
+              context_data_position = 0;
+              context_data.push(getCharFromInt(context_data_val));
+              context_data_val = 0;
+            } else {
+              context_data_position++;
+            }
+            value = value >> 1;
+          }
+          while (true) {
+            context_data_val = context_data_val << 1;
+            if (context_data_position == bitsPerChar - 1) {
+              context_data.push(getCharFromInt(context_data_val));
+              break;
+            } else context_data_position++;
+          }
+          return context_data.join("");
+        },
+        decompress: function(compressed) {
+          if (compressed == null) return "";
+          if (compressed == "") return null;
+          return LZString2._decompress(compressed.length, 32768, function(index2) {
+            return compressed.charCodeAt(index2);
+          });
+        },
+        _decompress: function(length, resetValue, getNextValue) {
+          var dictionary = [], enlargeIn = 4, dictSize = 4, numBits = 3, entry = "", result = [], i2, w2, bits, resb, maxpower, power, c2, data2 = { val: getNextValue(0), position: resetValue, index: 1 };
+          for (i2 = 0; i2 < 3; i2 += 1) {
+            dictionary[i2] = i2;
+          }
+          bits = 0;
+          maxpower = Math.pow(2, 2);
+          power = 1;
+          while (power != maxpower) {
+            resb = data2.val & data2.position;
+            data2.position >>= 1;
+            if (data2.position == 0) {
+              data2.position = resetValue;
+              data2.val = getNextValue(data2.index++);
+            }
+            bits |= (resb > 0 ? 1 : 0) * power;
+            power <<= 1;
+          }
+          switch (bits) {
+            case 0:
+              bits = 0;
+              maxpower = Math.pow(2, 8);
+              power = 1;
+              while (power != maxpower) {
+                resb = data2.val & data2.position;
+                data2.position >>= 1;
+                if (data2.position == 0) {
+                  data2.position = resetValue;
+                  data2.val = getNextValue(data2.index++);
+                }
+                bits |= (resb > 0 ? 1 : 0) * power;
+                power <<= 1;
+              }
+              c2 = f2(bits);
+              break;
+            case 1:
+              bits = 0;
+              maxpower = Math.pow(2, 16);
+              power = 1;
+              while (power != maxpower) {
+                resb = data2.val & data2.position;
+                data2.position >>= 1;
+                if (data2.position == 0) {
+                  data2.position = resetValue;
+                  data2.val = getNextValue(data2.index++);
+                }
+                bits |= (resb > 0 ? 1 : 0) * power;
+                power <<= 1;
+              }
+              c2 = f2(bits);
+              break;
+            case 2:
+              return "";
+          }
+          dictionary[3] = c2;
+          w2 = c2;
+          result.push(c2);
+          while (true) {
+            if (data2.index > length) {
+              return "";
+            }
+            bits = 0;
+            maxpower = Math.pow(2, numBits);
+            power = 1;
+            while (power != maxpower) {
+              resb = data2.val & data2.position;
+              data2.position >>= 1;
+              if (data2.position == 0) {
+                data2.position = resetValue;
+                data2.val = getNextValue(data2.index++);
+              }
+              bits |= (resb > 0 ? 1 : 0) * power;
+              power <<= 1;
+            }
+            switch (c2 = bits) {
+              case 0:
+                bits = 0;
+                maxpower = Math.pow(2, 8);
+                power = 1;
+                while (power != maxpower) {
+                  resb = data2.val & data2.position;
+                  data2.position >>= 1;
+                  if (data2.position == 0) {
+                    data2.position = resetValue;
+                    data2.val = getNextValue(data2.index++);
+                  }
+                  bits |= (resb > 0 ? 1 : 0) * power;
+                  power <<= 1;
+                }
+                dictionary[dictSize++] = f2(bits);
+                c2 = dictSize - 1;
+                enlargeIn--;
+                break;
+              case 1:
+                bits = 0;
+                maxpower = Math.pow(2, 16);
+                power = 1;
+                while (power != maxpower) {
+                  resb = data2.val & data2.position;
+                  data2.position >>= 1;
+                  if (data2.position == 0) {
+                    data2.position = resetValue;
+                    data2.val = getNextValue(data2.index++);
+                  }
+                  bits |= (resb > 0 ? 1 : 0) * power;
+                  power <<= 1;
+                }
+                dictionary[dictSize++] = f2(bits);
+                c2 = dictSize - 1;
+                enlargeIn--;
+                break;
+              case 2:
+                return result.join("");
+            }
+            if (enlargeIn == 0) {
+              enlargeIn = Math.pow(2, numBits);
+              numBits++;
+            }
+            if (dictionary[c2]) {
+              entry = dictionary[c2];
+            } else {
+              if (c2 === dictSize) {
+                entry = w2 + w2.charAt(0);
+              } else {
+                return null;
+              }
+            }
+            result.push(entry);
+            dictionary[dictSize++] = w2 + entry.charAt(0);
+            enlargeIn--;
+            w2 = entry;
+            if (enlargeIn == 0) {
+              enlargeIn = Math.pow(2, numBits);
+              numBits++;
+            }
+          }
+        }
+      };
+      return LZString2;
+    }();
+    if (module2 != null) {
+      module2.exports = LZString;
+    } else if (typeof angular !== "undefined" && angular != null) {
+      angular.module("LZString", []).factory("LZString", function() {
+        return LZString;
+      });
+    }
+  });
+  var chalk$1 = null;
+  var readFileSync$1 = null;
+  var codeFrameColumns$1 = null;
+  try {
+    var nodeRequire = module && module.require;
+    readFileSync$1 = nodeRequire.call(module, "fs").readFileSync;
+    codeFrameColumns$1 = nodeRequire.call(module, "@babel/code-frame").codeFrameColumns;
+    chalk$1 = nodeRequire.call(module, "chalk");
+  } catch (_unused) {
+  }
+  function getCodeFrame$1(frame) {
+    var locationStart = frame.indexOf("(") + 1;
+    var locationEnd = frame.indexOf(")");
+    var frameLocation = frame.slice(locationStart, locationEnd);
+    var frameLocationElements = frameLocation.split(":");
+    var _ref = [frameLocationElements[0], parseInt(frameLocationElements[1], 10), parseInt(frameLocationElements[2], 10)], filename = _ref[0], line = _ref[1], column = _ref[2];
+    var rawFileContents = "";
+    try {
+      rawFileContents = readFileSync$1(filename, "utf-8");
+    } catch (_unused2) {
+      return "";
+    }
+    var codeFrame = codeFrameColumns$1(rawFileContents, {
+      start: {
+        line,
+        column
+      }
+    }, {
+      highlightCode: true,
+      linesBelow: 0
+    });
+    return chalk$1.dim(frameLocation) + "\n" + codeFrame + "\n";
+  }
+  function getUserCodeFrame$1() {
+    if (!readFileSync$1 || !codeFrameColumns$1) {
+      return "";
+    }
+    var err = new Error();
+    var firstClientCodeFrame = err.stack.split("\n").slice(1).find(function(frame) {
+      return !frame.includes("node_modules/");
+    });
+    return getCodeFrame$1(firstClientCodeFrame);
+  }
+  var globalObj = typeof window === "undefined" ? global$1$1 : window;
+  var TEXT_NODE$4 = 3;
+  function runWithRealTimers(callback) {
+    return hasJestTimers() ? runWithJestRealTimers(callback).callbackReturnValue : (
+      // istanbul ignore next
+      callback()
+    );
+  }
+  function hasJestTimers() {
+    return typeof jest !== "undefined" && jest !== null && typeof jest.useRealTimers === "function";
+  }
+  function runWithJestRealTimers(callback) {
+    var timerAPI = {
+      clearInterval,
+      clearTimeout,
+      setInterval,
+      setTimeout
+    };
+    if (typeof setImmediate === "function") {
+      timerAPI.setImmediate = setImmediate;
+    }
+    if (typeof clearImmediate === "function") {
+      timerAPI.clearImmediate = clearImmediate;
+    }
+    jest.useRealTimers();
+    var callbackReturnValue = callback();
+    var usedFakeTimers = Object.entries(timerAPI).some(function(_ref) {
+      var name = _ref[0], func = _ref[1];
+      return func !== globalObj[name];
+    });
+    if (usedFakeTimers) {
+      var _timerAPI$setTimeout;
+      jest.useFakeTimers((_timerAPI$setTimeout = timerAPI.setTimeout) != null && _timerAPI$setTimeout.clock ? "modern" : "legacy");
+    }
+    return {
+      callbackReturnValue,
+      usedFakeTimers
+    };
+  }
+  function jestFakeTimersAreEnabled$2() {
+    return hasJestTimers() ? runWithJestRealTimers(function() {
+    }).usedFakeTimers : (
+      // istanbul ignore next
+      false
+    );
+  }
+  function setImmediatePolyfill(fn2) {
+    return globalObj.setTimeout(fn2, 0);
+  }
+  function getTimeFunctions() {
+    return {
+      clearTimeoutFn: globalObj.clearTimeout,
+      setImmediateFn: globalObj.setImmediate || setImmediatePolyfill,
+      setTimeoutFn: globalObj.setTimeout
+    };
+  }
+  var _runWithRealTimers = runWithRealTimers(getTimeFunctions), clearTimeoutFn = _runWithRealTimers.clearTimeoutFn, setImmediateFn = _runWithRealTimers.setImmediateFn, setTimeoutFn = _runWithRealTimers.setTimeoutFn;
+  function getDocument$2() {
+    if (typeof window === "undefined") {
+      throw new Error("Could not find default container");
+    }
+    return window.document;
+  }
+  function getWindowFromNode$2(node) {
+    if (node.defaultView) {
+      return node.defaultView;
+    } else if (node.ownerDocument && node.ownerDocument.defaultView) {
+      return node.ownerDocument.defaultView;
+    } else if (node.window) {
+      return node.window;
+    } else if (node.then instanceof Function) {
+      throw new Error("It looks like you passed a Promise object instead of a DOM node. Did you do something like `fireEvent.click(screen.findBy...` when you meant to use a `getBy` query `fireEvent.click(screen.getBy...`, or await the findBy query `fireEvent.click(await screen.findBy...`?");
+    } else if (Array.isArray(node)) {
+      throw new Error("It looks like you passed an Array instead of a DOM node. Did you do something like `fireEvent.click(screen.getAllBy...` when you meant to use a `getBy` query `fireEvent.click(screen.getBy...`?");
+    } else if (typeof node.debug === "function" && typeof node.logTestingPlaygroundURL === "function") {
+      throw new Error("It looks like you passed a `screen` object. Did you do something like `fireEvent.click(screen, ...` when you meant to use a query, e.g. `fireEvent.click(screen.getBy..., `?");
+    } else {
+      throw new Error(`Unable to find the "window" object for the given node. Please file an issue with the code that's causing you to see this error: https://github.com/testing-library/dom-testing-library/issues/new`);
+    }
+  }
+  function checkContainerType$2(container) {
+    if (!container || !(typeof container.querySelector === "function") || !(typeof container.querySelectorAll === "function")) {
+      throw new TypeError("Expected container to be an Element, a Document or a DocumentFragment but got " + getTypeName(container) + ".");
+    }
+    function getTypeName(object) {
+      if (typeof object === "object") {
+        return object === null ? "null" : object.constructor.name;
+      }
+      return typeof object;
+    }
+  }
+  function inCypress(dom2) {
+    var window2 = dom2.ownerDocument && dom2.ownerDocument.defaultView || void 0;
+    return typeof global$1$1 !== "undefined" && global$1$1.Cypress || typeof window2 !== "undefined" && window2.Cypress;
+  }
+  var inNode = function inNode2() {
+    return typeof process$1 !== "undefined" && process$1.versions !== void 0 && process$1.versions.node !== void 0;
+  };
+  var getMaxLength = function getMaxLength2(dom2) {
+    return inCypress(dom2) ? 0 : typeof process$1 !== "undefined" && process$1.env.DEBUG_PRINT_LIMIT || 7e3;
+  };
+  var _prettyFormat$plugins = build$1$1.plugins, DOMElement$2 = _prettyFormat$plugins.DOMElement, DOMCollection$2 = _prettyFormat$plugins.DOMCollection;
+  function prettyDOM$1(dom2, maxLength2, options) {
+    if (!dom2) {
+      dom2 = getDocument$2().body;
+    }
+    if (typeof maxLength2 !== "number") {
+      maxLength2 = getMaxLength(dom2);
+    }
+    if (maxLength2 === 0) {
+      return "";
+    }
+    if (dom2.documentElement) {
+      dom2 = dom2.documentElement;
+    }
+    var domTypeName = typeof dom2;
+    if (domTypeName === "object") {
+      domTypeName = dom2.constructor.name;
+    } else {
+      dom2 = {};
+    }
+    if (!("outerHTML" in dom2)) {
+      throw new TypeError("Expected an element or document but got " + domTypeName);
+    }
+    var debugContent = build$1$1(dom2, _extends({
+      plugins: [DOMElement$2, DOMCollection$2],
+      printFunctionName: false,
+      highlight: inNode()
+    }, options));
+    return maxLength2 !== void 0 && dom2.outerHTML.length > maxLength2 ? debugContent.slice(0, maxLength2) + "..." : debugContent;
+  }
+  var logDOM$1 = function logDOM2() {
+    var userCodeFrame = getUserCodeFrame$1();
+    if (userCodeFrame) {
+      console.log(prettyDOM$1.apply(void 0, arguments) + "\n\n" + userCodeFrame);
+    } else {
+      console.log(prettyDOM$1.apply(void 0, arguments));
+    }
+  };
+  var config$2 = {
+    testIdAttribute: "data-testid",
+    asyncUtilTimeout: 1e3,
+    // this is to support React's async `act` function.
+    // forcing react-testing-library to wrap all async functions would've been
+    // a total nightmare (consider wrapping every findBy* query and then also
+    // updating `within` so those would be wrapped too. Total nightmare).
+    // so we have this config option that's really only intended for
+    // react-testing-library to use. For that reason, this feature will remain
+    // undocumented.
+    asyncWrapper: function asyncWrapper(cb) {
+      return cb();
+    },
+    eventWrapper: function eventWrapper2(cb) {
+      return cb();
+    },
+    // default value for the `hidden` option in `ByRole` queries
+    defaultHidden: false,
+    // showOriginalStackTrace flag to show the full error stack traces for async errors
+    showOriginalStackTrace: false,
+    // throw errors w/ suggestions for better queries. Opt in so off by default.
+    throwSuggestions: false,
+    // called when getBy* queries fail. (message, container) => Error
+    getElementError: function getElementError2(message, container) {
+      var error = new Error([message, prettyDOM$1(container)].filter(Boolean).join("\n\n"));
+      error.name = "TestingLibraryElementError";
+      return error;
+    },
+    _disableExpensiveErrorDiagnostics: false,
+    computedStyleSupportsPseudoElements: false
+  };
+  var DEFAULT_IGNORE_TAGS = "script, style";
+  function runWithExpensiveErrorDiagnosticsDisabled$1(callback) {
+    try {
+      config$2._disableExpensiveErrorDiagnostics = true;
+      return callback();
+    } finally {
+      config$2._disableExpensiveErrorDiagnostics = false;
+    }
+  }
+  function configure$1(newConfig) {
+    if (typeof newConfig === "function") {
+      newConfig = newConfig(config$2);
+    }
+    config$2 = _extends({}, config$2, newConfig);
+  }
+  function getConfig$2() {
+    return config$2;
+  }
+  var labelledNodeNames$1 = ["button", "meter", "output", "progress", "select", "textarea", "input"];
+  function getTextContent$1(node) {
+    if (labelledNodeNames$1.includes(node.nodeName.toLowerCase())) {
+      return "";
+    }
+    if (node.nodeType === TEXT_NODE$4) return node.textContent;
+    return Array.from(node.childNodes).map(function(childNode) {
+      return getTextContent$1(childNode);
+    }).join("");
+  }
+  function getLabelContent$1(element) {
+    var textContent;
+    if (element.tagName.toLowerCase() === "label") {
+      textContent = getTextContent$1(element);
+    } else {
+      textContent = element.value || element.textContent;
+    }
+    return textContent;
+  }
+  function getRealLabels$1(element) {
+    if (element.labels !== void 0) {
+      var _labels;
+      return (_labels = element.labels) != null ? _labels : [];
+    }
+    if (!isLabelable$1(element)) return [];
+    var labels = element.ownerDocument.querySelectorAll("label");
+    return Array.from(labels).filter(function(label) {
+      return label.control === element;
+    });
+  }
+  function isLabelable$1(element) {
+    return /BUTTON|METER|OUTPUT|PROGRESS|SELECT|TEXTAREA/.test(element.tagName) || element.tagName === "INPUT" && element.getAttribute("type") !== "hidden";
+  }
+  function getLabels$2(container, element, _temp) {
+    var _ref = _temp === void 0 ? {} : _temp, _ref$selector = _ref.selector, selector2 = _ref$selector === void 0 ? "*" : _ref$selector;
+    var ariaLabelledBy = element.getAttribute("aria-labelledby");
+    var labelsId = ariaLabelledBy ? ariaLabelledBy.split(" ") : [];
+    return labelsId.length ? labelsId.map(function(labelId) {
+      var labellingElement = container.querySelector('[id="' + labelId + '"]');
+      return labellingElement ? {
+        content: getLabelContent$1(labellingElement),
+        formControl: null
+      } : {
+        content: "",
+        formControl: null
+      };
+    }) : Array.from(getRealLabels$1(element)).map(function(label) {
+      var textToMatch = getLabelContent$1(label);
+      var formControlSelector = "button, input, meter, output, progress, select, textarea";
+      var labelledFormControl = Array.from(label.querySelectorAll(formControlSelector)).filter(function(formControlElement) {
+        return formControlElement.matches(selector2);
+      })[0];
+      return {
+        content: textToMatch,
+        formControl: labelledFormControl
+      };
+    });
+  }
+  function assertNotNullOrUndefined$1(matcher) {
+    if (matcher === null || matcher === void 0) {
+      throw new Error(
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- implicitly converting `T` to `string`
+        "It looks like " + matcher + " was passed instead of a matcher. Did you do something like getByText(" + matcher + ")?"
+      );
+    }
+  }
+  function fuzzyMatches$1(textToMatch, node, matcher, normalizer) {
+    if (typeof textToMatch !== "string") {
+      return false;
+    }
+    assertNotNullOrUndefined$1(matcher);
+    var normalizedText = normalizer(textToMatch);
+    if (typeof matcher === "string" || typeof matcher === "number") {
+      return normalizedText.toLowerCase().includes(matcher.toString().toLowerCase());
+    } else if (typeof matcher === "function") {
+      return matcher(normalizedText, node);
+    } else {
+      return matcher.test(normalizedText);
+    }
+  }
+  function matches$1(textToMatch, node, matcher, normalizer) {
+    if (typeof textToMatch !== "string") {
+      return false;
+    }
+    assertNotNullOrUndefined$1(matcher);
+    var normalizedText = normalizer(textToMatch);
+    if (matcher instanceof Function) {
+      return matcher(normalizedText, node);
+    } else if (matcher instanceof RegExp) {
+      return matcher.test(normalizedText);
+    } else {
+      return normalizedText === String(matcher);
+    }
+  }
+  function getDefaultNormalizer$1(_temp) {
+    var _ref = _temp === void 0 ? {} : _temp, _ref$trim = _ref.trim, trim = _ref$trim === void 0 ? true : _ref$trim, _ref$collapseWhitespa = _ref.collapseWhitespace, collapseWhitespace = _ref$collapseWhitespa === void 0 ? true : _ref$collapseWhitespa;
+    return function(text) {
+      var normalizedText = text;
+      normalizedText = trim ? normalizedText.trim() : normalizedText;
+      normalizedText = collapseWhitespace ? normalizedText.replace(/\s+/g, " ") : normalizedText;
+      return normalizedText;
+    };
+  }
+  function makeNormalizer$1(_ref2) {
+    var trim = _ref2.trim, collapseWhitespace = _ref2.collapseWhitespace, normalizer = _ref2.normalizer;
+    if (normalizer) {
+      if (typeof trim !== "undefined" || typeof collapseWhitespace !== "undefined") {
+        throw new Error('trim and collapseWhitespace are not supported with a normalizer. If you want to use the default trim and collapseWhitespace logic in your normalizer, use "getDefaultNormalizer({trim, collapseWhitespace})" and compose that into your normalizer');
+      }
+      return normalizer;
+    } else {
+      return getDefaultNormalizer$1({
+        trim,
+        collapseWhitespace
+      });
+    }
+  }
+  function getNodeText$1(node) {
+    if (node.matches("input[type=submit], input[type=button]")) {
+      return node.value;
+    }
+    return Array.from(node.childNodes).filter(function(child) {
+      return child.nodeType === TEXT_NODE$4 && Boolean(child.textContent);
+    }).map(function(c2) {
+      return c2.textContent;
+    }).join("");
+  }
+  function _createForOfIteratorHelperLoose(o, allowArrayLike) {
+    var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"];
+    if (it) return (it = it.call(o)).next.bind(it);
+    if (Array.isArray(o) || (it = _unsupportedIterableToArray$5(o)) || allowArrayLike) {
+      if (it) o = it;
+      var i2 = 0;
+      return function() {
+        if (i2 >= o.length) return { done: true };
+        return { done: false, value: o[i2++] };
+      };
+    }
+    throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+  }
+  function _unsupportedIterableToArray$5(o, minLen) {
+    if (!o) return;
+    if (typeof o === "string") return _arrayLikeToArray$5(o, minLen);
+    var n2 = Object.prototype.toString.call(o).slice(8, -1);
+    if (n2 === "Object" && o.constructor) n2 = o.constructor.name;
+    if (n2 === "Map" || n2 === "Set") return Array.from(o);
+    if (n2 === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n2)) return _arrayLikeToArray$5(o, minLen);
+  }
+  function _arrayLikeToArray$5(arr, len) {
+    if (len == null || len > arr.length) len = arr.length;
+    for (var i2 = 0, arr2 = new Array(len); i2 < len; i2++) {
+      arr2[i2] = arr[i2];
+    }
+    return arr2;
+  }
+  var elementRoleList$1 = buildElementRoleList$1(lib$1.elementRoles);
+  function isSubtreeInaccessible$1(element) {
+    if (element.hidden === true) {
+      return true;
+    }
+    if (element.getAttribute("aria-hidden") === "true") {
+      return true;
+    }
+    var window2 = element.ownerDocument.defaultView;
+    if (window2.getComputedStyle(element).display === "none") {
+      return true;
+    }
+    return false;
+  }
+  function isInaccessible$1(element, options) {
+    if (options === void 0) {
+      options = {};
+    }
+    var _options = options, _options$isSubtreeIna = _options.isSubtreeInaccessible, isSubtreeInaccessibleImpl = _options$isSubtreeIna === void 0 ? isSubtreeInaccessible$1 : _options$isSubtreeIna;
+    var window2 = element.ownerDocument.defaultView;
+    if (window2.getComputedStyle(element).visibility === "hidden") {
+      return true;
+    }
+    var currentElement = element;
+    while (currentElement) {
+      if (isSubtreeInaccessibleImpl(currentElement)) {
+        return true;
+      }
+      currentElement = currentElement.parentElement;
+    }
+    return false;
+  }
+  function getImplicitAriaRoles$1(currentNode) {
+    for (var _iterator = _createForOfIteratorHelperLoose(elementRoleList$1), _step; !(_step = _iterator()).done; ) {
+      var _step$value = _step.value, match2 = _step$value.match, roles2 = _step$value.roles;
+      if (match2(currentNode)) {
+        return [].concat(roles2);
+      }
+    }
+    return [];
+  }
+  function buildElementRoleList$1(elementRolesMap) {
+    function makeElementSelector(_ref) {
+      var name = _ref.name, attributes = _ref.attributes;
+      return "" + name + attributes.map(function(_ref2) {
+        var attributeName = _ref2.name, value = _ref2.value, _ref2$constraints = _ref2.constraints, constraints = _ref2$constraints === void 0 ? [] : _ref2$constraints;
+        var shouldNotExist = constraints.indexOf("undefined") !== -1;
+        if (shouldNotExist) {
+          return ":not([" + attributeName + "])";
+        } else if (value) {
+          return "[" + attributeName + '="' + value + '"]';
+        } else {
+          return "[" + attributeName + "]";
+        }
+      }).join("");
+    }
+    function getSelectorSpecificity(_ref3) {
+      var _ref3$attributes = _ref3.attributes, attributes = _ref3$attributes === void 0 ? [] : _ref3$attributes;
+      return attributes.length;
+    }
+    function bySelectorSpecificity(_ref4, _ref5) {
+      var leftSpecificity = _ref4.specificity;
+      var rightSpecificity = _ref5.specificity;
+      return rightSpecificity - leftSpecificity;
+    }
+    function match2(element2) {
+      return function(node) {
+        var _element$attributes = element2.attributes, attributes = _element$attributes === void 0 ? [] : _element$attributes;
+        var typeTextIndex = attributes.findIndex(function(attribute) {
+          return attribute.value && attribute.name === "type" && attribute.value === "text";
+        });
+        if (typeTextIndex >= 0) {
+          attributes = [].concat(attributes.slice(0, typeTextIndex), attributes.slice(typeTextIndex + 1));
+          if (node.type !== "text") {
+            return false;
+          }
+        }
+        return node.matches(makeElementSelector(_extends({}, element2, {
+          attributes
+        })));
+      };
+    }
+    var result = [];
+    for (var _iterator2 = _createForOfIteratorHelperLoose(elementRolesMap.entries()), _step2; !(_step2 = _iterator2()).done; ) {
+      var _step2$value = _step2.value, element = _step2$value[0], roles2 = _step2$value[1];
+      result = [].concat(result, [{
+        match: match2(element),
+        roles: Array.from(roles2),
+        specificity: getSelectorSpecificity(element)
+      }]);
+    }
+    return result.sort(bySelectorSpecificity);
+  }
+  function getRoles$1(container, _temp) {
+    var _ref6 = _temp === void 0 ? {} : _temp, _ref6$hidden = _ref6.hidden, hidden = _ref6$hidden === void 0 ? false : _ref6$hidden;
+    function flattenDOM(node) {
+      return [node].concat(Array.from(node.children).reduce(function(acc, child) {
+        return [].concat(acc, flattenDOM(child));
+      }, []));
+    }
+    return flattenDOM(container).filter(function(element) {
+      return hidden === false ? isInaccessible$1(element) === false : true;
+    }).reduce(function(acc, node) {
+      var roles2 = [];
+      if (node.hasAttribute("role")) {
+        roles2 = node.getAttribute("role").split(" ").slice(0, 1);
+      } else {
+        roles2 = getImplicitAriaRoles$1(node);
+      }
+      return roles2.reduce(function(rolesAcc, role2) {
+        var _extends2, _extends3;
+        return Array.isArray(rolesAcc[role2]) ? _extends({}, rolesAcc, (_extends2 = {}, _extends2[role2] = [].concat(rolesAcc[role2], [node]), _extends2)) : _extends({}, rolesAcc, (_extends3 = {}, _extends3[role2] = [node], _extends3));
+      }, acc);
+    }, {});
+  }
+  function prettyRoles$1(dom2, _ref7) {
+    var hidden = _ref7.hidden;
+    var roles2 = getRoles$1(dom2, {
+      hidden
+    });
+    return Object.entries(roles2).filter(function(_ref8) {
+      var role2 = _ref8[0];
+      return role2 !== "generic";
+    }).map(function(_ref9) {
+      var role2 = _ref9[0], elements = _ref9[1];
+      var delimiterBar = "-".repeat(50);
+      var elementsString = elements.map(function(el) {
+        var nameString = 'Name "' + computeAccessibleName$1(el, {
+          computedStyleSupportsPseudoElements: getConfig$2().computedStyleSupportsPseudoElements
+        }) + '":\n';
+        var domString = prettyDOM$1(el.cloneNode(false));
+        return "" + nameString + domString;
+      }).join("\n\n");
+      return role2 + ":\n\n" + elementsString + "\n\n" + delimiterBar;
+    }).join("\n");
+  }
+  var logRoles$1 = function logRoles2(dom2, _temp2) {
+    var _ref10 = _temp2 === void 0 ? {} : _temp2, _ref10$hidden = _ref10.hidden, hidden = _ref10$hidden === void 0 ? false : _ref10$hidden;
+    return console.log(prettyRoles$1(dom2, {
+      hidden
+    }));
+  };
+  function computeAriaSelected$1(element) {
+    if (element.tagName === "OPTION") {
+      return element.selected;
+    }
+    return checkBooleanAttribute$1(element, "aria-selected");
+  }
+  function computeAriaChecked$1(element) {
+    if ("indeterminate" in element && element.indeterminate) {
+      return void 0;
+    }
+    if ("checked" in element) {
+      return element.checked;
+    }
+    return checkBooleanAttribute$1(element, "aria-checked");
+  }
+  function computeAriaPressed$1(element) {
+    return checkBooleanAttribute$1(element, "aria-pressed");
+  }
+  function computeAriaExpanded$1(element) {
+    return checkBooleanAttribute$1(element, "aria-expanded");
+  }
+  function checkBooleanAttribute$1(element, attribute) {
+    var attributeValue = element.getAttribute(attribute);
+    if (attributeValue === "true") {
+      return true;
+    }
+    if (attributeValue === "false") {
+      return false;
+    }
+    return void 0;
+  }
+  function computeHeadingLevel$1(element) {
+    var implicitHeadingLevels = {
+      H1: 1,
+      H2: 2,
+      H3: 3,
+      H4: 4,
+      H5: 5,
+      H6: 6
+    };
+    var ariaLevelAttribute = element.getAttribute("aria-level") && Number(element.getAttribute("aria-level"));
+    return ariaLevelAttribute || implicitHeadingLevels[element.tagName];
+  }
+  var normalize$2 = getDefaultNormalizer$1();
+  function escapeRegExp$1(string) {
+    return string.replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&");
+  }
+  function getRegExpMatcher$1(string) {
+    return new RegExp(escapeRegExp$1(string.toLowerCase()), "i");
+  }
+  function makeSuggestion$1(queryName, element, content, _ref) {
+    var variant = _ref.variant, name = _ref.name;
+    var warning = "";
+    var queryOptions = {};
+    var queryArgs = [["Role", "TestId"].includes(queryName) ? content : getRegExpMatcher$1(content)];
+    if (name) {
+      queryOptions.name = getRegExpMatcher$1(name);
+    }
+    if (queryName === "Role" && isInaccessible$1(element)) {
+      queryOptions.hidden = true;
+      warning = "Element is inaccessible. This means that the element and all its children are invisible to screen readers.\n    If you are using the aria-hidden prop, make sure this is the right choice for your case.\n    ";
+    }
+    if (Object.keys(queryOptions).length > 0) {
+      queryArgs.push(queryOptions);
+    }
+    var queryMethod = variant + "By" + queryName;
+    return {
+      queryName,
+      queryMethod,
+      queryArgs,
+      variant,
+      warning,
+      toString: function toString2() {
+        if (warning) {
+          console.warn(warning);
+        }
+        var text = queryArgs[0], options = queryArgs[1];
+        text = typeof text === "string" ? "'" + text + "'" : text;
+        options = options ? ", { " + Object.entries(options).map(function(_ref2) {
+          var k2 = _ref2[0], v2 = _ref2[1];
+          return k2 + ": " + v2;
+        }).join(", ") + " }" : "";
+        return queryMethod + "(" + text + options + ")";
+      }
+    };
+  }
+  function canSuggest$1(currentMethod, requestedMethod, data2) {
+    return data2 && (!requestedMethod || requestedMethod.toLowerCase() === currentMethod.toLowerCase());
+  }
+  function getSuggestedQuery$1(element, variant, method2) {
+    var _element$getAttribute, _getImplicitAriaRoles;
+    if (variant === void 0) {
+      variant = "get";
+    }
+    if (element.matches(DEFAULT_IGNORE_TAGS)) {
+      return void 0;
+    }
+    var role2 = (_element$getAttribute = element.getAttribute("role")) != null ? _element$getAttribute : (_getImplicitAriaRoles = getImplicitAriaRoles$1(element)) == null ? void 0 : _getImplicitAriaRoles[0];
+    if (role2 !== "generic" && canSuggest$1("Role", method2, role2)) {
+      return makeSuggestion$1("Role", element, role2, {
+        variant,
+        name: computeAccessibleName$1(element, {
+          computedStyleSupportsPseudoElements: getConfig$2().computedStyleSupportsPseudoElements
+        })
+      });
+    }
+    var labelText = getLabels$2(document, element).map(function(label) {
+      return label.content;
+    }).join(" ");
+    if (canSuggest$1("LabelText", method2, labelText)) {
+      return makeSuggestion$1("LabelText", element, labelText, {
+        variant
+      });
+    }
+    var placeholderText = element.getAttribute("placeholder");
+    if (canSuggest$1("PlaceholderText", method2, placeholderText)) {
+      return makeSuggestion$1("PlaceholderText", element, placeholderText, {
+        variant
+      });
+    }
+    var textContent = normalize$2(getNodeText$1(element));
+    if (canSuggest$1("Text", method2, textContent)) {
+      return makeSuggestion$1("Text", element, textContent, {
+        variant
+      });
+    }
+    if (canSuggest$1("DisplayValue", method2, element.value)) {
+      return makeSuggestion$1("DisplayValue", element, normalize$2(element.value), {
+        variant
+      });
+    }
+    var alt = element.getAttribute("alt");
+    if (canSuggest$1("AltText", method2, alt)) {
+      return makeSuggestion$1("AltText", element, alt, {
+        variant
+      });
+    }
+    var title2 = element.getAttribute("title");
+    if (canSuggest$1("Title", method2, title2)) {
+      return makeSuggestion$1("Title", element, title2, {
+        variant
+      });
+    }
+    var testId = element.getAttribute(getConfig$2().testIdAttribute);
+    if (canSuggest$1("TestId", method2, testId)) {
+      return makeSuggestion$1("TestId", element, testId, {
+        variant
+      });
+    }
+    return void 0;
+  }
+  function copyStackTrace$1(target, source) {
+    target.stack = source.stack.replace(source.message, target.message);
+  }
+  function waitFor$1(callback, _ref) {
+    var _ref$container = _ref.container, container = _ref$container === void 0 ? getDocument$2() : _ref$container, _ref$timeout = _ref.timeout, timeout = _ref$timeout === void 0 ? getConfig$2().asyncUtilTimeout : _ref$timeout, _ref$showOriginalStac = _ref.showOriginalStackTrace, showOriginalStackTrace = _ref$showOriginalStac === void 0 ? getConfig$2().showOriginalStackTrace : _ref$showOriginalStac, stackTraceError = _ref.stackTraceError, _ref$interval = _ref.interval, interval = _ref$interval === void 0 ? 50 : _ref$interval, _ref$onTimeout = _ref.onTimeout, onTimeout = _ref$onTimeout === void 0 ? function(error) {
+      error.message = getConfig$2().getElementError(error.message, container).message;
+      return error;
+    } : _ref$onTimeout, _ref$mutationObserver = _ref.mutationObserverOptions, mutationObserverOptions = _ref$mutationObserver === void 0 ? {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      characterData: true
+    } : _ref$mutationObserver;
+    if (typeof callback !== "function") {
+      throw new TypeError("Received `callback` arg must be a function");
+    }
+    return new Promise(/* @__PURE__ */ function() {
+      var _ref2 = _asyncToGenerator(/* @__PURE__ */ regenerator.mark(function _callee(resolve, reject) {
+        var lastError, intervalId, observer, finished, promiseStatus, overallTimeoutTimer, usingJestFakeTimers, error, _getWindowFromNode, MutationObserver, onDone, checkRealTimersCallback, checkCallback, handleTimeout;
+        return regenerator.wrap(function _callee$(_context) {
+          while (1) {
+            switch (_context.prev = _context.next) {
+              case 0:
+                handleTimeout = function _handleTimeout() {
+                  var error2;
+                  if (lastError) {
+                    error2 = lastError;
+                    if (!showOriginalStackTrace && error2.name === "TestingLibraryElementError") {
+                      copyStackTrace$1(error2, stackTraceError);
+                    }
+                  } else {
+                    error2 = new Error("Timed out in waitFor.");
+                    if (!showOriginalStackTrace) {
+                      copyStackTrace$1(error2, stackTraceError);
+                    }
+                  }
+                  onDone(onTimeout(error2), null);
+                };
+                checkCallback = function _checkCallback() {
+                  if (promiseStatus === "pending") return;
+                  try {
+                    var result = runWithExpensiveErrorDiagnosticsDisabled$1(callback);
+                    if (typeof (result == null ? void 0 : result.then) === "function") {
+                      promiseStatus = "pending";
+                      result.then(function(resolvedValue) {
+                        promiseStatus = "resolved";
+                        onDone(null, resolvedValue);
+                      }, function(rejectedValue) {
+                        promiseStatus = "rejected";
+                        lastError = rejectedValue;
+                      });
+                    } else {
+                      onDone(null, result);
+                    }
+                  } catch (error2) {
+                    lastError = error2;
+                  }
+                };
+                checkRealTimersCallback = function _checkRealTimersCallb() {
+                  if (jestFakeTimersAreEnabled$2()) {
+                    var _error = new Error("Changed from using real timers to fake timers while using waitFor. This is not allowed and will result in very strange behavior. Please ensure you're awaiting all async things your test is doing before changing to fake timers. For more info, please go to https://github.com/testing-library/dom-testing-library/issues/830");
+                    if (!showOriginalStackTrace) copyStackTrace$1(_error, stackTraceError);
+                    return reject(_error);
+                  } else {
+                    return checkCallback();
+                  }
+                };
+                onDone = function _onDone(error2, result) {
+                  finished = true;
+                  clearTimeoutFn(overallTimeoutTimer);
+                  if (!usingJestFakeTimers) {
+                    clearInterval(intervalId);
+                    observer.disconnect();
+                  }
+                  if (error2) {
+                    reject(error2);
+                  } else {
+                    resolve(result);
+                  }
+                };
+                finished = false;
+                promiseStatus = "idle";
+                overallTimeoutTimer = setTimeoutFn(handleTimeout, timeout);
+                usingJestFakeTimers = jestFakeTimersAreEnabled$2();
+                if (!usingJestFakeTimers) {
+                  _context.next = 24;
+                  break;
+                }
+                checkCallback();
+              case 10:
+                if (finished) {
+                  _context.next = 22;
+                  break;
+                }
+                if (jestFakeTimersAreEnabled$2()) {
+                  _context.next = 16;
+                  break;
+                }
+                error = new Error("Changed from using fake timers to real timers while using waitFor. This is not allowed and will result in very strange behavior. Please ensure you're awaiting all async things your test is doing before changing to real timers. For more info, please go to https://github.com/testing-library/dom-testing-library/issues/830");
+                if (!showOriginalStackTrace) copyStackTrace$1(error, stackTraceError);
+                reject(error);
+                return _context.abrupt("return");
+              case 16:
+                jest.advanceTimersByTime(interval);
+                checkCallback();
+                _context.next = 20;
+                return new Promise(function(r2) {
+                  return setImmediateFn(r2);
+                });
+              case 20:
+                _context.next = 10;
+                break;
+              case 22:
+                _context.next = 37;
+                break;
+              case 24:
+                _context.prev = 24;
+                checkContainerType$2(container);
+                _context.next = 32;
+                break;
+              case 28:
+                _context.prev = 28;
+                _context.t0 = _context["catch"](24);
+                reject(_context.t0);
+                return _context.abrupt("return");
+              case 32:
+                intervalId = setInterval(checkRealTimersCallback, interval);
+                _getWindowFromNode = getWindowFromNode$2(container), MutationObserver = _getWindowFromNode.MutationObserver;
+                observer = new MutationObserver(checkRealTimersCallback);
+                observer.observe(container, mutationObserverOptions);
+                checkCallback();
+              case 37:
+              case "end":
+                return _context.stop();
+            }
+          }
+        }, _callee, null, [[24, 28]]);
+      }));
+      return function(_x, _x2) {
+        return _ref2.apply(this, arguments);
+      };
+    }());
+  }
+  function waitForWrapper$1(callback, options) {
+    var stackTraceError = new Error("STACK_TRACE_MESSAGE");
+    return getConfig$2().asyncWrapper(function() {
+      return waitFor$1(callback, _extends({
+        stackTraceError
+      }, options));
+    });
+  }
+  var hasWarned$2 = false;
+  function wait$1$1() {
+    for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+    var _args$ = args[0], first = _args$ === void 0 ? function() {
+    } : _args$, rest = args.slice(1);
+    if (!hasWarned$2) {
+      hasWarned$2 = true;
+      console.warn("`wait` has been deprecated and replaced by `waitFor` instead. In most cases you should be able to find/replace `wait` with `waitFor`. Learn more: https://testing-library.com/docs/dom-testing-library/api-async#waitfor.");
+    }
+    return waitForWrapper$1.apply(void 0, [first].concat(rest));
+  }
+  function getElementError$1(message, container) {
+    return getConfig$2().getElementError(message, container);
+  }
+  function getMultipleElementsFoundError$1(message, container) {
+    return getElementError$1(message + "\n\n(If this is intentional, then use the `*AllBy*` variant of the query (like `queryAllByText`, `getAllByText`, or `findAllByText`)).", container);
+  }
+  function queryAllByAttribute$1(attribute, container, text, _temp) {
+    var _ref = _temp === void 0 ? {} : _temp, _ref$exact = _ref.exact, exact = _ref$exact === void 0 ? true : _ref$exact, collapseWhitespace = _ref.collapseWhitespace, trim = _ref.trim, normalizer = _ref.normalizer;
+    var matcher = exact ? matches$1 : fuzzyMatches$1;
+    var matchNormalizer = makeNormalizer$1({
+      collapseWhitespace,
+      trim,
+      normalizer
+    });
+    return Array.from(container.querySelectorAll("[" + attribute + "]")).filter(function(node) {
+      return matcher(node.getAttribute(attribute), node, text, matchNormalizer);
+    });
+  }
+  function queryByAttribute$1(attribute, container, text) {
+    for (var _len = arguments.length, args = new Array(_len > 3 ? _len - 3 : 0), _key = 3; _key < _len; _key++) {
+      args[_key - 3] = arguments[_key];
+    }
+    var els = queryAllByAttribute$1.apply(void 0, [attribute, container, text].concat(args));
+    if (els.length > 1) {
+      throw getMultipleElementsFoundError$1("Found multiple elements by [" + attribute + "=" + text + "]", container);
+    }
+    return els[0] || null;
+  }
+  function makeSingleQuery$1(allQuery, getMultipleError2) {
+    return function(container) {
+      for (var _len2 = arguments.length, args = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
+        args[_key2 - 1] = arguments[_key2];
+      }
+      var els = allQuery.apply(void 0, [container].concat(args));
+      if (els.length > 1) {
+        var elementStrings = els.map(function(element) {
+          return getElementError$1(null, element).message;
+        }).join("\n\n");
+        throw getMultipleElementsFoundError$1(getMultipleError2.apply(void 0, [container].concat(args)) + "\n\nHere are the matching elements:\n\n" + elementStrings, container);
+      }
+      return els[0] || null;
+    };
+  }
+  function getSuggestionError$1(suggestion, container) {
+    return getConfig$2().getElementError("A better query is available, try this:\n" + suggestion.toString() + "\n", container);
+  }
+  function makeGetAllQuery$1(allQuery, getMissingError2) {
+    return function(container) {
+      for (var _len3 = arguments.length, args = new Array(_len3 > 1 ? _len3 - 1 : 0), _key3 = 1; _key3 < _len3; _key3++) {
+        args[_key3 - 1] = arguments[_key3];
+      }
+      var els = allQuery.apply(void 0, [container].concat(args));
+      if (!els.length) {
+        throw getConfig$2().getElementError(getMissingError2.apply(void 0, [container].concat(args)), container);
+      }
+      return els;
+    };
+  }
+  function makeFindQuery$1(getter) {
+    return function(container, text, options, waitForOptions) {
+      return waitForWrapper$1(function() {
+        return getter(container, text, options);
+      }, _extends({
+        container
+      }, waitForOptions));
+    };
+  }
+  var wrapSingleQueryWithSuggestion$1 = function wrapSingleQueryWithSuggestion2(query, queryAllByName, variant) {
+    return function(container) {
+      for (var _len4 = arguments.length, args = new Array(_len4 > 1 ? _len4 - 1 : 0), _key4 = 1; _key4 < _len4; _key4++) {
+        args[_key4 - 1] = arguments[_key4];
+      }
+      var element = query.apply(void 0, [container].concat(args));
+      var _args$slice = args.slice(-1), _args$slice$ = _args$slice[0];
+      _args$slice$ = _args$slice$ === void 0 ? {} : _args$slice$;
+      var _args$slice$$suggest = _args$slice$.suggest, suggest = _args$slice$$suggest === void 0 ? getConfig$2().throwSuggestions : _args$slice$$suggest;
+      if (element && suggest) {
+        var suggestion = getSuggestedQuery$1(element, variant);
+        if (suggestion && !queryAllByName.endsWith(suggestion.queryName)) {
+          throw getSuggestionError$1(suggestion.toString(), container);
+        }
+      }
+      return element;
+    };
+  };
+  var wrapAllByQueryWithSuggestion$1 = function wrapAllByQueryWithSuggestion2(query, queryAllByName, variant) {
+    return function(container) {
+      for (var _len5 = arguments.length, args = new Array(_len5 > 1 ? _len5 - 1 : 0), _key5 = 1; _key5 < _len5; _key5++) {
+        args[_key5 - 1] = arguments[_key5];
+      }
+      var els = query.apply(void 0, [container].concat(args));
+      var _args$slice2 = args.slice(-1), _args$slice2$ = _args$slice2[0];
+      _args$slice2$ = _args$slice2$ === void 0 ? {} : _args$slice2$;
+      var _args$slice2$$suggest = _args$slice2$.suggest, suggest = _args$slice2$$suggest === void 0 ? getConfig$2().throwSuggestions : _args$slice2$$suggest;
+      if (els.length && suggest) {
+        var uniqueSuggestionMessages = [].concat(new Set(els.map(function(element) {
+          var _getSuggestedQuery;
+          return (_getSuggestedQuery = getSuggestedQuery$1(element, variant)) == null ? void 0 : _getSuggestedQuery.toString();
+        })));
+        if (
+          // only want to suggest if all the els have the same suggestion.
+          uniqueSuggestionMessages.length === 1 && !queryAllByName.endsWith(getSuggestedQuery$1(els[0], variant).queryName)
+        ) {
+          throw getSuggestionError$1(uniqueSuggestionMessages[0], container);
+        }
+      }
+      return els;
+    };
+  };
+  function buildQueries$1(queryAllBy, getMultipleError2, getMissingError2) {
+    var queryBy = wrapSingleQueryWithSuggestion$1(makeSingleQuery$1(queryAllBy, getMultipleError2), queryAllBy.name, "query");
+    var getAllBy = makeGetAllQuery$1(queryAllBy, getMissingError2);
+    var getBy = makeSingleQuery$1(getAllBy, getMultipleError2);
+    var getByWithSuggestions = wrapSingleQueryWithSuggestion$1(getBy, queryAllBy.name, "get");
+    var getAllWithSuggestions = wrapAllByQueryWithSuggestion$1(getAllBy, queryAllBy.name.replace("query", "get"), "getAll");
+    var findAllBy = makeFindQuery$1(wrapAllByQueryWithSuggestion$1(getAllBy, queryAllBy.name, "findAll"));
+    var findBy = makeFindQuery$1(wrapSingleQueryWithSuggestion$1(getBy, queryAllBy.name, "find"));
+    return [queryBy, getAllWithSuggestions, getByWithSuggestions, findAllBy, findBy];
+  }
+  var queryHelpers$1 = /* @__PURE__ */ Object.freeze({
+    __proto__: null,
+    getElementError: getElementError$1,
+    wrapAllByQueryWithSuggestion: wrapAllByQueryWithSuggestion$1,
+    wrapSingleQueryWithSuggestion: wrapSingleQueryWithSuggestion$1,
+    getMultipleElementsFoundError: getMultipleElementsFoundError$1,
+    queryAllByAttribute: queryAllByAttribute$1,
+    queryByAttribute: queryByAttribute$1,
+    makeSingleQuery: makeSingleQuery$1,
+    makeGetAllQuery: makeGetAllQuery$1,
+    makeFindQuery: makeFindQuery$1,
+    buildQueries: buildQueries$1
+  });
+  function queryAllLabels$1(container) {
+    return Array.from(container.querySelectorAll("label,input")).map(function(node) {
+      return {
+        node,
+        textToMatch: getLabelContent$1(node)
+      };
+    }).filter(function(_ref) {
+      var textToMatch = _ref.textToMatch;
+      return textToMatch !== null;
+    });
+  }
+  var queryAllLabelsByText$1 = function queryAllLabelsByText2(container, text, _temp) {
+    var _ref2 = _temp === void 0 ? {} : _temp, _ref2$exact = _ref2.exact, exact = _ref2$exact === void 0 ? true : _ref2$exact, trim = _ref2.trim, collapseWhitespace = _ref2.collapseWhitespace, normalizer = _ref2.normalizer;
+    var matcher = exact ? matches$1 : fuzzyMatches$1;
+    var matchNormalizer = makeNormalizer$1({
+      collapseWhitespace,
+      trim,
+      normalizer
+    });
+    var textToMatchByLabels = queryAllLabels$1(container);
+    return textToMatchByLabels.filter(function(_ref3) {
+      var node = _ref3.node, textToMatch = _ref3.textToMatch;
+      return matcher(textToMatch, node, text, matchNormalizer);
+    }).map(function(_ref4) {
+      var node = _ref4.node;
+      return node;
+    });
+  };
+  var queryAllByLabelText$1 = function queryAllByLabelText2(container, text, _temp2) {
+    var _ref5 = _temp2 === void 0 ? {} : _temp2, _ref5$selector = _ref5.selector, selector2 = _ref5$selector === void 0 ? "*" : _ref5$selector, _ref5$exact = _ref5.exact, exact = _ref5$exact === void 0 ? true : _ref5$exact, collapseWhitespace = _ref5.collapseWhitespace, trim = _ref5.trim, normalizer = _ref5.normalizer;
+    checkContainerType$2(container);
+    var matcher = exact ? matches$1 : fuzzyMatches$1;
+    var matchNormalizer = makeNormalizer$1({
+      collapseWhitespace,
+      trim,
+      normalizer
+    });
+    var matchingLabelledElements = Array.from(container.querySelectorAll("*")).filter(function(element) {
+      return getRealLabels$1(element).length || element.hasAttribute("aria-labelledby");
+    }).reduce(function(labelledElements, labelledElement) {
+      var labelList = getLabels$2(container, labelledElement, {
+        selector: selector2
+      });
+      labelList.filter(function(label) {
+        return Boolean(label.formControl);
+      }).forEach(function(label) {
+        if (matcher(label.content, label.formControl, text, matchNormalizer) && label.formControl) labelledElements.push(label.formControl);
+      });
+      var labelsValue = labelList.filter(function(label) {
+        return Boolean(label.content);
+      }).map(function(label) {
+        return label.content;
+      });
+      if (matcher(labelsValue.join(" "), labelledElement, text, matchNormalizer)) labelledElements.push(labelledElement);
+      if (labelsValue.length > 1) {
+        labelsValue.forEach(function(labelValue, index2) {
+          if (matcher(labelValue, labelledElement, text, matchNormalizer)) labelledElements.push(labelledElement);
+          var labelsFiltered = [].concat(labelsValue);
+          labelsFiltered.splice(index2, 1);
+          if (labelsFiltered.length > 1) {
+            if (matcher(labelsFiltered.join(" "), labelledElement, text, matchNormalizer)) labelledElements.push(labelledElement);
+          }
+        });
+      }
+      return labelledElements;
+    }, []).concat(
+      // TODO: Remove ignore after `queryAllByAttribute` will be moved to TS
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      queryAllByAttribute$1("aria-label", container, text, {
+        exact,
+        normalizer: matchNormalizer
+      })
+    );
+    return Array.from(new Set(matchingLabelledElements)).filter(function(element) {
+      return element.matches(selector2);
+    });
+  };
+  var getAllByLabelText$1 = function getAllByLabelText2(container, text) {
+    for (var _len = arguments.length, rest = new Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+      rest[_key - 2] = arguments[_key];
+    }
+    var els = queryAllByLabelText$1.apply(void 0, [container, text].concat(rest));
+    if (!els.length) {
+      var labels = queryAllLabelsByText$1.apply(void 0, [container, text].concat(rest));
+      if (labels.length) {
+        var tagNames = labels.map(function(label) {
+          return getTagNameOfElementAssociatedWithLabelViaFor$1(container, label);
+        }).filter(function(tagName) {
+          return !!tagName;
+        });
+        if (tagNames.length) {
+          throw getConfig$2().getElementError(tagNames.map(function(tagName) {
+            return "Found a label with the text of: " + text + ", however the element associated with this label (<" + tagName + " />) is non-labellable [https://html.spec.whatwg.org/multipage/forms.html#category-label]. If you really need to label a <" + tagName + " />, you can use aria-label or aria-labelledby instead.";
+          }).join("\n\n"), container);
+        } else {
+          throw getConfig$2().getElementError("Found a label with the text of: " + text + `, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.`, container);
+        }
+      } else {
+        throw getConfig$2().getElementError("Unable to find a label with the text of: " + text, container);
+      }
+    }
+    return els;
+  };
+  function getTagNameOfElementAssociatedWithLabelViaFor$1(container, label) {
+    var htmlFor = label.getAttribute("for");
+    if (!htmlFor) {
+      return null;
+    }
+    var element = container.querySelector('[id="' + htmlFor + '"]');
+    return element ? element.tagName.toLowerCase() : null;
+  }
+  var getMultipleError$7$1 = function getMultipleError2(c2, text) {
+    return "Found multiple elements with the text of: " + text;
+  };
+  var queryByLabelText$1 = wrapSingleQueryWithSuggestion$1(makeSingleQuery$1(queryAllByLabelText$1, getMultipleError$7$1), queryAllByLabelText$1.name, "query");
+  var getByLabelText$1 = makeSingleQuery$1(getAllByLabelText$1, getMultipleError$7$1);
+  var findAllByLabelText$1 = makeFindQuery$1(wrapAllByQueryWithSuggestion$1(getAllByLabelText$1, getAllByLabelText$1.name, "findAll"));
+  var findByLabelText$1 = makeFindQuery$1(wrapSingleQueryWithSuggestion$1(getByLabelText$1, getAllByLabelText$1.name, "find"));
+  var getAllByLabelTextWithSuggestions$1 = wrapAllByQueryWithSuggestion$1(getAllByLabelText$1, getAllByLabelText$1.name, "getAll");
+  var getByLabelTextWithSuggestions$1 = wrapSingleQueryWithSuggestion$1(getByLabelText$1, getAllByLabelText$1.name, "get");
+  var queryAllByLabelTextWithSuggestions$1 = wrapAllByQueryWithSuggestion$1(queryAllByLabelText$1, queryAllByLabelText$1.name, "queryAll");
+  var queryAllByPlaceholderText$1 = function queryAllByPlaceholderText2() {
+    for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+    checkContainerType$2(args[0]);
+    return queryAllByAttribute$1.apply(void 0, ["placeholder"].concat(args));
+  };
+  var getMultipleError$6$1 = function getMultipleError2(c2, text) {
+    return "Found multiple elements with the placeholder text of: " + text;
+  };
+  var getMissingError$6$1 = function getMissingError2(c2, text) {
+    return "Unable to find an element with the placeholder text of: " + text;
+  };
+  var queryAllByPlaceholderTextWithSuggestions$1 = wrapAllByQueryWithSuggestion$1(queryAllByPlaceholderText$1, queryAllByPlaceholderText$1.name, "queryAll");
+  var _buildQueries$6 = buildQueries$1(queryAllByPlaceholderText$1, getMultipleError$6$1, getMissingError$6$1), queryByPlaceholderText$1 = _buildQueries$6[0], getAllByPlaceholderText$1 = _buildQueries$6[1], getByPlaceholderText$1 = _buildQueries$6[2], findAllByPlaceholderText$1 = _buildQueries$6[3], findByPlaceholderText$1 = _buildQueries$6[4];
+  var queryAllByText$1 = function queryAllByText2(container, text, _temp) {
+    var _ref = _temp === void 0 ? {} : _temp, _ref$selector = _ref.selector, selector2 = _ref$selector === void 0 ? "*" : _ref$selector, _ref$exact = _ref.exact, exact = _ref$exact === void 0 ? true : _ref$exact, collapseWhitespace = _ref.collapseWhitespace, trim = _ref.trim, _ref$ignore = _ref.ignore, ignore = _ref$ignore === void 0 ? DEFAULT_IGNORE_TAGS : _ref$ignore, normalizer = _ref.normalizer;
+    checkContainerType$2(container);
+    var matcher = exact ? matches$1 : fuzzyMatches$1;
+    var matchNormalizer = makeNormalizer$1({
+      collapseWhitespace,
+      trim,
+      normalizer
+    });
+    var baseArray = [];
+    if (typeof container.matches === "function" && container.matches(selector2)) {
+      baseArray = [container];
+    }
+    return [].concat(baseArray, Array.from(container.querySelectorAll(selector2))).filter(function(node) {
+      return !ignore || !node.matches(ignore);
+    }).filter(function(node) {
+      return matcher(getNodeText$1(node), node, text, matchNormalizer);
+    });
+  };
+  var getMultipleError$5$1 = function getMultipleError2(c2, text) {
+    return "Found multiple elements with the text: " + text;
+  };
+  var getMissingError$5$1 = function getMissingError2(c2, text) {
+    return "Unable to find an element with the text: " + text + ". This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.";
+  };
+  var queryAllByTextWithSuggestions$1 = wrapAllByQueryWithSuggestion$1(queryAllByText$1, queryAllByText$1.name, "queryAll");
+  var _buildQueries$5 = buildQueries$1(queryAllByText$1, getMultipleError$5$1, getMissingError$5$1), queryByText$1 = _buildQueries$5[0], getAllByText$1 = _buildQueries$5[1], getByText$1 = _buildQueries$5[2], findAllByText$1 = _buildQueries$5[3], findByText$1 = _buildQueries$5[4];
+  var queryAllByDisplayValue$1 = function queryAllByDisplayValue2(container, value, _temp) {
+    var _ref = _temp === void 0 ? {} : _temp, _ref$exact = _ref.exact, exact = _ref$exact === void 0 ? true : _ref$exact, collapseWhitespace = _ref.collapseWhitespace, trim = _ref.trim, normalizer = _ref.normalizer;
+    checkContainerType$2(container);
+    var matcher = exact ? matches$1 : fuzzyMatches$1;
+    var matchNormalizer = makeNormalizer$1({
+      collapseWhitespace,
+      trim,
+      normalizer
+    });
+    return Array.from(container.querySelectorAll("input,textarea,select")).filter(function(node) {
+      if (node.tagName === "SELECT") {
+        var selectedOptions = Array.from(node.options).filter(function(option) {
+          return option.selected;
+        });
+        return selectedOptions.some(function(optionNode) {
+          return matcher(getNodeText$1(optionNode), optionNode, value, matchNormalizer);
+        });
+      } else {
+        return matcher(node.value, node, value, matchNormalizer);
+      }
+    });
+  };
+  var getMultipleError$4$1 = function getMultipleError2(c2, value) {
+    return "Found multiple elements with the display value: " + value + ".";
+  };
+  var getMissingError$4$1 = function getMissingError2(c2, value) {
+    return "Unable to find an element with the display value: " + value + ".";
+  };
+  var queryAllByDisplayValueWithSuggestions$1 = wrapAllByQueryWithSuggestion$1(queryAllByDisplayValue$1, queryAllByDisplayValue$1.name, "queryAll");
+  var _buildQueries$4 = buildQueries$1(queryAllByDisplayValue$1, getMultipleError$4$1, getMissingError$4$1), queryByDisplayValue$1 = _buildQueries$4[0], getAllByDisplayValue$1 = _buildQueries$4[1], getByDisplayValue$1 = _buildQueries$4[2], findAllByDisplayValue$1 = _buildQueries$4[3], findByDisplayValue$1 = _buildQueries$4[4];
+  var queryAllByAltText$1 = function queryAllByAltText2(container, alt, _temp) {
+    var _ref = _temp === void 0 ? {} : _temp, _ref$exact = _ref.exact, exact = _ref$exact === void 0 ? true : _ref$exact, collapseWhitespace = _ref.collapseWhitespace, trim = _ref.trim, normalizer = _ref.normalizer;
+    checkContainerType$2(container);
+    var matcher = exact ? matches$1 : fuzzyMatches$1;
+    var matchNormalizer = makeNormalizer$1({
+      collapseWhitespace,
+      trim,
+      normalizer
+    });
+    return Array.from(container.querySelectorAll("img,input,area")).filter(function(node) {
+      return matcher(node.getAttribute("alt"), node, alt, matchNormalizer);
+    });
+  };
+  var getMultipleError$3$1 = function getMultipleError2(c2, alt) {
+    return "Found multiple elements with the alt text: " + alt;
+  };
+  var getMissingError$3$1 = function getMissingError2(c2, alt) {
+    return "Unable to find an element with the alt text: " + alt;
+  };
+  var queryAllByAltTextWithSuggestions$1 = wrapAllByQueryWithSuggestion$1(queryAllByAltText$1, queryAllByAltText$1.name, "queryAll");
+  var _buildQueries$3 = buildQueries$1(queryAllByAltText$1, getMultipleError$3$1, getMissingError$3$1), queryByAltText$1 = _buildQueries$3[0], getAllByAltText$1 = _buildQueries$3[1], getByAltText$1 = _buildQueries$3[2], findAllByAltText$1 = _buildQueries$3[3], findByAltText$1 = _buildQueries$3[4];
+  var isSvgTitle$1 = function isSvgTitle2(node) {
+    var _node$parentElement;
+    return node.tagName.toLowerCase() === "title" && ((_node$parentElement = node.parentElement) == null ? void 0 : _node$parentElement.tagName.toLowerCase()) === "svg";
+  };
+  var queryAllByTitle$1 = function queryAllByTitle2(container, text, _temp) {
+    var _ref = _temp === void 0 ? {} : _temp, _ref$exact = _ref.exact, exact = _ref$exact === void 0 ? true : _ref$exact, collapseWhitespace = _ref.collapseWhitespace, trim = _ref.trim, normalizer = _ref.normalizer;
+    checkContainerType$2(container);
+    var matcher = exact ? matches$1 : fuzzyMatches$1;
+    var matchNormalizer = makeNormalizer$1({
+      collapseWhitespace,
+      trim,
+      normalizer
+    });
+    return Array.from(container.querySelectorAll("[title], svg > title")).filter(function(node) {
+      return matcher(node.getAttribute("title"), node, text, matchNormalizer) || isSvgTitle$1(node) && matcher(getNodeText$1(node), node, text, matchNormalizer);
+    });
+  };
+  var getMultipleError$2$1 = function getMultipleError2(c2, title2) {
+    return "Found multiple elements with the title: " + title2 + ".";
+  };
+  var getMissingError$2$1 = function getMissingError2(c2, title2) {
+    return "Unable to find an element with the title: " + title2 + ".";
+  };
+  var queryAllByTitleWithSuggestions$1 = wrapAllByQueryWithSuggestion$1(queryAllByTitle$1, queryAllByTitle$1.name, "queryAll");
+  var _buildQueries$2 = buildQueries$1(queryAllByTitle$1, getMultipleError$2$1, getMissingError$2$1), queryByTitle$1 = _buildQueries$2[0], getAllByTitle$1 = _buildQueries$2[1], getByTitle$1 = _buildQueries$2[2], findAllByTitle$1 = _buildQueries$2[3], findByTitle$1 = _buildQueries$2[4];
+  function queryAllByRole$1(container, role2, _temp) {
+    var _ref = _temp === void 0 ? {} : _temp, _ref$exact = _ref.exact, exact = _ref$exact === void 0 ? true : _ref$exact, collapseWhitespace = _ref.collapseWhitespace, _ref$hidden = _ref.hidden, hidden = _ref$hidden === void 0 ? getConfig$2().defaultHidden : _ref$hidden, name = _ref.name, trim = _ref.trim, normalizer = _ref.normalizer, _ref$queryFallbacks = _ref.queryFallbacks, queryFallbacks = _ref$queryFallbacks === void 0 ? false : _ref$queryFallbacks, selected = _ref.selected, checked = _ref.checked, pressed = _ref.pressed, level = _ref.level, expanded = _ref.expanded;
+    checkContainerType$2(container);
+    var matcher = exact ? matches$1 : fuzzyMatches$1;
+    var matchNormalizer = makeNormalizer$1({
+      collapseWhitespace,
+      trim,
+      normalizer
+    });
+    if (selected !== void 0) {
+      var _allRoles$get;
+      if (((_allRoles$get = lib$1.roles.get(role2)) == null ? void 0 : _allRoles$get.props["aria-selected"]) === void 0) {
+        throw new Error('"aria-selected" is not supported on role "' + role2 + '".');
+      }
+    }
+    if (checked !== void 0) {
+      var _allRoles$get2;
+      if (((_allRoles$get2 = lib$1.roles.get(role2)) == null ? void 0 : _allRoles$get2.props["aria-checked"]) === void 0) {
+        throw new Error('"aria-checked" is not supported on role "' + role2 + '".');
+      }
+    }
+    if (pressed !== void 0) {
+      var _allRoles$get3;
+      if (((_allRoles$get3 = lib$1.roles.get(role2)) == null ? void 0 : _allRoles$get3.props["aria-pressed"]) === void 0) {
+        throw new Error('"aria-pressed" is not supported on role "' + role2 + '".');
+      }
+    }
+    if (level !== void 0) {
+      if (role2 !== "heading") {
+        throw new Error('Role "' + role2 + '" cannot have "level" property.');
+      }
+    }
+    if (expanded !== void 0) {
+      var _allRoles$get4;
+      if (((_allRoles$get4 = lib$1.roles.get(role2)) == null ? void 0 : _allRoles$get4.props["aria-expanded"]) === void 0) {
+        throw new Error('"aria-expanded" is not supported on role "' + role2 + '".');
+      }
+    }
+    var subtreeIsInaccessibleCache = /* @__PURE__ */ new WeakMap();
+    function cachedIsSubtreeInaccessible(element) {
+      if (!subtreeIsInaccessibleCache.has(element)) {
+        subtreeIsInaccessibleCache.set(element, isSubtreeInaccessible$1(element));
+      }
+      return subtreeIsInaccessibleCache.get(element);
+    }
+    return Array.from(container.querySelectorAll("*")).filter(function(node) {
+      var isRoleSpecifiedExplicitly = node.hasAttribute("role");
+      if (isRoleSpecifiedExplicitly) {
+        var roleValue = node.getAttribute("role");
+        if (queryFallbacks) {
+          return roleValue.split(" ").filter(Boolean).some(function(text) {
+            return matcher(text, node, role2, matchNormalizer);
+          });
+        }
+        if (normalizer) {
+          return matcher(roleValue, node, role2, matchNormalizer);
+        }
+        var _roleValue$split = roleValue.split(" "), firstWord = _roleValue$split[0];
+        return matcher(firstWord, node, role2, matchNormalizer);
+      }
+      var implicitRoles = getImplicitAriaRoles$1(node);
+      return implicitRoles.some(function(implicitRole) {
+        return matcher(implicitRole, node, role2, matchNormalizer);
+      });
+    }).filter(function(element) {
+      if (selected !== void 0) {
+        return selected === computeAriaSelected$1(element);
+      }
+      if (checked !== void 0) {
+        return checked === computeAriaChecked$1(element);
+      }
+      if (pressed !== void 0) {
+        return pressed === computeAriaPressed$1(element);
+      }
+      if (expanded !== void 0) {
+        return expanded === computeAriaExpanded$1(element);
+      }
+      if (level !== void 0) {
+        return level === computeHeadingLevel$1(element);
+      }
+      return true;
+    }).filter(function(element) {
+      return hidden === false ? isInaccessible$1(element, {
+        isSubtreeInaccessible: cachedIsSubtreeInaccessible
+      }) === false : true;
+    }).filter(function(element) {
+      if (name === void 0) {
+        return true;
+      }
+      return matches$1(computeAccessibleName$1(element, {
+        computedStyleSupportsPseudoElements: getConfig$2().computedStyleSupportsPseudoElements
+      }), element, name, function(text) {
+        return text;
+      });
+    });
+  }
+  var getMultipleError$1$1 = function getMultipleError2(c2, role2, _temp2) {
+    var _ref2 = _temp2 === void 0 ? {} : _temp2, name = _ref2.name;
+    var nameHint = "";
+    if (name === void 0) {
+      nameHint = "";
+    } else if (typeof name === "string") {
+      nameHint = ' and name "' + name + '"';
+    } else {
+      nameHint = " and name `" + name + "`";
+    }
+    return 'Found multiple elements with the role "' + role2 + '"' + nameHint;
+  };
+  var getMissingError$1$1 = function getMissingError2(container, role2, _temp3) {
+    var _ref3 = _temp3 === void 0 ? {} : _temp3, _ref3$hidden = _ref3.hidden, hidden = _ref3$hidden === void 0 ? getConfig$2().defaultHidden : _ref3$hidden, name = _ref3.name;
+    if (getConfig$2()._disableExpensiveErrorDiagnostics) {
+      return 'Unable to find role="' + role2 + '"';
+    }
+    var roles2 = "";
+    Array.from(container.children).forEach(function(childElement) {
+      roles2 += prettyRoles$1(childElement, {
+        hidden,
+        includeName: name !== void 0
+      });
+    });
+    var roleMessage;
+    if (roles2.length === 0) {
+      if (hidden === false) {
+        roleMessage = "There are no accessible roles. But there might be some inaccessible roles. If you wish to access them, then set the `hidden` option to `true`. Learn more about this here: https://testing-library.com/docs/dom-testing-library/api-queries#byrole";
+      } else {
+        roleMessage = "There are no available roles.";
+      }
+    } else {
+      roleMessage = ("\nHere are the " + (hidden === false ? "accessible" : "available") + " roles:\n\n  " + roles2.replace(/\n/g, "\n  ").replace(/\n\s\s\n/g, "\n\n") + "\n").trim();
+    }
+    var nameHint = "";
+    if (name === void 0) {
+      nameHint = "";
+    } else if (typeof name === "string") {
+      nameHint = ' and name "' + name + '"';
+    } else {
+      nameHint = " and name `" + name + "`";
+    }
+    return ("\nUnable to find an " + (hidden === false ? "accessible " : "") + 'element with the role "' + role2 + '"' + nameHint + "\n\n" + roleMessage).trim();
+  };
+  var queryAllByRoleWithSuggestions$1 = wrapAllByQueryWithSuggestion$1(queryAllByRole$1, queryAllByRole$1.name, "queryAll");
+  var _buildQueries$1 = buildQueries$1(queryAllByRole$1, getMultipleError$1$1, getMissingError$1$1), queryByRole$1 = _buildQueries$1[0], getAllByRole$1 = _buildQueries$1[1], getByRole$1 = _buildQueries$1[2], findAllByRole$1 = _buildQueries$1[3], findByRole$1 = _buildQueries$1[4];
+  var getTestIdAttribute$1 = function getTestIdAttribute2() {
+    return getConfig$2().testIdAttribute;
+  };
+  var queryAllByTestId$1 = function queryAllByTestId2() {
+    for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+    checkContainerType$2(args[0]);
+    return queryAllByAttribute$1.apply(void 0, [getTestIdAttribute$1()].concat(args));
+  };
+  var getMultipleError$8 = function getMultipleError2(c2, id2) {
+    return "Found multiple elements by: [" + getTestIdAttribute$1() + '="' + id2 + '"]';
+  };
+  var getMissingError$7 = function getMissingError2(c2, id2) {
+    return "Unable to find an element by: [" + getTestIdAttribute$1() + '="' + id2 + '"]';
+  };
+  var queryAllByTestIdWithSuggestions$1 = wrapAllByQueryWithSuggestion$1(queryAllByTestId$1, queryAllByTestId$1.name, "queryAll");
+  var _buildQueries = buildQueries$1(queryAllByTestId$1, getMultipleError$8, getMissingError$7), queryByTestId$1 = _buildQueries[0], getAllByTestId$1 = _buildQueries[1], getByTestId$1 = _buildQueries[2], findAllByTestId$1 = _buildQueries[3], findByTestId$1 = _buildQueries[4];
+  var queries$1 = /* @__PURE__ */ Object.freeze({
+    __proto__: null,
+    queryAllByLabelText: queryAllByLabelTextWithSuggestions$1,
+    queryByLabelText: queryByLabelText$1,
+    getAllByLabelText: getAllByLabelTextWithSuggestions$1,
+    getByLabelText: getByLabelTextWithSuggestions$1,
+    findAllByLabelText: findAllByLabelText$1,
+    findByLabelText: findByLabelText$1,
+    queryByPlaceholderText: queryByPlaceholderText$1,
+    queryAllByPlaceholderText: queryAllByPlaceholderTextWithSuggestions$1,
+    getByPlaceholderText: getByPlaceholderText$1,
+    getAllByPlaceholderText: getAllByPlaceholderText$1,
+    findAllByPlaceholderText: findAllByPlaceholderText$1,
+    findByPlaceholderText: findByPlaceholderText$1,
+    queryByText: queryByText$1,
+    queryAllByText: queryAllByTextWithSuggestions$1,
+    getByText: getByText$1,
+    getAllByText: getAllByText$1,
+    findAllByText: findAllByText$1,
+    findByText: findByText$1,
+    queryByDisplayValue: queryByDisplayValue$1,
+    queryAllByDisplayValue: queryAllByDisplayValueWithSuggestions$1,
+    getByDisplayValue: getByDisplayValue$1,
+    getAllByDisplayValue: getAllByDisplayValue$1,
+    findAllByDisplayValue: findAllByDisplayValue$1,
+    findByDisplayValue: findByDisplayValue$1,
+    queryByAltText: queryByAltText$1,
+    queryAllByAltText: queryAllByAltTextWithSuggestions$1,
+    getByAltText: getByAltText$1,
+    getAllByAltText: getAllByAltText$1,
+    findAllByAltText: findAllByAltText$1,
+    findByAltText: findByAltText$1,
+    queryByTitle: queryByTitle$1,
+    queryAllByTitle: queryAllByTitleWithSuggestions$1,
+    getByTitle: getByTitle$1,
+    getAllByTitle: getAllByTitle$1,
+    findAllByTitle: findAllByTitle$1,
+    findByTitle: findByTitle$1,
+    queryByRole: queryByRole$1,
+    queryAllByRole: queryAllByRoleWithSuggestions$1,
+    getAllByRole: getAllByRole$1,
+    getByRole: getByRole$1,
+    findAllByRole: findAllByRole$1,
+    findByRole: findByRole$1,
+    queryByTestId: queryByTestId$1,
+    queryAllByTestId: queryAllByTestIdWithSuggestions$1,
+    getByTestId: getByTestId$1,
+    getAllByTestId: getAllByTestId$1,
+    findAllByTestId: findAllByTestId$1,
+    findByTestId: findByTestId$1
+  });
+  function getQueriesForElement$1(element, queries$1$1, initialValue2) {
+    if (queries$1$1 === void 0) {
+      queries$1$1 = queries$1;
+    }
+    if (initialValue2 === void 0) {
+      initialValue2 = {};
+    }
+    return Object.keys(queries$1$1).reduce(function(helpers2, key2) {
+      var fn2 = queries$1$1[key2];
+      helpers2[key2] = fn2.bind(null, element);
+      return helpers2;
+    }, initialValue2);
+  }
+  var hasWarned$1 = false;
+  function waitForElement(_x, _x2) {
+    return _waitForElement.apply(this, arguments);
+  }
+  function _waitForElement() {
+    _waitForElement = _asyncToGenerator(/* @__PURE__ */ regenerator.mark(function _callee(callback, options) {
+      return regenerator.wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              if (!hasWarned$1) {
+                hasWarned$1 = true;
+                console.warn("`waitForElement` has been deprecated. Use a `find*` query (preferred: https://testing-library.com/docs/dom-testing-library/api-queries#findby) or use `waitFor` instead: https://testing-library.com/docs/dom-testing-library/api-async#waitfor");
+              }
+              if (callback) {
+                _context.next = 3;
+                break;
+              }
+              throw new Error("waitForElement requires a callback as the first parameter");
+            case 3:
+              return _context.abrupt("return", waitForWrapper$1(function() {
+                var result = callback();
+                if (!result) {
+                  throw new Error("Timed out in waitForElement.");
+                }
+                return result;
+              }, options));
+            case 4:
+            case "end":
+              return _context.stop();
+          }
+        }
+      }, _callee);
+    }));
+    return _waitForElement.apply(this, arguments);
+  }
+  var isRemoved$1 = function isRemoved2(result) {
+    return !result || Array.isArray(result) && !result.length;
+  };
+  function initialCheck$1(elements) {
+    if (isRemoved$1(elements)) {
+      throw new Error("The element(s) given to waitForElementToBeRemoved are already removed. waitForElementToBeRemoved requires that the element(s) exist(s) before waiting for removal.");
+    }
+  }
+  function waitForElementToBeRemoved$1(_x, _x2) {
+    return _waitForElementToBeRemoved.apply(this, arguments);
+  }
+  function _waitForElementToBeRemoved() {
+    _waitForElementToBeRemoved = _asyncToGenerator(/* @__PURE__ */ regenerator.mark(function _callee(callback, options) {
+      var timeoutError, elements, getRemainingElements;
+      return regenerator.wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              timeoutError = new Error("Timed out in waitForElementToBeRemoved.");
+              if (typeof callback !== "function") {
+                initialCheck$1(callback);
+                elements = Array.isArray(callback) ? callback : [callback];
+                getRemainingElements = elements.map(function(element) {
+                  var parent2 = element.parentElement;
+                  if (parent2 === null) return function() {
+                    return null;
+                  };
+                  while (parent2.parentElement) {
+                    parent2 = parent2.parentElement;
+                  }
+                  return function() {
+                    return parent2.contains(element) ? element : null;
+                  };
+                });
+                callback = function callback2() {
+                  return getRemainingElements.map(function(c2) {
+                    return c2();
+                  }).filter(Boolean);
+                };
+              }
+              initialCheck$1(callback());
+              return _context.abrupt("return", waitForWrapper$1(function() {
+                var result;
+                try {
+                  result = callback();
+                } catch (error) {
+                  if (error.name === "TestingLibraryElementError") {
+                    return void 0;
+                  }
+                  throw error;
+                }
+                if (!isRemoved$1(result)) {
+                  throw timeoutError;
+                }
+                return void 0;
+              }, options));
+            case 4:
+            case "end":
+              return _context.stop();
+          }
+        }
+      }, _callee);
+    }));
+    return _waitForElementToBeRemoved.apply(this, arguments);
+  }
+  var hasWarned = false;
+  function waitForDomChange(_temp) {
+    var _ref = _temp === void 0 ? {} : _temp, _ref$container = _ref.container, container = _ref$container === void 0 ? getDocument$2() : _ref$container, _ref$timeout = _ref.timeout, timeout = _ref$timeout === void 0 ? getConfig$2().asyncUtilTimeout : _ref$timeout, _ref$mutationObserver = _ref.mutationObserverOptions, mutationObserverOptions = _ref$mutationObserver === void 0 ? {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      characterData: true
+    } : _ref$mutationObserver;
+    if (!hasWarned) {
+      hasWarned = true;
+      console.warn("`waitForDomChange` has been deprecated. Use `waitFor` instead: https://testing-library.com/docs/dom-testing-library/api-async#waitfor.");
+    }
+    return new Promise(function(resolve, reject) {
+      var timer = setTimeoutFn(onTimeout, timeout);
+      var _getWindowFromNode = getWindowFromNode$2(container), MutationObserver = _getWindowFromNode.MutationObserver;
+      var observer = new MutationObserver(onMutation);
+      runWithRealTimers(function() {
+        return observer.observe(container, mutationObserverOptions);
+      });
+      function onDone(error, result) {
+        clearTimeoutFn(timer);
+        setImmediateFn(function() {
+          return observer.disconnect();
+        });
+        if (error) {
+          reject(error);
+        } else {
+          resolve(result);
+        }
+      }
+      function onMutation(mutationsList) {
+        onDone(null, mutationsList);
+      }
+      function onTimeout() {
+        onDone(new Error("Timed out in waitForDomChange."), null);
+      }
+    });
+  }
+  function waitForDomChangeWrapper() {
+    for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+    return getConfig$2().asyncWrapper(function() {
+      return waitForDomChange.apply(void 0, args);
+    });
+  }
+  var eventMap$3 = {
+    // Clipboard Events
+    copy: {
+      EventType: "ClipboardEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    cut: {
+      EventType: "ClipboardEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    paste: {
+      EventType: "ClipboardEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    // Composition Events
+    compositionEnd: {
+      EventType: "CompositionEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    compositionStart: {
+      EventType: "CompositionEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    compositionUpdate: {
+      EventType: "CompositionEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    // Keyboard Events
+    keyDown: {
+      EventType: "KeyboardEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        charCode: 0,
+        composed: true
+      }
+    },
+    keyPress: {
+      EventType: "KeyboardEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        charCode: 0,
+        composed: true
+      }
+    },
+    keyUp: {
+      EventType: "KeyboardEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        charCode: 0,
+        composed: true
+      }
+    },
+    // Focus Events
+    focus: {
+      EventType: "FocusEvent",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false,
+        composed: true
+      }
+    },
+    blur: {
+      EventType: "FocusEvent",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false,
+        composed: true
+      }
+    },
+    focusIn: {
+      EventType: "FocusEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: false,
+        composed: true
+      }
+    },
+    focusOut: {
+      EventType: "FocusEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: false,
+        composed: true
+      }
+    },
+    // Form Events
+    change: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: true,
+        cancelable: false
+      }
+    },
+    input: {
+      EventType: "InputEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: false,
+        composed: true
+      }
+    },
+    invalid: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: true
+      }
+    },
+    submit: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true
+      }
+    },
+    reset: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true
+      }
+    },
+    // Mouse Events
+    click: {
+      EventType: "MouseEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        composed: true
+      }
+    },
+    contextMenu: {
+      EventType: "MouseEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    dblClick: {
+      EventType: "MouseEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    drag: {
+      EventType: "DragEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    dragEnd: {
+      EventType: "DragEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: false,
+        composed: true
+      }
+    },
+    dragEnter: {
+      EventType: "DragEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    dragExit: {
+      EventType: "DragEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: false,
+        composed: true
+      }
+    },
+    dragLeave: {
+      EventType: "DragEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: false,
+        composed: true
+      }
+    },
+    dragOver: {
+      EventType: "DragEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    dragStart: {
+      EventType: "DragEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    drop: {
+      EventType: "DragEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    mouseDown: {
+      EventType: "MouseEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    mouseEnter: {
+      EventType: "MouseEvent",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false,
+        composed: true
+      }
+    },
+    mouseLeave: {
+      EventType: "MouseEvent",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false,
+        composed: true
+      }
+    },
+    mouseMove: {
+      EventType: "MouseEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    mouseOut: {
+      EventType: "MouseEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    mouseOver: {
+      EventType: "MouseEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    mouseUp: {
+      EventType: "MouseEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    // Selection Events
+    select: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: true,
+        cancelable: false
+      }
+    },
+    // Touch Events
+    touchCancel: {
+      EventType: "TouchEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: false,
+        composed: true
+      }
+    },
+    touchEnd: {
+      EventType: "TouchEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    touchMove: {
+      EventType: "TouchEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    touchStart: {
+      EventType: "TouchEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    // UI Events
+    scroll: {
+      EventType: "UIEvent",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    // Wheel Events
+    wheel: {
+      EventType: "WheelEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    // Media Events
+    abort: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    canPlay: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    canPlayThrough: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    durationChange: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    emptied: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    encrypted: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    ended: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    loadedData: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    loadedMetadata: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    loadStart: {
+      EventType: "ProgressEvent",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    pause: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    play: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    playing: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    progress: {
+      EventType: "ProgressEvent",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    rateChange: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    seeked: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    seeking: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    stalled: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    suspend: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    timeUpdate: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    volumeChange: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    waiting: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    // Image Events
+    load: {
+      EventType: "UIEvent",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    error: {
+      EventType: "Event",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    // Animation Events
+    animationStart: {
+      EventType: "AnimationEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: false
+      }
+    },
+    animationEnd: {
+      EventType: "AnimationEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: false
+      }
+    },
+    animationIteration: {
+      EventType: "AnimationEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: false
+      }
+    },
+    // Transition Events
+    transitionEnd: {
+      EventType: "TransitionEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true
+      }
+    },
+    // pointer events
+    pointerOver: {
+      EventType: "PointerEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    pointerEnter: {
+      EventType: "PointerEvent",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    pointerDown: {
+      EventType: "PointerEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    pointerMove: {
+      EventType: "PointerEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    pointerUp: {
+      EventType: "PointerEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    pointerCancel: {
+      EventType: "PointerEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: false,
+        composed: true
+      }
+    },
+    pointerOut: {
+      EventType: "PointerEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      }
+    },
+    pointerLeave: {
+      EventType: "PointerEvent",
+      defaultInit: {
+        bubbles: false,
+        cancelable: false
+      }
+    },
+    gotPointerCapture: {
+      EventType: "PointerEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: false,
+        composed: true
+      }
+    },
+    lostPointerCapture: {
+      EventType: "PointerEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: false,
+        composed: true
+      }
+    },
+    // history events
+    popState: {
+      EventType: "PopStateEvent",
+      defaultInit: {
+        bubbles: true,
+        cancelable: false
+      }
+    }
+  };
+  var eventAliasMap$2 = {
+    doubleClick: "dblClick"
+  };
+  var _excluded = ["value", "files"], _excluded2 = ["bubbles", "cancelable", "detail"];
+  function fireEvent$1$1(element, event) {
+    return getConfig$2().eventWrapper(function() {
+      if (!event) {
+        throw new Error("Unable to fire an event - please provide an event object.");
+      }
+      if (!element) {
+        throw new Error('Unable to fire a "' + event.type + '" event - please provide a DOM element.');
+      }
+      return element.dispatchEvent(event);
+    });
+  }
+  function createEvent$1(eventName, node, init, _temp) {
+    var _ref = _temp === void 0 ? {} : _temp, _ref$EventType = _ref.EventType, EventType = _ref$EventType === void 0 ? "Event" : _ref$EventType, _ref$defaultInit = _ref.defaultInit, defaultInit = _ref$defaultInit === void 0 ? {} : _ref$defaultInit;
+    if (!node) {
+      throw new Error('Unable to fire a "' + eventName + '" event - please provide a DOM element.');
+    }
+    var eventInit = _extends({}, defaultInit, init);
+    var _eventInit$target = eventInit.target;
+    _eventInit$target = _eventInit$target === void 0 ? {} : _eventInit$target;
+    var value = _eventInit$target.value, files = _eventInit$target.files, targetProperties = _objectWithoutPropertiesLoose(_eventInit$target, _excluded);
+    if (value !== void 0) {
+      setNativeValue$1(node, value);
+    }
+    if (files !== void 0) {
+      Object.defineProperty(node, "files", {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: files
+      });
+    }
+    Object.assign(node, targetProperties);
+    var window2 = getWindowFromNode$2(node);
+    var EventConstructor = window2[EventType] || window2.Event;
+    var event;
+    if (typeof EventConstructor === "function") {
+      event = new EventConstructor(eventName, eventInit);
+    } else {
+      event = window2.document.createEvent(EventType);
+      var bubbles = eventInit.bubbles, cancelable = eventInit.cancelable, detail = eventInit.detail, otherInit = _objectWithoutPropertiesLoose(eventInit, _excluded2);
+      event.initEvent(eventName, bubbles, cancelable, detail);
+      Object.keys(otherInit).forEach(function(eventKey) {
+        event[eventKey] = otherInit[eventKey];
+      });
+    }
+    var dataTransferProperties = ["dataTransfer", "clipboardData"];
+    dataTransferProperties.forEach(function(dataTransferKey) {
+      var dataTransferValue = eventInit[dataTransferKey];
+      if (typeof dataTransferValue === "object") {
+        if (typeof window2.DataTransfer === "function") {
+          Object.defineProperty(event, dataTransferKey, {
+            value: Object.getOwnPropertyNames(dataTransferValue).reduce(function(acc, propName) {
+              Object.defineProperty(acc, propName, {
+                value: dataTransferValue[propName]
+              });
+              return acc;
+            }, new window2.DataTransfer())
+          });
+        } else {
+          Object.defineProperty(event, dataTransferKey, {
+            value: dataTransferValue
+          });
+        }
+      }
+    });
+    return event;
+  }
+  Object.keys(eventMap$3).forEach(function(key2) {
+    var _eventMap$key = eventMap$3[key2], EventType = _eventMap$key.EventType, defaultInit = _eventMap$key.defaultInit;
+    var eventName = key2.toLowerCase();
+    createEvent$1[key2] = function(node, init) {
+      return createEvent$1(eventName, node, init, {
+        EventType,
+        defaultInit
+      });
+    };
+    fireEvent$1$1[key2] = function(node, init) {
+      return fireEvent$1$1(node, createEvent$1[key2](node, init));
+    };
+  });
+  function setNativeValue$1(element, value) {
+    var _ref2 = Object.getOwnPropertyDescriptor(element, "value") || {}, valueSetter = _ref2.set;
+    var prototype = Object.getPrototypeOf(element);
+    var _ref3 = Object.getOwnPropertyDescriptor(prototype, "value") || {}, prototypeValueSetter = _ref3.set;
+    if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
+      prototypeValueSetter.call(element, value);
+    } else if (valueSetter) {
+      valueSetter.call(element, value);
+    } else {
+      throw new Error("The given element does not have a value setter");
+    }
+  }
+  Object.keys(eventAliasMap$2).forEach(function(aliasKey) {
+    var key2 = eventAliasMap$2[aliasKey];
+    fireEvent$1$1[aliasKey] = function() {
+      return fireEvent$1$1[key2].apply(fireEvent$1$1, arguments);
+    };
+  });
+  function unindent$1(string) {
+    return string.replace(/[ \t]*[\n][ \t]*/g, "\n");
+  }
+  function encode$1(value) {
+    return lzString$2.compressToEncodedURIComponent(unindent$1(value));
+  }
+  function getPlaygroundUrl$1(markup2) {
+    return "https://testing-playground.com/#markup=" + encode$1(markup2);
+  }
+  var debug$1 = function debug2(element, maxLength2, options) {
+    return Array.isArray(element) ? element.forEach(function(el) {
+      return logDOM$1(el, maxLength2, options);
+    }) : logDOM$1(element, maxLength2, options);
+  };
+  var logTestingPlaygroundURL$1 = function logTestingPlaygroundURL2(element) {
+    if (element === void 0) {
+      element = getDocument$2().body;
+    }
+    if (!element || !("innerHTML" in element)) {
+      console.log("The element you're providing isn't a valid DOM element.");
+      return;
+    }
+    if (!element.innerHTML) {
+      console.log("The provided element doesn't have any children.");
+      return;
+    }
+    console.log("Open this URL in your browser\n\n" + getPlaygroundUrl$1(element.innerHTML));
+  };
+  var initialValue$1 = {
+    debug: debug$1,
+    logTestingPlaygroundURL: logTestingPlaygroundURL$1
+  };
+  var screen$1 = typeof document !== "undefined" && document.body ? getQueriesForElement$1(document.body, queries$1, initialValue$1) : Object.keys(queries$1).reduce(function(helpers2, key2) {
+    helpers2[key2] = function() {
+      throw new TypeError("For queries bound to document.body a global document has to be available... Learn more: https://testing-library.com/s/screen-global-error");
+    };
+    return helpers2;
+  }, initialValue$1);
+  var dom_esm$1 = /* @__PURE__ */ Object.freeze({
+    __proto__: null,
+    buildQueries: buildQueries$1,
+    configure: configure$1,
+    createEvent: createEvent$1,
+    findAllByAltText: findAllByAltText$1,
+    findAllByDisplayValue: findAllByDisplayValue$1,
+    findAllByLabelText: findAllByLabelText$1,
+    findAllByPlaceholderText: findAllByPlaceholderText$1,
+    findAllByRole: findAllByRole$1,
+    findAllByTestId: findAllByTestId$1,
+    findAllByText: findAllByText$1,
+    findAllByTitle: findAllByTitle$1,
+    findByAltText: findByAltText$1,
+    findByDisplayValue: findByDisplayValue$1,
+    findByLabelText: findByLabelText$1,
+    findByPlaceholderText: findByPlaceholderText$1,
+    findByRole: findByRole$1,
+    findByTestId: findByTestId$1,
+    findByText: findByText$1,
+    findByTitle: findByTitle$1,
+    fireEvent: fireEvent$1$1,
+    getAllByAltText: getAllByAltText$1,
+    getAllByDisplayValue: getAllByDisplayValue$1,
+    getAllByLabelText: getAllByLabelTextWithSuggestions$1,
+    getAllByPlaceholderText: getAllByPlaceholderText$1,
+    getAllByRole: getAllByRole$1,
+    getAllByTestId: getAllByTestId$1,
+    getAllByText: getAllByText$1,
+    getAllByTitle: getAllByTitle$1,
+    getByAltText: getByAltText$1,
+    getByDisplayValue: getByDisplayValue$1,
+    getByLabelText: getByLabelTextWithSuggestions$1,
+    getByPlaceholderText: getByPlaceholderText$1,
+    getByRole: getByRole$1,
+    getByTestId: getByTestId$1,
+    getByText: getByText$1,
+    getByTitle: getByTitle$1,
+    getConfig: getConfig$2,
+    getDefaultNormalizer: getDefaultNormalizer$1,
+    getElementError: getElementError$1,
+    getMultipleElementsFoundError: getMultipleElementsFoundError$1,
+    getNodeText: getNodeText$1,
+    getQueriesForElement: getQueriesForElement$1,
+    getRoles: getRoles$1,
+    getSuggestedQuery: getSuggestedQuery$1,
+    isInaccessible: isInaccessible$1,
+    logDOM: logDOM$1,
+    logRoles: logRoles$1,
+    makeFindQuery: makeFindQuery$1,
+    makeGetAllQuery: makeGetAllQuery$1,
+    makeSingleQuery: makeSingleQuery$1,
+    prettyDOM: prettyDOM$1,
+    queries: queries$1,
+    queryAllByAltText: queryAllByAltTextWithSuggestions$1,
+    queryAllByAttribute: queryAllByAttribute$1,
+    queryAllByDisplayValue: queryAllByDisplayValueWithSuggestions$1,
+    queryAllByLabelText: queryAllByLabelTextWithSuggestions$1,
+    queryAllByPlaceholderText: queryAllByPlaceholderTextWithSuggestions$1,
+    queryAllByRole: queryAllByRoleWithSuggestions$1,
+    queryAllByTestId: queryAllByTestIdWithSuggestions$1,
+    queryAllByText: queryAllByTextWithSuggestions$1,
+    queryAllByTitle: queryAllByTitleWithSuggestions$1,
+    queryByAltText: queryByAltText$1,
+    queryByAttribute: queryByAttribute$1,
+    queryByDisplayValue: queryByDisplayValue$1,
+    queryByLabelText: queryByLabelText$1,
+    queryByPlaceholderText: queryByPlaceholderText$1,
+    queryByRole: queryByRole$1,
+    queryByTestId: queryByTestId$1,
+    queryByText: queryByText$1,
+    queryByTitle: queryByTitle$1,
+    queryHelpers: queryHelpers$1,
+    screen: screen$1,
+    wait: wait$1$1,
+    waitFor: waitForWrapper$1,
+    waitForDomChange: waitForDomChangeWrapper,
+    waitForElement,
+    waitForElementToBeRemoved: waitForElementToBeRemoved$1,
+    within: getQueriesForElement$1,
+    wrapAllByQueryWithSuggestion: wrapAllByQueryWithSuggestion$1,
+    wrapSingleQueryWithSuggestion: wrapSingleQueryWithSuggestion$1,
+    prettyFormat: build$1$1
+  });
+  /*
+  object-assign
+  (c) Sindre Sorhus
+  @license MIT
+  */
+  var getOwnPropertySymbols = Object.getOwnPropertySymbols;
+  var hasOwnProperty$2 = Object.prototype.hasOwnProperty;
+  var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+  function toObject(val) {
+    if (val === null || val === void 0) {
+      throw new TypeError("Object.assign cannot be called with null or undefined");
+    }
+    return Object(val);
+  }
+  function shouldUseNative() {
+    try {
+      if (!Object.assign) {
+        return false;
+      }
+      var test1 = new String("abc");
+      test1[5] = "de";
+      if (Object.getOwnPropertyNames(test1)[0] === "5") {
+        return false;
+      }
+      var test2 = {};
+      for (var i2 = 0; i2 < 10; i2++) {
+        test2["_" + String.fromCharCode(i2)] = i2;
+      }
+      var order2 = Object.getOwnPropertyNames(test2).map(function(n2) {
+        return test2[n2];
+      });
+      if (order2.join("") !== "0123456789") {
+        return false;
+      }
+      var test3 = {};
+      "abcdefghijklmnopqrst".split("").forEach(function(letter) {
+        test3[letter] = letter;
+      });
+      if (Object.keys(Object.assign({}, test3)).join("") !== "abcdefghijklmnopqrst") {
+        return false;
+      }
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+  var objectAssign = shouldUseNative() ? Object.assign : function(target, source) {
+    var from2;
+    var to = toObject(target);
+    var symbols;
+    for (var s = 1; s < arguments.length; s++) {
+      from2 = Object(arguments[s]);
+      for (var key2 in from2) {
+        if (hasOwnProperty$2.call(from2, key2)) {
+          to[key2] = from2[key2];
+        }
+      }
+      if (getOwnPropertySymbols) {
+        symbols = getOwnPropertySymbols(from2);
+        for (var i2 = 0; i2 < symbols.length; i2++) {
+          if (propIsEnumerable.call(from2, symbols[i2])) {
+            to[symbols[i2]] = from2[symbols[i2]];
+          }
+        }
+      }
+    }
+    return to;
+  };
+  /** @license React v0.20.2
+   * scheduler.production.min.js
+   *
+   * Copyright (c) Facebook, Inc. and its affiliates.
+   *
+   * This source code is licensed under the MIT license found in the
+   * LICENSE file in the root directory of this source tree.
+   */
+  var scheduler_production_min = createCommonjsModule(function(module2, exports2) {
+    var f2, g2, h2, k2;
+    if ("object" === typeof performance && "function" === typeof performance.now) {
+      var l2 = performance;
+      exports2.unstable_now = function() {
+        return l2.now();
+      };
+    } else {
+      var p2 = Date, q2 = p2.now();
+      exports2.unstable_now = function() {
+        return p2.now() - q2;
+      };
+    }
+    if ("undefined" === typeof window || "function" !== typeof MessageChannel) {
+      var t2 = null, u2 = null, w2 = function() {
+        if (null !== t2) try {
+          var a = exports2.unstable_now();
+          t2(true, a);
+          t2 = null;
+        } catch (b2) {
+          throw setTimeout(w2, 0), b2;
+        }
+      };
+      f2 = function(a) {
+        null !== t2 ? setTimeout(f2, 0, a) : (t2 = a, setTimeout(w2, 0));
+      };
+      g2 = function(a, b2) {
+        u2 = setTimeout(a, b2);
+      };
+      h2 = function() {
+        clearTimeout(u2);
+      };
+      exports2.unstable_shouldYield = function() {
+        return false;
+      };
+      k2 = exports2.unstable_forceFrameRate = function() {
+      };
+    } else {
+      var x2 = window.setTimeout, y2 = window.clearTimeout;
+      if ("undefined" !== typeof console) {
+        var z2 = window.cancelAnimationFrame;
+        "function" !== typeof window.requestAnimationFrame && console.error("This browser doesn't support requestAnimationFrame. Make sure that you load a polyfill in older browsers. https://reactjs.org/link/react-polyfills");
+        "function" !== typeof z2 && console.error("This browser doesn't support cancelAnimationFrame. Make sure that you load a polyfill in older browsers. https://reactjs.org/link/react-polyfills");
+      }
+      var A2 = false, B2 = null, C2 = -1, D2 = 5, E2 = 0;
+      exports2.unstable_shouldYield = function() {
+        return exports2.unstable_now() >= E2;
+      };
+      k2 = function() {
+      };
+      exports2.unstable_forceFrameRate = function(a) {
+        0 > a || 125 < a ? console.error("forceFrameRate takes a positive int between 0 and 125, forcing frame rates higher than 125 fps is not supported") : D2 = 0 < a ? Math.floor(1e3 / a) : 5;
+      };
+      var F2 = new MessageChannel(), G2 = F2.port2;
+      F2.port1.onmessage = function() {
+        if (null !== B2) {
+          var a = exports2.unstable_now();
+          E2 = a + D2;
+          try {
+            B2(true, a) ? G2.postMessage(null) : (A2 = false, B2 = null);
+          } catch (b2) {
+            throw G2.postMessage(null), b2;
+          }
+        } else A2 = false;
+      };
+      f2 = function(a) {
+        B2 = a;
+        A2 || (A2 = true, G2.postMessage(null));
+      };
+      g2 = function(a, b2) {
+        C2 = x2(function() {
+          a(exports2.unstable_now());
+        }, b2);
+      };
+      h2 = function() {
+        y2(C2);
+        C2 = -1;
+      };
+    }
+    function H2(a, b2) {
+      var c2 = a.length;
+      a.push(b2);
+      a: for (; ; ) {
+        var d2 = c2 - 1 >>> 1, e2 = a[d2];
+        if (void 0 !== e2 && 0 < I2(e2, b2)) a[d2] = b2, a[c2] = e2, c2 = d2;
+        else break a;
+      }
+    }
+    function J2(a) {
+      a = a[0];
+      return void 0 === a ? null : a;
+    }
+    function K2(a) {
+      var b2 = a[0];
+      if (void 0 !== b2) {
+        var c2 = a.pop();
+        if (c2 !== b2) {
+          a[0] = c2;
+          a: for (var d2 = 0, e2 = a.length; d2 < e2; ) {
+            var m2 = 2 * (d2 + 1) - 1, n2 = a[m2], v2 = m2 + 1, r2 = a[v2];
+            if (void 0 !== n2 && 0 > I2(n2, c2)) void 0 !== r2 && 0 > I2(r2, n2) ? (a[d2] = r2, a[v2] = c2, d2 = v2) : (a[d2] = n2, a[m2] = c2, d2 = m2);
+            else if (void 0 !== r2 && 0 > I2(r2, c2)) a[d2] = r2, a[v2] = c2, d2 = v2;
+            else break a;
+          }
+        }
+        return b2;
+      }
+      return null;
+    }
+    function I2(a, b2) {
+      var c2 = a.sortIndex - b2.sortIndex;
+      return 0 !== c2 ? c2 : a.id - b2.id;
+    }
+    var L2 = [], M2 = [], N = 1, O2 = null, P2 = 3, Q2 = false, R2 = false, S2 = false;
+    function T2(a) {
+      for (var b2 = J2(M2); null !== b2; ) {
+        if (null === b2.callback) K2(M2);
+        else if (b2.startTime <= a) K2(M2), b2.sortIndex = b2.expirationTime, H2(L2, b2);
+        else break;
+        b2 = J2(M2);
+      }
+    }
+    function U2(a) {
+      S2 = false;
+      T2(a);
+      if (!R2) if (null !== J2(L2)) R2 = true, f2(V2);
+      else {
+        var b2 = J2(M2);
+        null !== b2 && g2(U2, b2.startTime - a);
+      }
+    }
+    function V2(a, b2) {
+      R2 = false;
+      S2 && (S2 = false, h2());
+      Q2 = true;
+      var c2 = P2;
+      try {
+        T2(b2);
+        for (O2 = J2(L2); null !== O2 && (!(O2.expirationTime > b2) || a && !exports2.unstable_shouldYield()); ) {
+          var d2 = O2.callback;
+          if ("function" === typeof d2) {
+            O2.callback = null;
+            P2 = O2.priorityLevel;
+            var e2 = d2(O2.expirationTime <= b2);
+            b2 = exports2.unstable_now();
+            "function" === typeof e2 ? O2.callback = e2 : O2 === J2(L2) && K2(L2);
+            T2(b2);
+          } else K2(L2);
+          O2 = J2(L2);
+        }
+        if (null !== O2) var m2 = true;
+        else {
+          var n2 = J2(M2);
+          null !== n2 && g2(U2, n2.startTime - b2);
+          m2 = false;
+        }
+        return m2;
+      } finally {
+        O2 = null, P2 = c2, Q2 = false;
+      }
+    }
+    var W2 = k2;
+    exports2.unstable_IdlePriority = 5;
+    exports2.unstable_ImmediatePriority = 1;
+    exports2.unstable_LowPriority = 4;
+    exports2.unstable_NormalPriority = 3;
+    exports2.unstable_Profiling = null;
+    exports2.unstable_UserBlockingPriority = 2;
+    exports2.unstable_cancelCallback = function(a) {
+      a.callback = null;
+    };
+    exports2.unstable_continueExecution = function() {
+      R2 || Q2 || (R2 = true, f2(V2));
+    };
+    exports2.unstable_getCurrentPriorityLevel = function() {
+      return P2;
+    };
+    exports2.unstable_getFirstCallbackNode = function() {
+      return J2(L2);
+    };
+    exports2.unstable_next = function(a) {
+      switch (P2) {
+        case 1:
+        case 2:
+        case 3:
+          var b2 = 3;
+          break;
+        default:
+          b2 = P2;
+      }
+      var c2 = P2;
+      P2 = b2;
+      try {
+        return a();
+      } finally {
+        P2 = c2;
+      }
+    };
+    exports2.unstable_pauseExecution = function() {
+    };
+    exports2.unstable_requestPaint = W2;
+    exports2.unstable_runWithPriority = function(a, b2) {
+      switch (a) {
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+          break;
+        default:
+          a = 3;
+      }
+      var c2 = P2;
+      P2 = a;
+      try {
+        return b2();
+      } finally {
+        P2 = c2;
+      }
+    };
+    exports2.unstable_scheduleCallback = function(a, b2, c2) {
+      var d2 = exports2.unstable_now();
+      "object" === typeof c2 && null !== c2 ? (c2 = c2.delay, c2 = "number" === typeof c2 && 0 < c2 ? d2 + c2 : d2) : c2 = d2;
+      switch (a) {
+        case 1:
+          var e2 = -1;
+          break;
+        case 2:
+          e2 = 250;
+          break;
+        case 5:
+          e2 = 1073741823;
+          break;
+        case 4:
+          e2 = 1e4;
+          break;
+        default:
+          e2 = 5e3;
+      }
+      e2 = c2 + e2;
+      a = { id: N++, callback: b2, priorityLevel: a, startTime: c2, expirationTime: e2, sortIndex: -1 };
+      c2 > d2 ? (a.sortIndex = c2, H2(M2, a), null === J2(L2) && a === J2(M2) && (S2 ? h2() : S2 = true, g2(U2, c2 - d2))) : (a.sortIndex = e2, H2(L2, a), R2 || Q2 || (R2 = true, f2(V2)));
+      return a;
+    };
+    exports2.unstable_wrapCallback = function(a) {
+      var b2 = P2;
+      return function() {
+        var c2 = P2;
+        P2 = b2;
+        try {
+          return a.apply(this, arguments);
+        } finally {
+          P2 = c2;
+        }
+      };
+    };
+  });
+  var scheduler_development = createCommonjsModule(function(module2, exports2) {
+    if (process$1.env.NODE_ENV !== "production") {
+      (function() {
+        var enableSchedulerDebugging = false;
+        var enableProfiling = false;
+        var requestHostCallback;
+        var requestHostTimeout;
+        var cancelHostTimeout;
+        var requestPaint;
+        var hasPerformanceNow = typeof performance === "object" && typeof performance.now === "function";
+        if (hasPerformanceNow) {
+          var localPerformance = performance;
+          exports2.unstable_now = function() {
+            return localPerformance.now();
+          };
+        } else {
+          var localDate = Date;
+          var initialTime = localDate.now();
+          exports2.unstable_now = function() {
+            return localDate.now() - initialTime;
+          };
+        }
+        if (
+          // If Scheduler runs in a non-DOM environment, it falls back to a naive
+          // implementation using setTimeout.
+          typeof window === "undefined" || // Check if MessageChannel is supported, too.
+          typeof MessageChannel !== "function"
+        ) {
+          var _callback = null;
+          var _timeoutID = null;
+          var _flushCallback = function() {
+            if (_callback !== null) {
+              try {
+                var currentTime = exports2.unstable_now();
+                var hasRemainingTime = true;
+                _callback(hasRemainingTime, currentTime);
+                _callback = null;
+              } catch (e2) {
+                setTimeout(_flushCallback, 0);
+                throw e2;
+              }
+            }
+          };
+          requestHostCallback = function(cb) {
+            if (_callback !== null) {
+              setTimeout(requestHostCallback, 0, cb);
+            } else {
+              _callback = cb;
+              setTimeout(_flushCallback, 0);
+            }
+          };
+          requestHostTimeout = function(cb, ms) {
+            _timeoutID = setTimeout(cb, ms);
+          };
+          cancelHostTimeout = function() {
+            clearTimeout(_timeoutID);
+          };
+          exports2.unstable_shouldYield = function() {
+            return false;
+          };
+          requestPaint = exports2.unstable_forceFrameRate = function() {
+          };
+        } else {
+          var _setTimeout = window.setTimeout;
+          var _clearTimeout = window.clearTimeout;
+          if (typeof console !== "undefined") {
+            var requestAnimationFrame = window.requestAnimationFrame;
+            var cancelAnimationFrame = window.cancelAnimationFrame;
+            if (typeof requestAnimationFrame !== "function") {
+              console["error"]("This browser doesn't support requestAnimationFrame. Make sure that you load a polyfill in older browsers. https://reactjs.org/link/react-polyfills");
+            }
+            if (typeof cancelAnimationFrame !== "function") {
+              console["error"]("This browser doesn't support cancelAnimationFrame. Make sure that you load a polyfill in older browsers. https://reactjs.org/link/react-polyfills");
+            }
+          }
+          var isMessageLoopRunning = false;
+          var scheduledHostCallback = null;
+          var taskTimeoutID = -1;
+          var yieldInterval = 5;
+          var deadline = 0;
+          {
+            exports2.unstable_shouldYield = function() {
+              return exports2.unstable_now() >= deadline;
+            };
+            requestPaint = function() {
+            };
+          }
+          exports2.unstable_forceFrameRate = function(fps) {
+            if (fps < 0 || fps > 125) {
+              console["error"]("forceFrameRate takes a positive int between 0 and 125, forcing frame rates higher than 125 fps is not supported");
+              return;
+            }
+            if (fps > 0) {
+              yieldInterval = Math.floor(1e3 / fps);
+            } else {
+              yieldInterval = 5;
+            }
+          };
+          var performWorkUntilDeadline = function() {
+            if (scheduledHostCallback !== null) {
+              var currentTime = exports2.unstable_now();
+              deadline = currentTime + yieldInterval;
+              var hasTimeRemaining = true;
+              try {
+                var hasMoreWork = scheduledHostCallback(hasTimeRemaining, currentTime);
+                if (!hasMoreWork) {
+                  isMessageLoopRunning = false;
+                  scheduledHostCallback = null;
+                } else {
+                  port.postMessage(null);
+                }
+              } catch (error) {
+                port.postMessage(null);
+                throw error;
+              }
+            } else {
+              isMessageLoopRunning = false;
+            }
+          };
+          var channel2 = new MessageChannel();
+          var port = channel2.port2;
+          channel2.port1.onmessage = performWorkUntilDeadline;
+          requestHostCallback = function(callback) {
+            scheduledHostCallback = callback;
+            if (!isMessageLoopRunning) {
+              isMessageLoopRunning = true;
+              port.postMessage(null);
+            }
+          };
+          requestHostTimeout = function(callback, ms) {
+            taskTimeoutID = _setTimeout(function() {
+              callback(exports2.unstable_now());
+            }, ms);
+          };
+          cancelHostTimeout = function() {
+            _clearTimeout(taskTimeoutID);
+            taskTimeoutID = -1;
+          };
+        }
+        function push2(heap, node) {
+          var index2 = heap.length;
+          heap.push(node);
+          siftUp(heap, node, index2);
+        }
+        function peek(heap) {
+          var first = heap[0];
+          return first === void 0 ? null : first;
+        }
+        function pop(heap) {
+          var first = heap[0];
+          if (first !== void 0) {
+            var last = heap.pop();
+            if (last !== first) {
+              heap[0] = last;
+              siftDown(heap, last, 0);
+            }
+            return first;
+          } else {
+            return null;
+          }
+        }
+        function siftUp(heap, node, i2) {
+          var index2 = i2;
+          while (true) {
+            var parentIndex = index2 - 1 >>> 1;
+            var parent2 = heap[parentIndex];
+            if (parent2 !== void 0 && compare(parent2, node) > 0) {
+              heap[parentIndex] = node;
+              heap[index2] = parent2;
+              index2 = parentIndex;
+            } else {
+              return;
+            }
+          }
+        }
+        function siftDown(heap, node, i2) {
+          var index2 = i2;
+          var length = heap.length;
+          while (index2 < length) {
+            var leftIndex = (index2 + 1) * 2 - 1;
+            var left = heap[leftIndex];
+            var rightIndex = leftIndex + 1;
+            var right = heap[rightIndex];
+            if (left !== void 0 && compare(left, node) < 0) {
+              if (right !== void 0 && compare(right, left) < 0) {
+                heap[index2] = right;
+                heap[rightIndex] = node;
+                index2 = rightIndex;
+              } else {
+                heap[index2] = left;
+                heap[leftIndex] = node;
+                index2 = leftIndex;
+              }
+            } else if (right !== void 0 && compare(right, node) < 0) {
+              heap[index2] = right;
+              heap[rightIndex] = node;
+              index2 = rightIndex;
+            } else {
+              return;
+            }
+          }
+        }
+        function compare(a, b2) {
+          var diff = a.sortIndex - b2.sortIndex;
+          return diff !== 0 ? diff : a.id - b2.id;
+        }
+        var ImmediatePriority = 1;
+        var UserBlockingPriority = 2;
+        var NormalPriority = 3;
+        var LowPriority = 4;
+        var IdlePriority = 5;
+        var maxSigned31BitInt = 1073741823;
+        var IMMEDIATE_PRIORITY_TIMEOUT = -1;
+        var USER_BLOCKING_PRIORITY_TIMEOUT = 250;
+        var NORMAL_PRIORITY_TIMEOUT = 5e3;
+        var LOW_PRIORITY_TIMEOUT = 1e4;
+        var IDLE_PRIORITY_TIMEOUT = maxSigned31BitInt;
+        var taskQueue = [];
+        var timerQueue = [];
+        var taskIdCounter = 1;
+        var currentTask = null;
+        var currentPriorityLevel = NormalPriority;
+        var isPerformingWork = false;
+        var isHostCallbackScheduled = false;
+        var isHostTimeoutScheduled = false;
+        function advanceTimers(currentTime) {
+          var timer = peek(timerQueue);
+          while (timer !== null) {
+            if (timer.callback === null) {
+              pop(timerQueue);
+            } else if (timer.startTime <= currentTime) {
+              pop(timerQueue);
+              timer.sortIndex = timer.expirationTime;
+              push2(taskQueue, timer);
+            } else {
+              return;
+            }
+            timer = peek(timerQueue);
+          }
+        }
+        function handleTimeout(currentTime) {
+          isHostTimeoutScheduled = false;
+          advanceTimers(currentTime);
+          if (!isHostCallbackScheduled) {
+            if (peek(taskQueue) !== null) {
+              isHostCallbackScheduled = true;
+              requestHostCallback(flushWork);
+            } else {
+              var firstTimer = peek(timerQueue);
+              if (firstTimer !== null) {
+                requestHostTimeout(handleTimeout, firstTimer.startTime - currentTime);
+              }
+            }
+          }
+        }
+        function flushWork(hasTimeRemaining, initialTime2) {
+          isHostCallbackScheduled = false;
+          if (isHostTimeoutScheduled) {
+            isHostTimeoutScheduled = false;
+            cancelHostTimeout();
+          }
+          isPerformingWork = true;
+          var previousPriorityLevel = currentPriorityLevel;
+          try {
+            var currentTime;
+            if (enableProfiling) ;
+            else {
+              return workLoop(hasTimeRemaining, initialTime2);
+            }
+          } finally {
+            currentTask = null;
+            currentPriorityLevel = previousPriorityLevel;
+            isPerformingWork = false;
+          }
+        }
+        function workLoop(hasTimeRemaining, initialTime2) {
+          var currentTime = initialTime2;
+          advanceTimers(currentTime);
+          currentTask = peek(taskQueue);
+          while (currentTask !== null && !enableSchedulerDebugging) {
+            if (currentTask.expirationTime > currentTime && (!hasTimeRemaining || exports2.unstable_shouldYield())) {
+              break;
+            }
+            var callback = currentTask.callback;
+            if (typeof callback === "function") {
+              currentTask.callback = null;
+              currentPriorityLevel = currentTask.priorityLevel;
+              var didUserCallbackTimeout = currentTask.expirationTime <= currentTime;
+              var continuationCallback = callback(didUserCallbackTimeout);
+              currentTime = exports2.unstable_now();
+              if (typeof continuationCallback === "function") {
+                currentTask.callback = continuationCallback;
+              } else {
+                if (currentTask === peek(taskQueue)) {
+                  pop(taskQueue);
+                }
+              }
+              advanceTimers(currentTime);
+            } else {
+              pop(taskQueue);
+            }
+            currentTask = peek(taskQueue);
+          }
+          if (currentTask !== null) {
+            return true;
+          } else {
+            var firstTimer = peek(timerQueue);
+            if (firstTimer !== null) {
+              requestHostTimeout(handleTimeout, firstTimer.startTime - currentTime);
+            }
+            return false;
+          }
+        }
+        function unstable_runWithPriority(priorityLevel, eventHandler) {
+          switch (priorityLevel) {
+            case ImmediatePriority:
+            case UserBlockingPriority:
+            case NormalPriority:
+            case LowPriority:
+            case IdlePriority:
+              break;
+            default:
+              priorityLevel = NormalPriority;
+          }
+          var previousPriorityLevel = currentPriorityLevel;
+          currentPriorityLevel = priorityLevel;
+          try {
+            return eventHandler();
+          } finally {
+            currentPriorityLevel = previousPriorityLevel;
+          }
+        }
+        function unstable_next(eventHandler) {
+          var priorityLevel;
+          switch (currentPriorityLevel) {
+            case ImmediatePriority:
+            case UserBlockingPriority:
+            case NormalPriority:
+              priorityLevel = NormalPriority;
+              break;
+            default:
+              priorityLevel = currentPriorityLevel;
+              break;
+          }
+          var previousPriorityLevel = currentPriorityLevel;
+          currentPriorityLevel = priorityLevel;
+          try {
+            return eventHandler();
+          } finally {
+            currentPriorityLevel = previousPriorityLevel;
+          }
+        }
+        function unstable_wrapCallback(callback) {
+          var parentPriorityLevel = currentPriorityLevel;
+          return function() {
+            var previousPriorityLevel = currentPriorityLevel;
+            currentPriorityLevel = parentPriorityLevel;
+            try {
+              return callback.apply(this, arguments);
+            } finally {
+              currentPriorityLevel = previousPriorityLevel;
+            }
+          };
+        }
+        function unstable_scheduleCallback(priorityLevel, callback, options) {
+          var currentTime = exports2.unstable_now();
+          var startTime2;
+          if (typeof options === "object" && options !== null) {
+            var delay = options.delay;
+            if (typeof delay === "number" && delay > 0) {
+              startTime2 = currentTime + delay;
+            } else {
+              startTime2 = currentTime;
+            }
+          } else {
+            startTime2 = currentTime;
+          }
+          var timeout;
+          switch (priorityLevel) {
+            case ImmediatePriority:
+              timeout = IMMEDIATE_PRIORITY_TIMEOUT;
+              break;
+            case UserBlockingPriority:
+              timeout = USER_BLOCKING_PRIORITY_TIMEOUT;
+              break;
+            case IdlePriority:
+              timeout = IDLE_PRIORITY_TIMEOUT;
+              break;
+            case LowPriority:
+              timeout = LOW_PRIORITY_TIMEOUT;
+              break;
+            case NormalPriority:
+            default:
+              timeout = NORMAL_PRIORITY_TIMEOUT;
+              break;
+          }
+          var expirationTime = startTime2 + timeout;
+          var newTask = {
+            id: taskIdCounter++,
+            callback,
+            priorityLevel,
+            startTime: startTime2,
+            expirationTime,
+            sortIndex: -1
+          };
+          if (startTime2 > currentTime) {
+            newTask.sortIndex = startTime2;
+            push2(timerQueue, newTask);
+            if (peek(taskQueue) === null && newTask === peek(timerQueue)) {
+              if (isHostTimeoutScheduled) {
+                cancelHostTimeout();
+              } else {
+                isHostTimeoutScheduled = true;
+              }
+              requestHostTimeout(handleTimeout, startTime2 - currentTime);
+            }
+          } else {
+            newTask.sortIndex = expirationTime;
+            push2(taskQueue, newTask);
+            if (!isHostCallbackScheduled && !isPerformingWork) {
+              isHostCallbackScheduled = true;
+              requestHostCallback(flushWork);
+            }
+          }
+          return newTask;
+        }
+        function unstable_pauseExecution() {
+        }
+        function unstable_continueExecution() {
+          if (!isHostCallbackScheduled && !isPerformingWork) {
+            isHostCallbackScheduled = true;
+            requestHostCallback(flushWork);
+          }
+        }
+        function unstable_getFirstCallbackNode() {
+          return peek(taskQueue);
+        }
+        function unstable_cancelCallback(task) {
+          task.callback = null;
+        }
+        function unstable_getCurrentPriorityLevel() {
+          return currentPriorityLevel;
+        }
+        var unstable_requestPaint = requestPaint;
+        var unstable_Profiling = null;
+        exports2.unstable_IdlePriority = IdlePriority;
+        exports2.unstable_ImmediatePriority = ImmediatePriority;
+        exports2.unstable_LowPriority = LowPriority;
+        exports2.unstable_NormalPriority = NormalPriority;
+        exports2.unstable_Profiling = unstable_Profiling;
+        exports2.unstable_UserBlockingPriority = UserBlockingPriority;
+        exports2.unstable_cancelCallback = unstable_cancelCallback;
+        exports2.unstable_continueExecution = unstable_continueExecution;
+        exports2.unstable_getCurrentPriorityLevel = unstable_getCurrentPriorityLevel;
+        exports2.unstable_getFirstCallbackNode = unstable_getFirstCallbackNode;
+        exports2.unstable_next = unstable_next;
+        exports2.unstable_pauseExecution = unstable_pauseExecution;
+        exports2.unstable_requestPaint = unstable_requestPaint;
+        exports2.unstable_runWithPriority = unstable_runWithPriority;
+        exports2.unstable_scheduleCallback = unstable_scheduleCallback;
+        exports2.unstable_wrapCallback = unstable_wrapCallback;
+      })();
+    }
+  });
+  var scheduler = createCommonjsModule(function(module2) {
+    if (process$1.env.NODE_ENV === "production") {
+      module2.exports = scheduler_production_min;
+    } else {
+      module2.exports = scheduler_development;
+    }
+  });
+  /** @license React v17.0.2
+   * react-dom-test-utils.production.min.js
+   *
+   * Copyright (c) Facebook, Inc. and its affiliates.
+   *
+   * This source code is licensed under the MIT license found in the
+   * LICENSE file in the root directory of this source tree.
+   */
+  var reactDomTestUtils_production_min$1 = createCommonjsModule(function(module2, exports2) {
+    function p2(a) {
+      for (var b2 = "https://reactjs.org/docs/error-decoder.html?invariant=" + a, c2 = 1; c2 < arguments.length; c2++) b2 += "&args[]=" + encodeURIComponent(arguments[c2]);
+      return "Minified React error #" + a + "; visit " + b2 + " for the full message or use the non-minified dev environment for full errors and additional helpful warnings.";
+    }
+    var q2 = l__default.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+    function r2(a) {
+      var b2 = a, c2 = a;
+      if (a.alternate) for (; b2.return; ) b2 = b2.return;
+      else {
+        a = b2;
+        do
+          b2 = a, 0 !== (b2.flags & 1026) && (c2 = b2.return), a = b2.return;
+        while (a);
+      }
+      return 3 === b2.tag ? c2 : null;
+    }
+    function t2(a) {
+      if (r2(a) !== a) throw Error(p2(188));
+    }
+    function aa2(a) {
+      var b2 = a.alternate;
+      if (!b2) {
+        b2 = r2(a);
+        if (null === b2) throw Error(p2(188));
+        return b2 !== a ? null : a;
+      }
+      for (var c2 = a, d2 = b2; ; ) {
+        var e2 = c2.return;
+        if (null === e2) break;
+        var g2 = e2.alternate;
+        if (null === g2) {
+          d2 = e2.return;
+          if (null !== d2) {
+            c2 = d2;
+            continue;
+          }
+          break;
+        }
+        if (e2.child === g2.child) {
+          for (g2 = e2.child; g2; ) {
+            if (g2 === c2) return t2(e2), a;
+            if (g2 === d2) return t2(e2), b2;
+            g2 = g2.sibling;
+          }
+          throw Error(p2(188));
+        }
+        if (c2.return !== d2.return) c2 = e2, d2 = g2;
+        else {
+          for (var f2 = false, k2 = e2.child; k2; ) {
+            if (k2 === c2) {
+              f2 = true;
+              c2 = e2;
+              d2 = g2;
+              break;
+            }
+            if (k2 === d2) {
+              f2 = true;
+              d2 = e2;
+              c2 = g2;
+              break;
+            }
+            k2 = k2.sibling;
+          }
+          if (!f2) {
+            for (k2 = g2.child; k2; ) {
+              if (k2 === c2) {
+                f2 = true;
+                c2 = g2;
+                d2 = e2;
+                break;
+              }
+              if (k2 === d2) {
+                f2 = true;
+                d2 = g2;
+                c2 = e2;
+                break;
+              }
+              k2 = k2.sibling;
+            }
+            if (!f2) throw Error(p2(189));
+          }
+        }
+        if (c2.alternate !== d2) throw Error(p2(190));
+      }
+      if (3 !== c2.tag) throw Error(p2(188));
+      return c2.stateNode.current === c2 ? a : b2;
+    }
+    function u2(a) {
+      var b2 = a.keyCode;
+      "charCode" in a ? (a = a.charCode, 0 === a && 13 === b2 && (a = 13)) : a = b2;
+      10 === a && (a = 13);
+      return 32 <= a || 13 === a ? a : 0;
+    }
+    function v2() {
+      return true;
+    }
+    function w2() {
+      return false;
+    }
+    function x2(a) {
+      function b2(c2, b3, e2, g2, f2) {
+        this._reactName = c2;
+        this._targetInst = e2;
+        this.type = b3;
+        this.nativeEvent = g2;
+        this.target = f2;
+        this.currentTarget = null;
+        for (var d2 in a) a.hasOwnProperty(d2) && (c2 = a[d2], this[d2] = c2 ? c2(g2) : g2[d2]);
+        this.isDefaultPrevented = (null != g2.defaultPrevented ? g2.defaultPrevented : false === g2.returnValue) ? v2 : w2;
+        this.isPropagationStopped = w2;
+        return this;
+      }
+      objectAssign(b2.prototype, { preventDefault: function() {
+        this.defaultPrevented = true;
+        var a2 = this.nativeEvent;
+        a2 && (a2.preventDefault ? a2.preventDefault() : "unknown" !== typeof a2.returnValue && (a2.returnValue = false), this.isDefaultPrevented = v2);
+      }, stopPropagation: function() {
+        var a2 = this.nativeEvent;
+        a2 && (a2.stopPropagation ? a2.stopPropagation() : "unknown" !== typeof a2.cancelBubble && (a2.cancelBubble = true), this.isPropagationStopped = v2);
+      }, persist: function() {
+      }, isPersistent: v2 });
+      return b2;
+    }
+    var y2 = { eventPhase: 0, bubbles: 0, cancelable: 0, timeStamp: function(a) {
+      return a.timeStamp || Date.now();
+    }, defaultPrevented: 0, isTrusted: 0 }, ba2 = x2(y2), z2 = objectAssign({}, y2, { view: 0, detail: 0 });
+    x2(z2);
+    var A2, B2, C2, E2 = objectAssign({}, z2, { screenX: 0, screenY: 0, clientX: 0, clientY: 0, pageX: 0, pageY: 0, ctrlKey: 0, shiftKey: 0, altKey: 0, metaKey: 0, getModifierState: D2, button: 0, buttons: 0, relatedTarget: function(a) {
+      return void 0 === a.relatedTarget ? a.fromElement === a.srcElement ? a.toElement : a.fromElement : a.relatedTarget;
+    }, movementX: function(a) {
+      if ("movementX" in a) return a.movementX;
+      a !== C2 && (C2 && "mousemove" === a.type ? (A2 = a.screenX - C2.screenX, B2 = a.screenY - C2.screenY) : B2 = A2 = 0, C2 = a);
+      return A2;
+    }, movementY: function(a) {
+      return "movementY" in a ? a.movementY : B2;
+    } });
+    x2(E2);
+    var da2 = objectAssign({}, E2, { dataTransfer: 0 });
+    x2(da2);
+    var ea2 = objectAssign({}, z2, { relatedTarget: 0 });
+    x2(ea2);
+    var fa2 = objectAssign({}, y2, { animationName: 0, elapsedTime: 0, pseudoElement: 0 });
+    x2(fa2);
+    var ha2 = objectAssign({}, y2, { clipboardData: function(a) {
+      return "clipboardData" in a ? a.clipboardData : window.clipboardData;
+    } });
+    x2(ha2);
+    var ia2 = objectAssign({}, y2, { data: 0 });
+    x2(ia2);
+    var ja2 = { Esc: "Escape", Spacebar: " ", Left: "ArrowLeft", Up: "ArrowUp", Right: "ArrowRight", Down: "ArrowDown", Del: "Delete", Win: "OS", Menu: "ContextMenu", Apps: "ContextMenu", Scroll: "ScrollLock", MozPrintableKey: "Unidentified" }, ka2 = {
+      8: "Backspace",
+      9: "Tab",
+      12: "Clear",
+      13: "Enter",
+      16: "Shift",
+      17: "Control",
+      18: "Alt",
+      19: "Pause",
+      20: "CapsLock",
+      27: "Escape",
+      32: " ",
+      33: "PageUp",
+      34: "PageDown",
+      35: "End",
+      36: "Home",
+      37: "ArrowLeft",
+      38: "ArrowUp",
+      39: "ArrowRight",
+      40: "ArrowDown",
+      45: "Insert",
+      46: "Delete",
+      112: "F1",
+      113: "F2",
+      114: "F3",
+      115: "F4",
+      116: "F5",
+      117: "F6",
+      118: "F7",
+      119: "F8",
+      120: "F9",
+      121: "F10",
+      122: "F11",
+      123: "F12",
+      144: "NumLock",
+      145: "ScrollLock",
+      224: "Meta"
+    }, la2 = { Alt: "altKey", Control: "ctrlKey", Meta: "metaKey", Shift: "shiftKey" };
+    function ma2(a) {
+      var b2 = this.nativeEvent;
+      return b2.getModifierState ? b2.getModifierState(a) : (a = la2[a]) ? !!b2[a] : false;
+    }
+    function D2() {
+      return ma2;
+    }
+    var na2 = objectAssign({}, z2, { key: function(a) {
+      if (a.key) {
+        var b2 = ja2[a.key] || a.key;
+        if ("Unidentified" !== b2) return b2;
+      }
+      return "keypress" === a.type ? (a = u2(a), 13 === a ? "Enter" : String.fromCharCode(a)) : "keydown" === a.type || "keyup" === a.type ? ka2[a.keyCode] || "Unidentified" : "";
+    }, code: 0, location: 0, ctrlKey: 0, shiftKey: 0, altKey: 0, metaKey: 0, repeat: 0, locale: 0, getModifierState: D2, charCode: function(a) {
+      return "keypress" === a.type ? u2(a) : 0;
+    }, keyCode: function(a) {
+      return "keydown" === a.type || "keyup" === a.type ? a.keyCode : 0;
+    }, which: function(a) {
+      return "keypress" === a.type ? u2(a) : "keydown" === a.type || "keyup" === a.type ? a.keyCode : 0;
+    } });
+    x2(na2);
+    var oa = objectAssign({}, E2, { pointerId: 0, width: 0, height: 0, pressure: 0, tangentialPressure: 0, tiltX: 0, tiltY: 0, twist: 0, pointerType: 0, isPrimary: 0 });
+    x2(oa);
+    var pa2 = objectAssign({}, z2, { touches: 0, targetTouches: 0, changedTouches: 0, altKey: 0, metaKey: 0, ctrlKey: 0, shiftKey: 0, getModifierState: D2 });
+    x2(pa2);
+    var qa2 = objectAssign({}, y2, { propertyName: 0, elapsedTime: 0, pseudoElement: 0 });
+    x2(qa2);
+    var ra2 = objectAssign({}, E2, { deltaX: function(a) {
+      return "deltaX" in a ? a.deltaX : "wheelDeltaX" in a ? -a.wheelDeltaX : 0;
+    }, deltaY: function(a) {
+      return "deltaY" in a ? a.deltaY : "wheelDeltaY" in a ? -a.wheelDeltaY : "wheelDelta" in a ? -a.wheelDelta : 0;
+    }, deltaZ: 0, deltaMode: 0 });
+    x2(ra2);
+    var F2 = null;
+    function G2(a) {
+      if (null === F2) try {
+        var b2 = ("require" + Math.random()).slice(0, 7);
+        F2 = (module2 && module2[b2]).call(module2, "timers").setImmediate;
+      } catch (c2) {
+        F2 = function(a2) {
+          var b3 = new MessageChannel();
+          b3.port1.onmessage = a2;
+          b3.port2.postMessage(void 0);
+        };
+      }
+      return F2(a);
+    }
+    var H2 = m$1$1.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events, sa2 = H2[5], I2 = H2[6], ta2 = m$1$1.unstable_batchedUpdates, J2 = q2.IsSomeRendererActing, K2 = "function" === typeof scheduler.unstable_flushAllWithoutAsserting, L2 = scheduler.unstable_flushAllWithoutAsserting || function() {
+      for (var a = false; sa2(); ) a = true;
+      return a;
+    };
+    function M2(a) {
+      try {
+        L2(), G2(function() {
+          L2() ? M2(a) : a();
+        });
+      } catch (b2) {
+        a(b2);
+      }
+    }
+    var N = 0, ua2 = false, O2 = m$1$1.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events[6], va2 = m$1$1.unstable_batchedUpdates, Q2 = q2.IsSomeRendererActing;
+    function wa2(a, b2) {
+      jest.runOnlyPendingTimers();
+      G2(function() {
+        try {
+          scheduler.unstable_flushAllWithoutAsserting() ? wa2(a, b2) : a();
+        } catch (c2) {
+          b2(c2);
+        }
+      });
+    }
+    function xa2(a, b2, c2, d2, e2, g2, f2, k2, ca2) {
+      var P2 = Array.prototype.slice.call(arguments, 3);
+      try {
+        b2.apply(c2, P2);
+      } catch (Ga) {
+        this.onError(Ga);
+      }
+    }
+    var R2 = false, S2 = null, T2 = false, U2 = null, ya2 = { onError: function(a) {
+      R2 = true;
+      S2 = a;
+    } };
+    function za2(a, b2, c2, d2, e2, g2, f2, k2, ca2) {
+      R2 = false;
+      S2 = null;
+      xa2.apply(ya2, arguments);
+    }
+    function Aa2(a, b2, c2, d2, e2, g2, f2, k2, ca2) {
+      za2.apply(this, arguments);
+      if (R2) {
+        if (R2) {
+          var P2 = S2;
+          R2 = false;
+          S2 = null;
+        } else throw Error(p2(198));
+        T2 || (T2 = true, U2 = P2);
+      }
+    }
+    var V2 = m$1$1.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events, Ba2 = V2[0], Ca2 = V2[1], Da2 = V2[2], Ea = V2[3], Fa = V2[4];
+    function Ha() {
+    }
+    function Ia(a, b2) {
+      if (!a) return [];
+      a = aa2(a);
+      if (!a) return [];
+      for (var c2 = a, d2 = []; ; ) {
+        if (5 === c2.tag || 6 === c2.tag || 1 === c2.tag || 0 === c2.tag) {
+          var e2 = c2.stateNode;
+          b2(e2) && d2.push(e2);
+        }
+        if (c2.child) c2.child.return = c2, c2 = c2.child;
+        else {
+          if (c2 === a) return d2;
+          for (; !c2.sibling; ) {
+            if (!c2.return || c2.return === a) return d2;
+            c2 = c2.return;
+          }
+          c2.sibling.return = c2.return;
+          c2 = c2.sibling;
+        }
+      }
+    }
+    function W2(a, b2) {
+      if (a && !a._reactInternals) {
+        var c2 = "" + a;
+        a = Array.isArray(a) ? "an array" : a && 1 === a.nodeType && a.tagName ? "a DOM node" : "[object Object]" === c2 ? "object with keys {" + Object.keys(a).join(", ") + "}" : c2;
+        throw Error(p2(286, b2, a));
+      }
+    }
+    function X2(a) {
+      return !(!a || 1 !== a.nodeType || !a.tagName);
+    }
+    function Y2(a) {
+      return X2(a) ? false : null != a && "function" === typeof a.render && "function" === typeof a.setState;
+    }
+    function Ja(a, b2) {
+      return Y2(a) ? a._reactInternals.type === b2 : false;
+    }
+    function Z2(a, b2) {
+      W2(a, "findAllInRenderedTree");
+      return a ? Ia(a._reactInternals, b2) : [];
+    }
+    function Ka(a, b2) {
+      W2(a, "scryRenderedDOMComponentsWithClass");
+      return Z2(a, function(a2) {
+        if (X2(a2)) {
+          var c2 = a2.className;
+          "string" !== typeof c2 && (c2 = a2.getAttribute("class") || "");
+          var e2 = c2.split(/\s+/);
+          if (!Array.isArray(b2)) {
+            if (void 0 === b2) throw Error(p2(11));
+            b2 = b2.split(/\s+/);
+          }
+          return b2.every(function(a3) {
+            return -1 !== e2.indexOf(a3);
+          });
+        }
+        return false;
+      });
+    }
+    function La(a, b2) {
+      W2(a, "scryRenderedDOMComponentsWithTag");
+      return Z2(a, function(a2) {
+        return X2(a2) && a2.tagName.toUpperCase() === b2.toUpperCase();
+      });
+    }
+    function Ma(a, b2) {
+      W2(a, "scryRenderedComponentsWithType");
+      return Z2(a, function(a2) {
+        return Ja(a2, b2);
+      });
+    }
+    function Na(a, b2, c2) {
+      var d2 = a.type || "unknown-event";
+      a.currentTarget = Ca2(c2);
+      Aa2(d2, b2, void 0, a);
+      a.currentTarget = null;
+    }
+    function Oa(a, b2, c2) {
+      for (var d2 = []; a; ) {
+        d2.push(a);
+        do
+          a = a.return;
+        while (a && 5 !== a.tag);
+        a = a ? a : null;
+      }
+      for (a = d2.length; 0 < a--; ) b2(d2[a], "captured", c2);
+      for (a = 0; a < d2.length; a++) b2(d2[a], "bubbled", c2);
+    }
+    function Pa(a, b2) {
+      var c2 = a.stateNode;
+      if (!c2) return null;
+      var d2 = Da2(c2);
+      if (!d2) return null;
+      c2 = d2[b2];
+      a: switch (b2) {
+        case "onClick":
+        case "onClickCapture":
+        case "onDoubleClick":
+        case "onDoubleClickCapture":
+        case "onMouseDown":
+        case "onMouseDownCapture":
+        case "onMouseMove":
+        case "onMouseMoveCapture":
+        case "onMouseUp":
+        case "onMouseUpCapture":
+        case "onMouseEnter":
+          (d2 = !d2.disabled) || (a = a.type, d2 = !("button" === a || "input" === a || "select" === a || "textarea" === a));
+          a = !d2;
+          break a;
+        default:
+          a = false;
+      }
+      if (a) return null;
+      if (c2 && "function" !== typeof c2) throw Error(p2(
+        231,
+        b2,
+        typeof c2
+      ));
+      return c2;
+    }
+    function Qa(a, b2, c2) {
+      a && c2 && c2._reactName && (b2 = Pa(a, c2._reactName)) && (null == c2._dispatchListeners && (c2._dispatchListeners = []), null == c2._dispatchInstances && (c2._dispatchInstances = []), c2._dispatchListeners.push(b2), c2._dispatchInstances.push(a));
+    }
+    function Ra(a, b2, c2) {
+      var d2 = c2._reactName;
+      "captured" === b2 && (d2 += "Capture");
+      if (b2 = Pa(a, d2)) null == c2._dispatchListeners && (c2._dispatchListeners = []), null == c2._dispatchInstances && (c2._dispatchInstances = []), c2._dispatchListeners.push(b2), c2._dispatchInstances.push(a);
+    }
+    var Sa = {}, Ta = /* @__PURE__ */ new Set(["mouseEnter", "mouseLeave", "pointerEnter", "pointerLeave"]);
+    function Ua(a) {
+      return function(b2, c2) {
+        if (l__default.isValidElement(b2)) throw Error(p2(228));
+        if (Y2(b2)) throw Error(p2(229));
+        var d2 = "on" + a[0].toUpperCase() + a.slice(1), e2 = new Ha();
+        e2.target = b2;
+        e2.type = a.toLowerCase();
+        var g2 = Ba2(b2), f2 = new ba2(d2, e2.type, g2, e2, b2);
+        f2.persist();
+        objectAssign(f2, c2);
+        Ta.has(a) ? f2 && f2._reactName && Qa(f2._targetInst, null, f2) : f2 && f2._reactName && Oa(f2._targetInst, Ra, f2);
+        m$1$1.unstable_batchedUpdates(function() {
+          Ea(b2);
+          if (f2) {
+            var a2 = f2._dispatchListeners, c3 = f2._dispatchInstances;
+            if (Array.isArray(a2)) for (var d3 = 0; d3 < a2.length && !f2.isPropagationStopped(); d3++) Na(
+              f2,
+              a2[d3],
+              c3[d3]
+            );
+            else a2 && Na(f2, a2, c3);
+            f2._dispatchListeners = null;
+            f2._dispatchInstances = null;
+            f2.isPersistent() || f2.constructor.release(f2);
+          }
+          if (T2) throw a2 = U2, T2 = false, U2 = null, a2;
+        });
+        Fa();
+      };
+    }
+    "blur cancel click close contextMenu copy cut auxClick doubleClick dragEnd dragStart drop focus input invalid keyDown keyPress keyUp mouseDown mouseUp paste pause play pointerCancel pointerDown pointerUp rateChange reset seeked submit touchCancel touchEnd touchStart volumeChange drag dragEnter dragExit dragLeave dragOver mouseMove mouseOut mouseOver pointerMove pointerOut pointerOver scroll toggle touchMove wheel abort animationEnd animationIteration animationStart canPlay canPlayThrough durationChange emptied encrypted ended error gotPointerCapture load loadedData loadedMetadata loadStart lostPointerCapture playing progress seeking stalled suspend timeUpdate transitionEnd waiting mouseEnter mouseLeave pointerEnter pointerLeave change select beforeInput compositionEnd compositionStart compositionUpdate".split(" ").forEach(function(a) {
+      Sa[a] = Ua(a);
+    });
+    exports2.Simulate = Sa;
+    exports2.act = function(a) {
+      function b2() {
+        N--;
+        J2.current = c2;
+        I2.current = d2;
+      }
+      false === ua2 && (ua2 = true, console.error("act(...) is not supported in production builds of React, and might not behave as expected."));
+      N++;
+      var c2 = J2.current, d2 = I2.current;
+      J2.current = true;
+      I2.current = true;
+      try {
+        var e2 = ta2(a);
+      } catch (g2) {
+        throw b2(), g2;
+      }
+      if (null !== e2 && "object" === typeof e2 && "function" === typeof e2.then) return { then: function(a2, d3) {
+        e2.then(function() {
+          1 < N || true === K2 && true === c2 ? (b2(), a2()) : M2(function(c3) {
+            b2();
+            c3 ? d3(c3) : a2();
+          });
+        }, function(a3) {
+          b2();
+          d3(a3);
+        });
+      } };
+      try {
+        1 !== N || false !== K2 && false !== c2 || L2(), b2();
+      } catch (g2) {
+        throw b2(), g2;
+      }
+      return { then: function(a2) {
+        a2();
+      } };
+    };
+    exports2.findAllInRenderedTree = Z2;
+    exports2.findRenderedComponentWithType = function(a, b2) {
+      W2(a, "findRenderedComponentWithType");
+      a = Ma(a, b2);
+      if (1 !== a.length) throw Error("Did not find exactly one match (found: " + a.length + ") for componentType:" + b2);
+      return a[0];
+    };
+    exports2.findRenderedDOMComponentWithClass = function(a, b2) {
+      W2(a, "findRenderedDOMComponentWithClass");
+      a = Ka(a, b2);
+      if (1 !== a.length) throw Error("Did not find exactly one match (found: " + a.length + ") for class:" + b2);
+      return a[0];
+    };
+    exports2.findRenderedDOMComponentWithTag = function(a, b2) {
+      W2(a, "findRenderedDOMComponentWithTag");
+      a = La(a, b2);
+      if (1 !== a.length) throw Error("Did not find exactly one match (found: " + a.length + ") for tag:" + b2);
+      return a[0];
+    };
+    exports2.isCompositeComponent = Y2;
+    exports2.isCompositeComponentWithType = Ja;
+    exports2.isDOMComponent = X2;
+    exports2.isDOMComponentElement = function(a) {
+      return !!(a && l__default.isValidElement(a) && a.tagName);
+    };
+    exports2.isElement = function(a) {
+      return l__default.isValidElement(a);
+    };
+    exports2.isElementOfType = function(a, b2) {
+      return l__default.isValidElement(a) && a.type === b2;
+    };
+    exports2.mockComponent = function(a, b2) {
+      b2 = b2 || a.mockTagName || "div";
+      a.prototype.render.mockImplementation(function() {
+        return l__default.createElement(b2, null, this.props.children);
+      });
+      return this;
+    };
+    exports2.nativeTouchData = function(a, b2) {
+      return { touches: [{ pageX: a, pageY: b2 }] };
+    };
+    exports2.renderIntoDocument = function(a) {
+      var b2 = document.createElement("div");
+      return m$1$1.render(a, b2);
+    };
+    exports2.scryRenderedComponentsWithType = Ma;
+    exports2.scryRenderedDOMComponentsWithClass = Ka;
+    exports2.scryRenderedDOMComponentsWithTag = La;
+    exports2.traverseTwoPhase = Oa;
+    exports2.unstable_concurrentAct = function(a) {
+      function b2() {
+        Q2.current = c2;
+        O2.current = d2;
+      }
+      if (void 0 === scheduler.unstable_flushAllWithoutAsserting) throw Error("This version of `act` requires a special mock build of Scheduler.");
+      if (true !== setTimeout._isMockFunction) throw Error("This version of `act` requires Jest's timer mocks (i.e. jest.useFakeTimers).");
+      var c2 = Q2.current, d2 = O2.current;
+      Q2.current = true;
+      O2.current = true;
+      try {
+        var e2 = va2(a);
+        if ("object" === typeof e2 && null !== e2 && "function" === typeof e2.then) return { then: function(a2, c3) {
+          e2.then(function() {
+            wa2(function() {
+              b2();
+              a2();
+            }, function(a3) {
+              b2();
+              c3(a3);
+            });
+          }, function(a3) {
+            b2();
+            c3(a3);
+          });
+        } };
+        try {
+          do
+            var g2 = scheduler.unstable_flushAllWithoutAsserting();
+          while (g2);
+        } finally {
+          b2();
+        }
+      } catch (f2) {
+        throw b2(), f2;
+      }
+    };
+  });
+  var reactDomTestUtils_development = createCommonjsModule(function(module2, exports2) {
+    if (process$1.env.NODE_ENV !== "production") {
+      (function() {
+        var _assign = objectAssign;
+        var React = l__default;
+        var ReactDOM = m$1$1;
+        var Scheduler = scheduler;
+        var ReactSharedInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+        function warn(format2) {
+          {
+            for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+              args[_key - 1] = arguments[_key];
+            }
+            printWarning("warn", format2, args);
+          }
+        }
+        function error(format2) {
+          {
+            for (var _len2 = arguments.length, args = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
+              args[_key2 - 1] = arguments[_key2];
+            }
+            printWarning("error", format2, args);
+          }
+        }
+        function printWarning(level, format2, args) {
+          {
+            var ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
+            var stack = ReactDebugCurrentFrame.getStackAddendum();
+            if (stack !== "") {
+              format2 += "%s";
+              args = args.concat([stack]);
+            }
+            var argsWithFormat = args.map(function(item) {
+              return "" + item;
+            });
+            argsWithFormat.unshift("Warning: " + format2);
+            Function.prototype.apply.call(console[level], console, argsWithFormat);
+          }
+        }
+        function get2(key2) {
+          return key2._reactInternals;
+        }
+        if (typeof Symbol === "function" && Symbol.for) {
+          var symbolFor = Symbol.for;
+          symbolFor("react.element");
+          symbolFor("react.portal");
+          symbolFor("react.fragment");
+          symbolFor("react.strict_mode");
+          symbolFor("react.profiler");
+          symbolFor("react.provider");
+          symbolFor("react.context");
+          symbolFor("react.forward_ref");
+          symbolFor("react.suspense");
+          symbolFor("react.suspense_list");
+          symbolFor("react.memo");
+          symbolFor("react.lazy");
+          symbolFor("react.block");
+          symbolFor("react.server.block");
+          symbolFor("react.fundamental");
+          symbolFor("react.scope");
+          symbolFor("react.opaque.id");
+          symbolFor("react.debug_trace_mode");
+          symbolFor("react.offscreen");
+          symbolFor("react.legacy_hidden");
+        }
+        var FunctionComponent = 0;
+        var ClassComponent = 1;
+        var HostRoot = 3;
+        var HostComponent = 5;
+        var HostText = 6;
+        var NoFlags = (
+          /*                      */
+          0
+        );
+        var Placement = (
+          /*                    */
+          2
+        );
+        var Hydrating = (
+          /*                    */
+          1024
+        );
+        ReactSharedInternals.ReactCurrentOwner;
+        function getNearestMountedFiber(fiber) {
+          var node = fiber;
+          var nearestMounted = fiber;
+          if (!fiber.alternate) {
+            var nextNode = node;
+            do {
+              node = nextNode;
+              if ((node.flags & (Placement | Hydrating)) !== NoFlags) {
+                nearestMounted = node.return;
+              }
+              nextNode = node.return;
+            } while (nextNode);
+          } else {
+            while (node.return) {
+              node = node.return;
+            }
+          }
+          if (node.tag === HostRoot) {
+            return nearestMounted;
+          }
+          return null;
+        }
+        function assertIsMounted(fiber) {
+          if (!(getNearestMountedFiber(fiber) === fiber)) {
+            {
+              throw Error("Unable to find node on an unmounted component.");
+            }
+          }
+        }
+        function findCurrentFiberUsingSlowPath(fiber) {
+          var alternate = fiber.alternate;
+          if (!alternate) {
+            var nearestMounted = getNearestMountedFiber(fiber);
+            if (!(nearestMounted !== null)) {
+              {
+                throw Error("Unable to find node on an unmounted component.");
+              }
+            }
+            if (nearestMounted !== fiber) {
+              return null;
+            }
+            return fiber;
+          }
+          var a = fiber;
+          var b2 = alternate;
+          while (true) {
+            var parentA = a.return;
+            if (parentA === null) {
+              break;
+            }
+            var parentB = parentA.alternate;
+            if (parentB === null) {
+              var nextParent = parentA.return;
+              if (nextParent !== null) {
+                a = b2 = nextParent;
+                continue;
+              }
+              break;
+            }
+            if (parentA.child === parentB.child) {
+              var child = parentA.child;
+              while (child) {
+                if (child === a) {
+                  assertIsMounted(parentA);
+                  return fiber;
+                }
+                if (child === b2) {
+                  assertIsMounted(parentA);
+                  return alternate;
+                }
+                child = child.sibling;
+              }
+              {
+                {
+                  throw Error("Unable to find node on an unmounted component.");
+                }
+              }
+            }
+            if (a.return !== b2.return) {
+              a = parentA;
+              b2 = parentB;
+            } else {
+              var didFindChild = false;
+              var _child = parentA.child;
+              while (_child) {
+                if (_child === a) {
+                  didFindChild = true;
+                  a = parentA;
+                  b2 = parentB;
+                  break;
+                }
+                if (_child === b2) {
+                  didFindChild = true;
+                  b2 = parentA;
+                  a = parentB;
+                  break;
+                }
+                _child = _child.sibling;
+              }
+              if (!didFindChild) {
+                _child = parentB.child;
+                while (_child) {
+                  if (_child === a) {
+                    didFindChild = true;
+                    a = parentB;
+                    b2 = parentA;
+                    break;
+                  }
+                  if (_child === b2) {
+                    didFindChild = true;
+                    b2 = parentB;
+                    a = parentA;
+                    break;
+                  }
+                  _child = _child.sibling;
+                }
+                if (!didFindChild) {
+                  {
+                    throw Error("Child was not found in either parent set. This indicates a bug in React related to the return pointer. Please file an issue.");
+                  }
+                }
+              }
+            }
+            if (!(a.alternate === b2)) {
+              {
+                throw Error("Return fibers should always be each others' alternates. This error is likely caused by a bug in React. Please file an issue.");
+              }
+            }
+          }
+          if (!(a.tag === HostRoot)) {
+            {
+              throw Error("Unable to find node on an unmounted component.");
+            }
+          }
+          if (a.stateNode.current === a) {
+            return fiber;
+          }
+          return alternate;
+        }
+        function getEventCharCode(nativeEvent) {
+          var charCode;
+          var keyCode = nativeEvent.keyCode;
+          if ("charCode" in nativeEvent) {
+            charCode = nativeEvent.charCode;
+            if (charCode === 0 && keyCode === 13) {
+              charCode = 13;
+            }
+          } else {
+            charCode = keyCode;
+          }
+          if (charCode === 10) {
+            charCode = 13;
+          }
+          if (charCode >= 32 || charCode === 13) {
+            return charCode;
+          }
+          return 0;
+        }
+        function functionThatReturnsTrue() {
+          return true;
+        }
+        function functionThatReturnsFalse() {
+          return false;
+        }
+        function createSyntheticEvent(Interface) {
+          function SyntheticBaseEvent(reactName, reactEventType, targetInst, nativeEvent, nativeEventTarget) {
+            this._reactName = reactName;
+            this._targetInst = targetInst;
+            this.type = reactEventType;
+            this.nativeEvent = nativeEvent;
+            this.target = nativeEventTarget;
+            this.currentTarget = null;
+            for (var _propName in Interface) {
+              if (!Interface.hasOwnProperty(_propName)) {
+                continue;
+              }
+              var normalize2 = Interface[_propName];
+              if (normalize2) {
+                this[_propName] = normalize2(nativeEvent);
+              } else {
+                this[_propName] = nativeEvent[_propName];
+              }
+            }
+            var defaultPrevented = nativeEvent.defaultPrevented != null ? nativeEvent.defaultPrevented : nativeEvent.returnValue === false;
+            if (defaultPrevented) {
+              this.isDefaultPrevented = functionThatReturnsTrue;
+            } else {
+              this.isDefaultPrevented = functionThatReturnsFalse;
+            }
+            this.isPropagationStopped = functionThatReturnsFalse;
+            return this;
+          }
+          _assign(SyntheticBaseEvent.prototype, {
+            preventDefault: function() {
+              this.defaultPrevented = true;
+              var event = this.nativeEvent;
+              if (!event) {
+                return;
+              }
+              if (event.preventDefault) {
+                event.preventDefault();
+              } else if (typeof event.returnValue !== "unknown") {
+                event.returnValue = false;
+              }
+              this.isDefaultPrevented = functionThatReturnsTrue;
+            },
+            stopPropagation: function() {
+              var event = this.nativeEvent;
+              if (!event) {
+                return;
+              }
+              if (event.stopPropagation) {
+                event.stopPropagation();
+              } else if (typeof event.cancelBubble !== "unknown") {
+                event.cancelBubble = true;
+              }
+              this.isPropagationStopped = functionThatReturnsTrue;
+            },
+            /**
+             * We release all dispatched `SyntheticEvent`s after each event loop, adding
+             * them back into the pool. This allows a way to hold onto a reference that
+             * won't be added back into the pool.
+             */
+            persist: function() {
+            },
+            /**
+             * Checks if this event should be released back into the pool.
+             *
+             * @return {boolean} True if this should not be released, false otherwise.
+             */
+            isPersistent: functionThatReturnsTrue
+          });
+          return SyntheticBaseEvent;
+        }
+        var EventInterface = {
+          eventPhase: 0,
+          bubbles: 0,
+          cancelable: 0,
+          timeStamp: function(event) {
+            return event.timeStamp || Date.now();
+          },
+          defaultPrevented: 0,
+          isTrusted: 0
+        };
+        var SyntheticEvent = createSyntheticEvent(EventInterface);
+        var UIEventInterface = _assign({}, EventInterface, {
+          view: 0,
+          detail: 0
+        });
+        createSyntheticEvent(UIEventInterface);
+        var lastMovementX;
+        var lastMovementY;
+        var lastMouseEvent;
+        function updateMouseMovementPolyfillState(event) {
+          if (event !== lastMouseEvent) {
+            if (lastMouseEvent && event.type === "mousemove") {
+              lastMovementX = event.screenX - lastMouseEvent.screenX;
+              lastMovementY = event.screenY - lastMouseEvent.screenY;
+            } else {
+              lastMovementX = 0;
+              lastMovementY = 0;
+            }
+            lastMouseEvent = event;
+          }
+        }
+        var MouseEventInterface = _assign({}, UIEventInterface, {
+          screenX: 0,
+          screenY: 0,
+          clientX: 0,
+          clientY: 0,
+          pageX: 0,
+          pageY: 0,
+          ctrlKey: 0,
+          shiftKey: 0,
+          altKey: 0,
+          metaKey: 0,
+          getModifierState: getEventModifierState,
+          button: 0,
+          buttons: 0,
+          relatedTarget: function(event) {
+            if (event.relatedTarget === void 0) return event.fromElement === event.srcElement ? event.toElement : event.fromElement;
+            return event.relatedTarget;
+          },
+          movementX: function(event) {
+            if ("movementX" in event) {
+              return event.movementX;
+            }
+            updateMouseMovementPolyfillState(event);
+            return lastMovementX;
+          },
+          movementY: function(event) {
+            if ("movementY" in event) {
+              return event.movementY;
+            }
+            return lastMovementY;
+          }
+        });
+        createSyntheticEvent(MouseEventInterface);
+        var DragEventInterface = _assign({}, MouseEventInterface, {
+          dataTransfer: 0
+        });
+        createSyntheticEvent(DragEventInterface);
+        var FocusEventInterface = _assign({}, UIEventInterface, {
+          relatedTarget: 0
+        });
+        createSyntheticEvent(FocusEventInterface);
+        var AnimationEventInterface = _assign({}, EventInterface, {
+          animationName: 0,
+          elapsedTime: 0,
+          pseudoElement: 0
+        });
+        createSyntheticEvent(AnimationEventInterface);
+        var ClipboardEventInterface = _assign({}, EventInterface, {
+          clipboardData: function(event) {
+            return "clipboardData" in event ? event.clipboardData : window.clipboardData;
+          }
+        });
+        createSyntheticEvent(ClipboardEventInterface);
+        var CompositionEventInterface = _assign({}, EventInterface, {
+          data: 0
+        });
+        createSyntheticEvent(CompositionEventInterface);
+        var normalizeKey = {
+          Esc: "Escape",
+          Spacebar: " ",
+          Left: "ArrowLeft",
+          Up: "ArrowUp",
+          Right: "ArrowRight",
+          Down: "ArrowDown",
+          Del: "Delete",
+          Win: "OS",
+          Menu: "ContextMenu",
+          Apps: "ContextMenu",
+          Scroll: "ScrollLock",
+          MozPrintableKey: "Unidentified"
+        };
+        var translateToKey = {
+          "8": "Backspace",
+          "9": "Tab",
+          "12": "Clear",
+          "13": "Enter",
+          "16": "Shift",
+          "17": "Control",
+          "18": "Alt",
+          "19": "Pause",
+          "20": "CapsLock",
+          "27": "Escape",
+          "32": " ",
+          "33": "PageUp",
+          "34": "PageDown",
+          "35": "End",
+          "36": "Home",
+          "37": "ArrowLeft",
+          "38": "ArrowUp",
+          "39": "ArrowRight",
+          "40": "ArrowDown",
+          "45": "Insert",
+          "46": "Delete",
+          "112": "F1",
+          "113": "F2",
+          "114": "F3",
+          "115": "F4",
+          "116": "F5",
+          "117": "F6",
+          "118": "F7",
+          "119": "F8",
+          "120": "F9",
+          "121": "F10",
+          "122": "F11",
+          "123": "F12",
+          "144": "NumLock",
+          "145": "ScrollLock",
+          "224": "Meta"
+        };
+        function getEventKey(nativeEvent) {
+          if (nativeEvent.key) {
+            var key2 = normalizeKey[nativeEvent.key] || nativeEvent.key;
+            if (key2 !== "Unidentified") {
+              return key2;
+            }
+          }
+          if (nativeEvent.type === "keypress") {
+            var charCode = getEventCharCode(nativeEvent);
+            return charCode === 13 ? "Enter" : String.fromCharCode(charCode);
+          }
+          if (nativeEvent.type === "keydown" || nativeEvent.type === "keyup") {
+            return translateToKey[nativeEvent.keyCode] || "Unidentified";
+          }
+          return "";
+        }
+        var modifierKeyToProp = {
+          Alt: "altKey",
+          Control: "ctrlKey",
+          Meta: "metaKey",
+          Shift: "shiftKey"
+        };
+        function modifierStateGetter(keyArg) {
+          var syntheticEvent = this;
+          var nativeEvent = syntheticEvent.nativeEvent;
+          if (nativeEvent.getModifierState) {
+            return nativeEvent.getModifierState(keyArg);
+          }
+          var keyProp = modifierKeyToProp[keyArg];
+          return keyProp ? !!nativeEvent[keyProp] : false;
+        }
+        function getEventModifierState(nativeEvent) {
+          return modifierStateGetter;
+        }
+        var KeyboardEventInterface = _assign({}, UIEventInterface, {
+          key: getEventKey,
+          code: 0,
+          location: 0,
+          ctrlKey: 0,
+          shiftKey: 0,
+          altKey: 0,
+          metaKey: 0,
+          repeat: 0,
+          locale: 0,
+          getModifierState: getEventModifierState,
+          // Legacy Interface
+          charCode: function(event) {
+            if (event.type === "keypress") {
+              return getEventCharCode(event);
+            }
+            return 0;
+          },
+          keyCode: function(event) {
+            if (event.type === "keydown" || event.type === "keyup") {
+              return event.keyCode;
+            }
+            return 0;
+          },
+          which: function(event) {
+            if (event.type === "keypress") {
+              return getEventCharCode(event);
+            }
+            if (event.type === "keydown" || event.type === "keyup") {
+              return event.keyCode;
+            }
+            return 0;
+          }
+        });
+        createSyntheticEvent(KeyboardEventInterface);
+        var PointerEventInterface = _assign({}, MouseEventInterface, {
+          pointerId: 0,
+          width: 0,
+          height: 0,
+          pressure: 0,
+          tangentialPressure: 0,
+          tiltX: 0,
+          tiltY: 0,
+          twist: 0,
+          pointerType: 0,
+          isPrimary: 0
+        });
+        createSyntheticEvent(PointerEventInterface);
+        var TouchEventInterface = _assign({}, UIEventInterface, {
+          touches: 0,
+          targetTouches: 0,
+          changedTouches: 0,
+          altKey: 0,
+          metaKey: 0,
+          ctrlKey: 0,
+          shiftKey: 0,
+          getModifierState: getEventModifierState
+        });
+        createSyntheticEvent(TouchEventInterface);
+        var TransitionEventInterface = _assign({}, EventInterface, {
+          propertyName: 0,
+          elapsedTime: 0,
+          pseudoElement: 0
+        });
+        createSyntheticEvent(TransitionEventInterface);
+        var WheelEventInterface = _assign({}, MouseEventInterface, {
+          deltaX: function(event) {
+            return "deltaX" in event ? event.deltaX : (
+              // Fallback to `wheelDeltaX` for Webkit and normalize (right is positive).
+              "wheelDeltaX" in event ? -event.wheelDeltaX : 0
+            );
+          },
+          deltaY: function(event) {
+            return "deltaY" in event ? event.deltaY : (
+              // Fallback to `wheelDeltaY` for Webkit and normalize (down is positive).
+              "wheelDeltaY" in event ? -event.wheelDeltaY : (
+                // Fallback to `wheelDelta` for IE<9 and normalize (down is positive).
+                "wheelDelta" in event ? -event.wheelDelta : 0
+              )
+            );
+          },
+          deltaZ: 0,
+          // Browsers without "deltaMode" is reporting in raw wheel delta where one
+          // notch on the scroll is always +/- 120, roughly equivalent to pixels.
+          // A good approximation of DOM_DELTA_LINE (1) is 5% of viewport size or
+          // ~40 pixels, for DOM_DELTA_SCREEN (2) it is 87.5% of viewport size.
+          deltaMode: 0
+        });
+        createSyntheticEvent(WheelEventInterface);
+        var ELEMENT_NODE2 = 1;
+        var didWarnAboutMessageChannel = false;
+        var enqueueTaskImpl = null;
+        function enqueueTask(task) {
+          if (enqueueTaskImpl === null) {
+            try {
+              var requireString = ("require" + Math.random()).slice(0, 7);
+              var nodeRequire2 = module2 && module2[requireString];
+              enqueueTaskImpl = nodeRequire2.call(module2, "timers").setImmediate;
+            } catch (_err) {
+              enqueueTaskImpl = function(callback) {
+                {
+                  if (didWarnAboutMessageChannel === false) {
+                    didWarnAboutMessageChannel = true;
+                    if (typeof MessageChannel === "undefined") {
+                      error("This browser does not have a MessageChannel implementation, so enqueuing tasks via await act(async () => ...) will fail. Please file an issue at https://github.com/facebook/react/issues if you encounter this warning.");
+                    }
+                  }
+                }
+                var channel2 = new MessageChannel();
+                channel2.port1.onmessage = callback;
+                channel2.port2.postMessage(void 0);
+              };
+            }
+          }
+          return enqueueTaskImpl(task);
+        }
+        var EventInternals = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
+        var flushPassiveEffects = EventInternals[5];
+        var IsThisRendererActing = EventInternals[6];
+        var batchedUpdates = ReactDOM.unstable_batchedUpdates;
+        var IsSomeRendererActing = ReactSharedInternals.IsSomeRendererActing;
+        var isSchedulerMocked = typeof Scheduler.unstable_flushAllWithoutAsserting === "function";
+        var flushWork = Scheduler.unstable_flushAllWithoutAsserting || function() {
+          var didFlushWork = false;
+          while (flushPassiveEffects()) {
+            didFlushWork = true;
+          }
+          return didFlushWork;
+        };
+        function flushWorkAndMicroTasks(onDone) {
+          try {
+            flushWork();
+            enqueueTask(function() {
+              if (flushWork()) {
+                flushWorkAndMicroTasks(onDone);
+              } else {
+                onDone();
+              }
+            });
+          } catch (err) {
+            onDone(err);
+          }
+        }
+        var actingUpdatesScopeDepth = 0;
+        function act2(callback) {
+          var previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
+          actingUpdatesScopeDepth++;
+          var previousIsSomeRendererActing = IsSomeRendererActing.current;
+          var previousIsThisRendererActing = IsThisRendererActing.current;
+          IsSomeRendererActing.current = true;
+          IsThisRendererActing.current = true;
+          function onDone() {
+            actingUpdatesScopeDepth--;
+            IsSomeRendererActing.current = previousIsSomeRendererActing;
+            IsThisRendererActing.current = previousIsThisRendererActing;
+            {
+              if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
+                error("You seem to have overlapping act() calls, this is not supported. Be sure to await previous act() calls before making a new one. ");
+              }
+            }
+          }
+          var result;
+          try {
+            result = batchedUpdates(callback);
+          } catch (error2) {
+            onDone();
+            throw error2;
+          }
+          if (result !== null && typeof result === "object" && typeof result.then === "function") {
+            var called2 = false;
+            {
+              if (typeof Promise !== "undefined") {
+                Promise.resolve().then(function() {
+                }).then(function() {
+                  if (called2 === false) {
+                    error("You called act(async () => ...) without await. This could lead to unexpected testing behaviour, interleaving multiple act calls and mixing their scopes. You should - await act(async () => ...);");
+                  }
+                });
+              }
+            }
+            return {
+              then: function(resolve, reject) {
+                called2 = true;
+                result.then(function() {
+                  if (actingUpdatesScopeDepth > 1 || isSchedulerMocked === true && previousIsSomeRendererActing === true) {
+                    onDone();
+                    resolve();
+                    return;
+                  }
+                  flushWorkAndMicroTasks(function(err) {
+                    onDone();
+                    if (err) {
+                      reject(err);
+                    } else {
+                      resolve();
+                    }
+                  });
+                }, function(err) {
+                  onDone();
+                  reject(err);
+                });
+              }
+            };
+          } else {
+            {
+              if (result !== void 0) {
+                error("The callback passed to act(...) function must return undefined, or a Promise. You returned %s", result);
+              }
+            }
+            try {
+              if (actingUpdatesScopeDepth === 1 && (isSchedulerMocked === false || previousIsSomeRendererActing === false)) {
+                flushWork();
+              }
+              onDone();
+            } catch (err) {
+              onDone();
+              throw err;
+            }
+            return {
+              then: function(resolve) {
+                {
+                  error("Do not await the result of calling act(...) with sync logic, it is not a Promise.");
+                }
+                resolve();
+              }
+            };
+          }
+        }
+        var EventInternals$1 = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
+        var IsThisRendererActing$1 = EventInternals$1[6];
+        var batchedUpdates$1 = ReactDOM.unstable_batchedUpdates;
+        var IsSomeRendererActing$1 = ReactSharedInternals.IsSomeRendererActing;
+        var actingUpdatesScopeDepth$1 = 0;
+        function unstable_concurrentAct(scope) {
+          if (Scheduler.unstable_flushAllWithoutAsserting === void 0) {
+            throw Error("This version of `act` requires a special mock build of Scheduler.");
+          }
+          if (setTimeout._isMockFunction !== true) {
+            throw Error("This version of `act` requires Jest's timer mocks (i.e. jest.useFakeTimers).");
+          }
+          var previousActingUpdatesScopeDepth = actingUpdatesScopeDepth$1;
+          var previousIsSomeRendererActing = IsSomeRendererActing$1.current;
+          var previousIsThisRendererActing = IsThisRendererActing$1.current;
+          IsSomeRendererActing$1.current = true;
+          IsThisRendererActing$1.current = true;
+          actingUpdatesScopeDepth$1++;
+          var unwind = function() {
+            actingUpdatesScopeDepth$1--;
+            IsSomeRendererActing$1.current = previousIsSomeRendererActing;
+            IsThisRendererActing$1.current = previousIsThisRendererActing;
+            {
+              if (actingUpdatesScopeDepth$1 > previousActingUpdatesScopeDepth) {
+                error("You seem to have overlapping act() calls, this is not supported. Be sure to await previous act() calls before making a new one. ");
+              }
+            }
+          };
+          try {
+            var thenable = batchedUpdates$1(scope);
+            if (typeof thenable === "object" && thenable !== null && typeof thenable.then === "function") {
+              return {
+                then: function(resolve, reject) {
+                  thenable.then(function() {
+                    flushActWork(function() {
+                      unwind();
+                      resolve();
+                    }, function(error2) {
+                      unwind();
+                      reject(error2);
+                    });
+                  }, function(error2) {
+                    unwind();
+                    reject(error2);
+                  });
+                }
+              };
+            } else {
+              try {
+                var didFlushWork;
+                do {
+                  didFlushWork = Scheduler.unstable_flushAllWithoutAsserting();
+                } while (didFlushWork);
+              } finally {
+                unwind();
+              }
+            }
+          } catch (error2) {
+            unwind();
+            throw error2;
+          }
+        }
+        function flushActWork(resolve, reject) {
+          jest.runOnlyPendingTimers();
+          enqueueTask(function() {
+            try {
+              var didFlushWork = Scheduler.unstable_flushAllWithoutAsserting();
+              if (didFlushWork) {
+                flushActWork(resolve, reject);
+              } else {
+                resolve();
+              }
+            } catch (error2) {
+              reject(error2);
+            }
+          });
+        }
+        function invokeGuardedCallbackProd(name, func, context, a, b2, c2, d2, e2, f2) {
+          var funcArgs = Array.prototype.slice.call(arguments, 3);
+          try {
+            func.apply(context, funcArgs);
+          } catch (error2) {
+            this.onError(error2);
+          }
+        }
+        var invokeGuardedCallbackImpl = invokeGuardedCallbackProd;
+        {
+          if (typeof window !== "undefined" && typeof window.dispatchEvent === "function" && typeof document !== "undefined" && typeof document.createEvent === "function") {
+            var fakeNode = document.createElement("react");
+            invokeGuardedCallbackImpl = function invokeGuardedCallbackDev(name, func, context, a, b2, c2, d2, e2, f2) {
+              if (!(typeof document !== "undefined")) {
+                {
+                  throw Error("The `document` global was defined when React was initialized, but is not defined anymore. This can happen in a test environment if a component schedules an update from an asynchronous callback, but the test has already finished running. To solve this, you can either unmount the component at the end of your test (and ensure that any asynchronous operations get canceled in `componentWillUnmount`), or you can change the test itself to be asynchronous.");
+                }
+              }
+              var evt = document.createEvent("Event");
+              var didCall = false;
+              var didError = true;
+              var windowEvent = window.event;
+              var windowEventDescriptor = Object.getOwnPropertyDescriptor(window, "event");
+              function restoreAfterDispatch() {
+                fakeNode.removeEventListener(evtType, callCallback, false);
+                if (typeof window.event !== "undefined" && window.hasOwnProperty("event")) {
+                  window.event = windowEvent;
+                }
+              }
+              var funcArgs = Array.prototype.slice.call(arguments, 3);
+              function callCallback() {
+                didCall = true;
+                restoreAfterDispatch();
+                func.apply(context, funcArgs);
+                didError = false;
+              }
+              var error2;
+              var didSetError = false;
+              var isCrossOriginError = false;
+              function handleWindowError(event) {
+                error2 = event.error;
+                didSetError = true;
+                if (error2 === null && event.colno === 0 && event.lineno === 0) {
+                  isCrossOriginError = true;
+                }
+                if (event.defaultPrevented) {
+                  if (error2 != null && typeof error2 === "object") {
+                    try {
+                      error2._suppressLogging = true;
+                    } catch (inner) {
+                    }
+                  }
+                }
+              }
+              var evtType = "react-" + (name ? name : "invokeguardedcallback");
+              window.addEventListener("error", handleWindowError);
+              fakeNode.addEventListener(evtType, callCallback, false);
+              evt.initEvent(evtType, false, false);
+              fakeNode.dispatchEvent(evt);
+              if (windowEventDescriptor) {
+                Object.defineProperty(window, "event", windowEventDescriptor);
+              }
+              if (didCall && didError) {
+                if (!didSetError) {
+                  error2 = new Error(`An error was thrown inside one of your components, but React doesn't know what it was. This is likely due to browser flakiness. React does its best to preserve the "Pause on exceptions" behavior of the DevTools, which requires some DEV-mode only tricks. It's possible that these don't work in your browser. Try triggering the error in production mode, or switching to a modern browser. If you suspect that this is actually an issue with React, please file an issue.`);
+                } else if (isCrossOriginError) {
+                  error2 = new Error("A cross-origin error was thrown. React doesn't have access to the actual error object in development. See https://reactjs.org/link/crossorigin-error for more information.");
+                }
+                this.onError(error2);
+              }
+              window.removeEventListener("error", handleWindowError);
+              if (!didCall) {
+                restoreAfterDispatch();
+                return invokeGuardedCallbackProd.apply(this, arguments);
+              }
+            };
+          }
+        }
+        var invokeGuardedCallbackImpl$1 = invokeGuardedCallbackImpl;
+        var hasError = false;
+        var caughtError = null;
+        var hasRethrowError = false;
+        var rethrowError = null;
+        var reporter = {
+          onError: function(error2) {
+            hasError = true;
+            caughtError = error2;
+          }
+        };
+        function invokeGuardedCallback(name, func, context, a, b2, c2, d2, e2, f2) {
+          hasError = false;
+          caughtError = null;
+          invokeGuardedCallbackImpl$1.apply(reporter, arguments);
+        }
+        function invokeGuardedCallbackAndCatchFirstError(name, func, context, a, b2, c2, d2, e2, f2) {
+          invokeGuardedCallback.apply(this, arguments);
+          if (hasError) {
+            var error2 = clearCaughtError();
+            if (!hasRethrowError) {
+              hasRethrowError = true;
+              rethrowError = error2;
+            }
+          }
+        }
+        function rethrowCaughtError() {
+          if (hasRethrowError) {
+            var error2 = rethrowError;
+            hasRethrowError = false;
+            rethrowError = null;
+            throw error2;
+          }
+        }
+        function clearCaughtError() {
+          if (hasError) {
+            var error2 = caughtError;
+            hasError = false;
+            caughtError = null;
+            return error2;
+          } else {
+            {
+              {
+                throw Error("clearCaughtError was called but no error was captured. This error is likely caused by a bug in React. Please file an issue.");
+              }
+            }
+          }
+        }
+        var EventInternals$2 = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
+        var getInstanceFromNode = EventInternals$2[0];
+        var getNodeFromInstance = EventInternals$2[1];
+        var getFiberCurrentPropsFromNode = EventInternals$2[2];
+        var enqueueStateRestore = EventInternals$2[3];
+        var restoreStateIfNeeded = EventInternals$2[4];
+        function Event(suffix) {
+        }
+        var hasWarnedAboutDeprecatedMockComponent = false;
+        function findAllInRenderedFiberTreeInternal(fiber, test2) {
+          if (!fiber) {
+            return [];
+          }
+          var currentParent = findCurrentFiberUsingSlowPath(fiber);
+          if (!currentParent) {
+            return [];
+          }
+          var node = currentParent;
+          var ret = [];
+          while (true) {
+            if (node.tag === HostComponent || node.tag === HostText || node.tag === ClassComponent || node.tag === FunctionComponent) {
+              var publicInst = node.stateNode;
+              if (test2(publicInst)) {
+                ret.push(publicInst);
+              }
+            }
+            if (node.child) {
+              node.child.return = node;
+              node = node.child;
+              continue;
+            }
+            if (node === currentParent) {
+              return ret;
+            }
+            while (!node.sibling) {
+              if (!node.return || node.return === currentParent) {
+                return ret;
+              }
+              node = node.return;
+            }
+            node.sibling.return = node.return;
+            node = node.sibling;
+          }
+        }
+        function validateClassInstance(inst, methodName) {
+          if (!inst) {
+            return;
+          }
+          if (get2(inst)) {
+            return;
+          }
+          var received;
+          var stringified = "" + inst;
+          if (Array.isArray(inst)) {
+            received = "an array";
+          } else if (inst && inst.nodeType === ELEMENT_NODE2 && inst.tagName) {
+            received = "a DOM node";
+          } else if (stringified === "[object Object]") {
+            received = "object with keys {" + Object.keys(inst).join(", ") + "}";
+          } else {
+            received = stringified;
+          }
+          {
+            {
+              throw Error(methodName + "(...): the first argument must be a React class instance. Instead received: " + received + ".");
+            }
+          }
+        }
+        function renderIntoDocument(element) {
+          var div = document.createElement("div");
+          return ReactDOM.render(element, div);
+        }
+        function isElement2(element) {
+          return React.isValidElement(element);
+        }
+        function isElementOfType(inst, convenienceConstructor) {
+          return React.isValidElement(inst) && inst.type === convenienceConstructor;
+        }
+        function isDOMComponent(inst) {
+          return !!(inst && inst.nodeType === ELEMENT_NODE2 && inst.tagName);
+        }
+        function isDOMComponentElement(inst) {
+          return !!(inst && React.isValidElement(inst) && !!inst.tagName);
+        }
+        function isCompositeComponent(inst) {
+          if (isDOMComponent(inst)) {
+            return false;
+          }
+          return inst != null && typeof inst.render === "function" && typeof inst.setState === "function";
+        }
+        function isCompositeComponentWithType(inst, type2) {
+          if (!isCompositeComponent(inst)) {
+            return false;
+          }
+          var internalInstance = get2(inst);
+          var constructor = internalInstance.type;
+          return constructor === type2;
+        }
+        function findAllInRenderedTree(inst, test2) {
+          validateClassInstance(inst, "findAllInRenderedTree");
+          if (!inst) {
+            return [];
+          }
+          var internalInstance = get2(inst);
+          return findAllInRenderedFiberTreeInternal(internalInstance, test2);
+        }
+        function scryRenderedDOMComponentsWithClass(root, classNames) {
+          validateClassInstance(root, "scryRenderedDOMComponentsWithClass");
+          return findAllInRenderedTree(root, function(inst) {
+            if (isDOMComponent(inst)) {
+              var className = inst.className;
+              if (typeof className !== "string") {
+                className = inst.getAttribute("class") || "";
+              }
+              var classList = className.split(/\s+/);
+              if (!Array.isArray(classNames)) {
+                if (!(classNames !== void 0)) {
+                  {
+                    throw Error("TestUtils.scryRenderedDOMComponentsWithClass expects a className as a second argument.");
+                  }
+                }
+                classNames = classNames.split(/\s+/);
+              }
+              return classNames.every(function(name) {
+                return classList.indexOf(name) !== -1;
+              });
+            }
+            return false;
+          });
+        }
+        function findRenderedDOMComponentWithClass(root, className) {
+          validateClassInstance(root, "findRenderedDOMComponentWithClass");
+          var all2 = scryRenderedDOMComponentsWithClass(root, className);
+          if (all2.length !== 1) {
+            throw new Error("Did not find exactly one match (found: " + all2.length + ") for class:" + className);
+          }
+          return all2[0];
+        }
+        function scryRenderedDOMComponentsWithTag(root, tagName) {
+          validateClassInstance(root, "scryRenderedDOMComponentsWithTag");
+          return findAllInRenderedTree(root, function(inst) {
+            return isDOMComponent(inst) && inst.tagName.toUpperCase() === tagName.toUpperCase();
+          });
+        }
+        function findRenderedDOMComponentWithTag(root, tagName) {
+          validateClassInstance(root, "findRenderedDOMComponentWithTag");
+          var all2 = scryRenderedDOMComponentsWithTag(root, tagName);
+          if (all2.length !== 1) {
+            throw new Error("Did not find exactly one match (found: " + all2.length + ") for tag:" + tagName);
+          }
+          return all2[0];
+        }
+        function scryRenderedComponentsWithType(root, componentType) {
+          validateClassInstance(root, "scryRenderedComponentsWithType");
+          return findAllInRenderedTree(root, function(inst) {
+            return isCompositeComponentWithType(inst, componentType);
+          });
+        }
+        function findRenderedComponentWithType(root, componentType) {
+          validateClassInstance(root, "findRenderedComponentWithType");
+          var all2 = scryRenderedComponentsWithType(root, componentType);
+          if (all2.length !== 1) {
+            throw new Error("Did not find exactly one match (found: " + all2.length + ") for componentType:" + componentType);
+          }
+          return all2[0];
+        }
+        function mockComponent(module3, mockTagName) {
+          {
+            if (!hasWarnedAboutDeprecatedMockComponent) {
+              hasWarnedAboutDeprecatedMockComponent = true;
+              warn("ReactTestUtils.mockComponent() is deprecated. Use shallow rendering or jest.mock() instead.\n\nSee https://reactjs.org/link/test-utils-mock-component for more information.");
+            }
+          }
+          mockTagName = mockTagName || module3.mockTagName || "div";
+          module3.prototype.render.mockImplementation(function() {
+            return React.createElement(mockTagName, null, this.props.children);
+          });
+          return this;
+        }
+        function nativeTouchData(x2, y2) {
+          return {
+            touches: [{
+              pageX: x2,
+              pageY: y2
+            }]
+          };
+        }
+        function executeDispatch(event, listener, inst) {
+          var type2 = event.type || "unknown-event";
+          event.currentTarget = getNodeFromInstance(inst);
+          invokeGuardedCallbackAndCatchFirstError(type2, listener, void 0, event);
+          event.currentTarget = null;
+        }
+        function executeDispatchesInOrder(event) {
+          var dispatchListeners = event._dispatchListeners;
+          var dispatchInstances = event._dispatchInstances;
+          if (Array.isArray(dispatchListeners)) {
+            for (var i2 = 0; i2 < dispatchListeners.length; i2++) {
+              if (event.isPropagationStopped()) {
+                break;
+              }
+              executeDispatch(event, dispatchListeners[i2], dispatchInstances[i2]);
+            }
+          } else if (dispatchListeners) {
+            executeDispatch(event, dispatchListeners, dispatchInstances);
+          }
+          event._dispatchListeners = null;
+          event._dispatchInstances = null;
+        }
+        var executeDispatchesAndRelease = function(event) {
+          if (event) {
+            executeDispatchesInOrder(event);
+            if (!event.isPersistent()) {
+              event.constructor.release(event);
+            }
+          }
+        };
+        function isInteractive(tag) {
+          return tag === "button" || tag === "input" || tag === "select" || tag === "textarea";
+        }
+        function getParent(inst) {
+          do {
+            inst = inst.return;
+          } while (inst && inst.tag !== HostComponent);
+          if (inst) {
+            return inst;
+          }
+          return null;
+        }
+        function traverseTwoPhase(inst, fn2, arg) {
+          var path2 = [];
+          while (inst) {
+            path2.push(inst);
+            inst = getParent(inst);
+          }
+          var i2;
+          for (i2 = path2.length; i2-- > 0; ) {
+            fn2(path2[i2], "captured", arg);
+          }
+          for (i2 = 0; i2 < path2.length; i2++) {
+            fn2(path2[i2], "bubbled", arg);
+          }
+        }
+        function shouldPreventMouseEvent(name, type2, props) {
+          switch (name) {
+            case "onClick":
+            case "onClickCapture":
+            case "onDoubleClick":
+            case "onDoubleClickCapture":
+            case "onMouseDown":
+            case "onMouseDownCapture":
+            case "onMouseMove":
+            case "onMouseMoveCapture":
+            case "onMouseUp":
+            case "onMouseUpCapture":
+            case "onMouseEnter":
+              return !!(props.disabled && isInteractive(type2));
+            default:
+              return false;
+          }
+        }
+        function getListener(inst, registrationName) {
+          var stateNode = inst.stateNode;
+          if (!stateNode) {
+            return null;
+          }
+          var props = getFiberCurrentPropsFromNode(stateNode);
+          if (!props) {
+            return null;
+          }
+          var listener = props[registrationName];
+          if (shouldPreventMouseEvent(registrationName, inst.type, props)) {
+            return null;
+          }
+          if (!(!listener || typeof listener === "function")) {
+            {
+              throw Error("Expected `" + registrationName + "` listener to be a function, instead got a value of `" + typeof listener + "` type.");
+            }
+          }
+          return listener;
+        }
+        function listenerAtPhase(inst, event, propagationPhase) {
+          var registrationName = event._reactName;
+          if (propagationPhase === "captured") {
+            registrationName += "Capture";
+          }
+          return getListener(inst, registrationName);
+        }
+        function accumulateDispatches(inst, ignoredDirection, event) {
+          if (inst && event && event._reactName) {
+            var registrationName = event._reactName;
+            var listener = getListener(inst, registrationName);
+            if (listener) {
+              if (event._dispatchListeners == null) {
+                event._dispatchListeners = [];
+              }
+              if (event._dispatchInstances == null) {
+                event._dispatchInstances = [];
+              }
+              event._dispatchListeners.push(listener);
+              event._dispatchInstances.push(inst);
+            }
+          }
+        }
+        function accumulateDirectionalDispatches(inst, phase, event) {
+          {
+            if (!inst) {
+              error("Dispatching inst must not be null");
+            }
+          }
+          var listener = listenerAtPhase(inst, event, phase);
+          if (listener) {
+            if (event._dispatchListeners == null) {
+              event._dispatchListeners = [];
+            }
+            if (event._dispatchInstances == null) {
+              event._dispatchInstances = [];
+            }
+            event._dispatchListeners.push(listener);
+            event._dispatchInstances.push(inst);
+          }
+        }
+        function accumulateDirectDispatchesSingle(event) {
+          if (event && event._reactName) {
+            accumulateDispatches(event._targetInst, null, event);
+          }
+        }
+        function accumulateTwoPhaseDispatchesSingle(event) {
+          if (event && event._reactName) {
+            traverseTwoPhase(event._targetInst, accumulateDirectionalDispatches, event);
+          }
+        }
+        var Simulate = {};
+        var directDispatchEventTypes = /* @__PURE__ */ new Set(["mouseEnter", "mouseLeave", "pointerEnter", "pointerLeave"]);
+        function makeSimulator(eventType) {
+          return function(domNode, eventData) {
+            if (!!React.isValidElement(domNode)) {
+              {
+                throw Error("TestUtils.Simulate expected a DOM node as the first argument but received a React element. Pass the DOM node you wish to simulate the event on instead. Note that TestUtils.Simulate will not work if you are using shallow rendering.");
+              }
+            }
+            if (!!isCompositeComponent(domNode)) {
+              {
+                throw Error("TestUtils.Simulate expected a DOM node as the first argument but received a component instance. Pass the DOM node you wish to simulate the event on instead.");
+              }
+            }
+            var reactName = "on" + eventType[0].toUpperCase() + eventType.slice(1);
+            var fakeNativeEvent = new Event();
+            fakeNativeEvent.target = domNode;
+            fakeNativeEvent.type = eventType.toLowerCase();
+            var targetInst = getInstanceFromNode(domNode);
+            var event = new SyntheticEvent(reactName, fakeNativeEvent.type, targetInst, fakeNativeEvent, domNode);
+            event.persist();
+            _assign(event, eventData);
+            if (directDispatchEventTypes.has(eventType)) {
+              accumulateDirectDispatchesSingle(event);
+            } else {
+              accumulateTwoPhaseDispatchesSingle(event);
+            }
+            ReactDOM.unstable_batchedUpdates(function() {
+              enqueueStateRestore(domNode);
+              executeDispatchesAndRelease(event);
+              rethrowCaughtError();
+            });
+            restoreStateIfNeeded();
+          };
+        }
+        var simulatedEventTypes = ["blur", "cancel", "click", "close", "contextMenu", "copy", "cut", "auxClick", "doubleClick", "dragEnd", "dragStart", "drop", "focus", "input", "invalid", "keyDown", "keyPress", "keyUp", "mouseDown", "mouseUp", "paste", "pause", "play", "pointerCancel", "pointerDown", "pointerUp", "rateChange", "reset", "seeked", "submit", "touchCancel", "touchEnd", "touchStart", "volumeChange", "drag", "dragEnter", "dragExit", "dragLeave", "dragOver", "mouseMove", "mouseOut", "mouseOver", "pointerMove", "pointerOut", "pointerOver", "scroll", "toggle", "touchMove", "wheel", "abort", "animationEnd", "animationIteration", "animationStart", "canPlay", "canPlayThrough", "durationChange", "emptied", "encrypted", "ended", "error", "gotPointerCapture", "load", "loadedData", "loadedMetadata", "loadStart", "lostPointerCapture", "playing", "progress", "seeking", "stalled", "suspend", "timeUpdate", "transitionEnd", "waiting", "mouseEnter", "mouseLeave", "pointerEnter", "pointerLeave", "change", "select", "beforeInput", "compositionEnd", "compositionStart", "compositionUpdate"];
+        function buildSimulators() {
+          simulatedEventTypes.forEach(function(eventType) {
+            Simulate[eventType] = makeSimulator(eventType);
+          });
+        }
+        buildSimulators();
+        exports2.Simulate = Simulate;
+        exports2.act = act2;
+        exports2.findAllInRenderedTree = findAllInRenderedTree;
+        exports2.findRenderedComponentWithType = findRenderedComponentWithType;
+        exports2.findRenderedDOMComponentWithClass = findRenderedDOMComponentWithClass;
+        exports2.findRenderedDOMComponentWithTag = findRenderedDOMComponentWithTag;
+        exports2.isCompositeComponent = isCompositeComponent;
+        exports2.isCompositeComponentWithType = isCompositeComponentWithType;
+        exports2.isDOMComponent = isDOMComponent;
+        exports2.isDOMComponentElement = isDOMComponentElement;
+        exports2.isElement = isElement2;
+        exports2.isElementOfType = isElementOfType;
+        exports2.mockComponent = mockComponent;
+        exports2.nativeTouchData = nativeTouchData;
+        exports2.renderIntoDocument = renderIntoDocument;
+        exports2.scryRenderedComponentsWithType = scryRenderedComponentsWithType;
+        exports2.scryRenderedDOMComponentsWithClass = scryRenderedDOMComponentsWithClass;
+        exports2.scryRenderedDOMComponentsWithTag = scryRenderedDOMComponentsWithTag;
+        exports2.traverseTwoPhase = traverseTwoPhase;
+        exports2.unstable_concurrentAct = unstable_concurrentAct;
+      })();
+    }
+  });
+  var testUtils$1 = createCommonjsModule(function(module2) {
+    if (process$1.env.NODE_ENV === "production") {
+      module2.exports = reactDomTestUtils_production_min$1;
+    } else {
+      module2.exports = reactDomTestUtils_development;
+    }
+  });
+  var reactAct = testUtils$1.act;
+  var actSupported = reactAct !== void 0;
+  function actPolyfill(cb) {
+    m$1$1.unstable_batchedUpdates(cb);
+    m$1$1.render(/* @__PURE__ */ l__default__namespace.createElement("div", null), document.createElement("div"));
+  }
+  var act$1 = reactAct || actPolyfill;
+  var youHaveBeenWarned = false;
+  var isAsyncActSupported = null;
+  function asyncAct(cb) {
+    if (actSupported === true) {
+      if (isAsyncActSupported === null) {
+        return new Promise(function(resolve, reject) {
+          var originalConsoleError = console.error;
+          console.error = function error() {
+            for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+              args[_key] = arguments[_key];
+            }
+            var firstArgIsString = typeof args[0] === "string";
+            if (firstArgIsString && args[0].indexOf("Warning: Do not await the result of calling ReactTestUtils.act") === 0) {
+              isAsyncActSupported = false;
+            } else if (firstArgIsString && args[0].indexOf("Warning: The callback passed to ReactTestUtils.act(...) function must not return anything") === 0) ;
+            else {
+              originalConsoleError.apply(console, args);
+            }
+          };
+          var cbReturn, result2;
+          try {
+            result2 = reactAct(function() {
+              cbReturn = cb();
+              return cbReturn;
+            });
+          } catch (err) {
+            console.error = originalConsoleError;
+            reject(err);
+            return;
+          }
+          result2.then(function() {
+            console.error = originalConsoleError;
+            isAsyncActSupported = true;
+            resolve();
+          }, function(err) {
+            console.error = originalConsoleError;
+            isAsyncActSupported = true;
+            reject(err);
+          });
+          if (isAsyncActSupported === false) {
+            console.error = originalConsoleError;
+            if (!youHaveBeenWarned) {
+              console.error(`It looks like you're using a version of react-dom that supports the "act" function, but not an awaitable version of "act" which you will need. Please upgrade to at least react-dom@16.9.0 to remove this warning.`);
+              youHaveBeenWarned = true;
+            }
+            cbReturn.then(function() {
+              Promise.resolve().then(function() {
+                act$1(function() {
+                });
+                resolve();
+              });
+            }, reject);
+          }
+        });
+      } else if (isAsyncActSupported === false) {
+        var _result;
+        act$1(function() {
+          _result = cb();
+        });
+        return _result.then(function() {
+          return Promise.resolve().then(function() {
+            act$1(function() {
+            });
+          });
+        });
+      }
+      return act$1(cb);
+    }
+    var result;
+    act$1(function() {
+      result = cb();
+    });
+    return result.then(function() {
+      return Promise.resolve().then(function() {
+        act$1(function() {
+        });
+      });
+    });
+  }
+  var fireEvent$2 = function fireEvent2() {
+    return fireEvent$1$1.apply(void 0, arguments);
+  };
+  Object.keys(fireEvent$1$1).forEach(function(key2) {
+    fireEvent$2[key2] = function() {
+      return fireEvent$1$1[key2].apply(fireEvent$1$1, arguments);
+    };
+  });
+  var mouseEnter$1 = fireEvent$2.mouseEnter;
+  var mouseLeave$1 = fireEvent$2.mouseLeave;
+  fireEvent$2.mouseEnter = function() {
+    mouseEnter$1.apply(void 0, arguments);
+    return fireEvent$2.mouseOver.apply(fireEvent$2, arguments);
+  };
+  fireEvent$2.mouseLeave = function() {
+    mouseLeave$1.apply(void 0, arguments);
+    return fireEvent$2.mouseOut.apply(fireEvent$2, arguments);
+  };
+  var pointerEnter$1 = fireEvent$2.pointerEnter;
+  var pointerLeave$1 = fireEvent$2.pointerLeave;
+  fireEvent$2.pointerEnter = function() {
+    pointerEnter$1.apply(void 0, arguments);
+    return fireEvent$2.pointerOver.apply(fireEvent$2, arguments);
+  };
+  fireEvent$2.pointerLeave = function() {
+    pointerLeave$1.apply(void 0, arguments);
+    return fireEvent$2.pointerOut.apply(fireEvent$2, arguments);
+  };
+  var select$1 = fireEvent$2.select;
+  fireEvent$2.select = function(node, init) {
+    select$1(node, init);
+    node.focus();
+    fireEvent$2.keyUp(node, init);
+  };
+  var blur$1$1 = fireEvent$2.blur;
+  var focus$1$1 = fireEvent$2.focus;
+  fireEvent$2.blur = function() {
+    fireEvent$2.focusOut.apply(fireEvent$2, arguments);
+    return blur$1$1.apply(void 0, arguments);
+  };
+  fireEvent$2.focus = function() {
+    fireEvent$2.focusIn.apply(fireEvent$2, arguments);
+    return focus$1$1.apply(void 0, arguments);
+  };
+  configure$1({
+    asyncWrapper: function() {
+      var _asyncWrapper = _asyncToGenerator(/* @__PURE__ */ regenerator.mark(function _callee2(cb) {
+        var result;
+        return regenerator.wrap(function _callee2$(_context2) {
+          while (1) {
+            switch (_context2.prev = _context2.next) {
+              case 0:
+                _context2.next = 2;
+                return asyncAct(/* @__PURE__ */ _asyncToGenerator(/* @__PURE__ */ regenerator.mark(function _callee() {
+                  return regenerator.wrap(function _callee$(_context) {
+                    while (1) {
+                      switch (_context.prev = _context.next) {
+                        case 0:
+                          _context.next = 2;
+                          return cb();
+                        case 2:
+                          result = _context.sent;
+                        case 3:
+                        case "end":
+                          return _context.stop();
+                      }
+                    }
+                  }, _callee);
+                })));
+              case 2:
+                return _context2.abrupt("return", result);
+              case 3:
+              case "end":
+                return _context2.stop();
+            }
+          }
+        }, _callee2);
+      }));
+      function asyncWrapper(_x) {
+        return _asyncWrapper.apply(this, arguments);
+      }
+      return asyncWrapper;
+    }(),
+    eventWrapper: function eventWrapper2(cb) {
+      var result;
+      act$1(function() {
+        result = cb();
+      });
+      return result;
+    }
+  });
+  var mountedContainers$1 = /* @__PURE__ */ new Set();
+  function render$1(ui, _temp) {
+    var _ref2 = _temp === void 0 ? {} : _temp, container = _ref2.container, _ref2$baseElement = _ref2.baseElement, baseElement = _ref2$baseElement === void 0 ? container : _ref2$baseElement, queries2 = _ref2.queries, _ref2$hydrate = _ref2.hydrate, hydrate = _ref2$hydrate === void 0 ? false : _ref2$hydrate, WrapperComponent = _ref2.wrapper;
+    if (!baseElement) {
+      baseElement = document.body;
+    }
+    if (!container) {
+      container = baseElement.appendChild(document.createElement("div"));
+    }
+    mountedContainers$1.add(container);
+    var wrapUiIfNeeded = function wrapUiIfNeeded2(innerElement) {
+      return WrapperComponent ? /* @__PURE__ */ l__default__namespace.createElement(WrapperComponent, null, innerElement) : innerElement;
+    };
+    act$1(function() {
+      if (hydrate) {
+        m$1$1.hydrate(wrapUiIfNeeded(ui), container);
+      } else {
+        m$1$1.render(wrapUiIfNeeded(ui), container);
+      }
+    });
+    return _extends({
+      container,
+      baseElement,
+      debug: function debug2(el, maxLength2, options) {
+        if (el === void 0) {
+          el = baseElement;
+        }
+        return Array.isArray(el) ? (
+          // eslint-disable-next-line no-console
+          el.forEach(function(e2) {
+            return console.log(prettyDOM$1(e2, maxLength2, options));
+          })
+        ) : (
+          // eslint-disable-next-line no-console,
+          console.log(prettyDOM$1(el, maxLength2, options))
+        );
+      },
+      unmount: function unmount() {
+        act$1(function() {
+          m$1$1.unmountComponentAtNode(container);
+        });
+      },
+      rerender: function rerender(rerenderUi) {
+        render$1(wrapUiIfNeeded(rerenderUi), {
+          container,
+          baseElement
+        });
+      },
+      asFragment: function asFragment() {
+        if (typeof document.createRange === "function") {
+          return document.createRange().createContextualFragment(container.innerHTML);
+        } else {
+          var template = document.createElement("template");
+          template.innerHTML = container.innerHTML;
+          return template.content;
+        }
+      }
+    }, getQueriesForElement$1(baseElement, queries2));
+  }
+  function cleanup$1() {
+    mountedContainers$1.forEach(cleanupAtContainer);
+  }
+  function cleanupAtContainer(container) {
+    act$1(function() {
+      m$1$1.unmountComponentAtNode(container);
+    });
+    if (container.parentNode === document.body) {
+      document.body.removeChild(container);
+    }
+    mountedContainers$1.delete(container);
+  }
+  var _process$env$1;
+  if (typeof process$1 === "undefined" || !((_process$env$1 = process$1.env) != null && _process$env$1.RTL_SKIP_AUTO_CLEANUP)) {
+    if (typeof afterEach === "function") {
+      afterEach(function() {
+        cleanup$1();
+      });
+    } else if (typeof teardown === "function") {
+      teardown(function() {
+        cleanup$1();
+      });
+    }
+  }
+  var buildTestingLibraryElementError$1 = function buildTestingLibraryElementError2(message) {
+    var err = new Error(message);
+    err.name = "TestingLibraryElementError";
+    return err;
+  };
+  var buildJsGetElementError$1 = function buildJsGetElementError2(message, container) {
+    var _message$replace;
+    var prettyDOMRegex = new RegExp("(?<=[\\s\\S]*)\\s*<\\w+>[\\s\\S]+", "gm");
+    var newMessage = (_message$replace = message === null || message === void 0 ? void 0 : message.replace(prettyDOMRegex, "")) !== null && _message$replace !== void 0 ? _message$replace : "";
+    var prettyDomOutput = prettyDOM$1(container);
+    return buildTestingLibraryElementError$1([newMessage, prettyDomOutput].filter(Boolean).join("\n\n"));
+  };
+  var getMouseEventOptions_2 = getMouseEventOptions$2;
+  function isMousePressEvent$1(event) {
+    return event === "mousedown" || event === "mouseup" || event === "click" || event === "dblclick";
+  }
+  const BUTTONS_NAMES$1 = {
+    none: 0,
+    primary: 1,
+    secondary: 2,
+    auxiliary: 4
+  };
+  const BUTTON_NAMES$1 = {
+    primary: 0,
+    auxiliary: 1,
+    secondary: 2
+  };
+  function translateButtonNumber$1(value, from2) {
+    var _Object$entries$find;
+    const [mapIn, mapOut] = from2 === "button" ? [BUTTON_NAMES$1, BUTTONS_NAMES$1] : [BUTTONS_NAMES$1, BUTTON_NAMES$1];
+    const name = (_Object$entries$find = Object.entries(mapIn).find(([, i2]) => i2 === value)) == null ? void 0 : _Object$entries$find[0];
+    return name && Object.prototype.hasOwnProperty.call(mapOut, name) ? mapOut[name] : 0;
+  }
+  function convertMouseButtons$1(event, init, property) {
+    if (!isMousePressEvent$1(event)) {
+      return 0;
+    }
+    if (typeof init[property] === "number") {
+      return init[property];
+    } else if (property === "button" && typeof init.buttons === "number") {
+      return translateButtonNumber$1(init.buttons, "buttons");
+    } else if (property === "buttons" && typeof init.button === "number") {
+      return translateButtonNumber$1(init.button, "button");
+    }
+    return property != "button" && isMousePressEvent$1(event) ? 1 : 0;
+  }
+  function getMouseEventOptions$2(event, init, clickCount = 0) {
+    var _init;
+    init = (_init = init) != null ? _init : {};
+    return {
+      ...init,
+      // https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail
+      detail: event === "mousedown" || event === "mouseup" || event === "click" ? 1 + clickCount : clickCount,
+      buttons: convertMouseButtons$1(event, init, "buttons"),
+      button: convertMouseButtons$1(event, init, "button")
+    };
+  }
+  var getMouseEventOptions_1 = /* @__PURE__ */ Object.defineProperty({
+    getMouseEventOptions: getMouseEventOptions_2
+  }, "__esModule", { value: true });
+  var isElementType_2 = isElementType$2;
+  function isElementType$2(element, tag, props) {
+    if (element.namespaceURI && element.namespaceURI !== "http://www.w3.org/1999/xhtml") {
+      return false;
+    }
+    tag = Array.isArray(tag) ? tag : [tag];
+    if (!tag.includes(element.tagName.toLowerCase())) {
+      return false;
+    }
+    if (props) {
+      return Object.entries(props).every(([k2, v2]) => element[k2] === v2);
+    }
+    return true;
+  }
+  var isElementType_1 = /* @__PURE__ */ Object.defineProperty({
+    isElementType: isElementType_2
+  }, "__esModule", { value: true });
+  var isClickableInput_2 = isClickableInput$2;
+  const CLICKABLE_INPUT_TYPES$1 = ["button", "color", "file", "image", "reset", "submit", "checkbox", "radio"];
+  function isClickableInput$2(element) {
+    return (0, isElementType_1.isElementType)(element, "button") || (0, isElementType_1.isElementType)(element, "input") && CLICKABLE_INPUT_TYPES$1.includes(element.type);
+  }
+  var isClickableInput_1 = /* @__PURE__ */ Object.defineProperty({
+    isClickableInput: isClickableInput_2
+  }, "__esModule", { value: true });
+  var buildTimeValue_2 = buildTimeValue$2;
+  function buildTimeValue$2(value) {
+    const onlyDigitsValue = value.replace(/\D/g, "");
+    if (onlyDigitsValue.length < 2) {
+      return value;
+    }
+    const firstDigit = parseInt(onlyDigitsValue[0], 10);
+    const secondDigit = parseInt(onlyDigitsValue[1], 10);
+    if (firstDigit >= 3 || firstDigit === 2 && secondDigit >= 4) {
+      let index2;
+      if (firstDigit >= 3) {
+        index2 = 1;
+      } else {
+        index2 = 2;
+      }
+      return build$2(onlyDigitsValue, index2);
+    }
+    if (value.length === 2) {
+      return value;
+    }
+    return build$2(onlyDigitsValue, 2);
+  }
+  function build$2(onlyDigitsValue, index2) {
+    const hours = onlyDigitsValue.slice(0, index2);
+    const validHours = Math.min(parseInt(hours, 10), 23);
+    const minuteCharacters = onlyDigitsValue.slice(index2);
+    const parsedMinutes = parseInt(minuteCharacters, 10);
+    const validMinutes = Math.min(parsedMinutes, 59);
+    return `${validHours.toString().padStart(2, "0")}:${validMinutes.toString().padStart(2, "0")}`;
+  }
+  var buildTimeValue_1 = /* @__PURE__ */ Object.defineProperty({
+    buildTimeValue: buildTimeValue_2
+  }, "__esModule", { value: true });
+  var getSelectionRange_1 = getSelectionRange$1;
+  var hasSelectionSupport_1 = hasSelectionSupport$1;
+  var setSelectionRange_1 = setSelectionRange$1;
+  var selectionSupportType$1;
+  (function(selectionSupportType2) {
+    selectionSupportType2["text"] = "text";
+    selectionSupportType2["search"] = "search";
+    selectionSupportType2["url"] = "url";
+    selectionSupportType2["tel"] = "tel";
+    selectionSupportType2["password"] = "password";
+  })(selectionSupportType$1 || (selectionSupportType$1 = {}));
+  const InputSelection$1 = Symbol("inputSelection");
+  function hasSelectionSupport$1(element) {
+    return (0, isElementType_1.isElementType)(element, "textarea") || (0, isElementType_1.isElementType)(element, "input") && Boolean(selectionSupportType$1[element.type]);
+  }
+  function getSelectionRange$1(element) {
+    if (hasSelectionSupport$1(element)) {
+      return {
+        selectionStart: element.selectionStart,
+        selectionEnd: element.selectionEnd
+      };
+    }
+    if ((0, isElementType_1.isElementType)(element, "input")) {
+      var _InputSelection;
+      return (_InputSelection = element[InputSelection$1]) != null ? _InputSelection : {
+        selectionStart: null,
+        selectionEnd: null
+      };
+    }
+    const selection = element.ownerDocument.getSelection();
+    if (selection != null && selection.rangeCount && element.contains(selection.focusNode)) {
+      const range2 = selection.getRangeAt(0);
+      return {
+        selectionStart: range2.startOffset,
+        selectionEnd: range2.endOffset
+      };
+    } else {
+      return {
+        selectionStart: null,
+        selectionEnd: null
+      };
+    }
+  }
+  function setSelectionRange$1(element, newSelectionStart, newSelectionEnd) {
+    const {
+      selectionStart,
+      selectionEnd
+    } = getSelectionRange$1(element);
+    if (selectionStart === newSelectionStart && selectionEnd === newSelectionEnd) {
+      return;
+    }
+    if (hasSelectionSupport$1(element)) {
+      element.setSelectionRange(newSelectionStart, newSelectionEnd);
+    }
+    if ((0, isElementType_1.isElementType)(element, "input")) {
+      element[InputSelection$1] = {
+        selectionStart: newSelectionStart,
+        selectionEnd: newSelectionEnd
+      };
+    }
+    if ((0, isElementType_1.isElementType)(element, "input") || (0, isElementType_1.isElementType)(element, "textarea")) {
+      return;
+    }
+    const range2 = element.ownerDocument.createRange();
+    range2.selectNodeContents(element);
+    if (element.firstChild) {
+      range2.setStart(element.firstChild, newSelectionStart);
+      range2.setEnd(element.firstChild, newSelectionEnd);
+    }
+    const selection = element.ownerDocument.getSelection();
+    if (selection) {
+      selection.removeAllRanges();
+      selection.addRange(range2);
+    }
+  }
+  var selectionRange$1 = /* @__PURE__ */ Object.defineProperty({
+    getSelectionRange: getSelectionRange_1,
+    hasSelectionSupport: hasSelectionSupport_1,
+    setSelectionRange: setSelectionRange_1
+  }, "__esModule", { value: true });
+  var isContentEditable_2 = isContentEditable$2;
+  function isContentEditable$2(element) {
+    return element.hasAttribute("contenteditable") && (element.getAttribute("contenteditable") == "true" || element.getAttribute("contenteditable") == "");
+  }
+  var isContentEditable_1 = /* @__PURE__ */ Object.defineProperty({
+    isContentEditable: isContentEditable_2
+  }, "__esModule", { value: true });
+  var getValue_2 = getValue$2;
+  function getValue$2(element) {
+    if (!element) {
+      return null;
+    }
+    if ((0, isContentEditable_1.isContentEditable)(element)) {
+      return element.textContent;
+    }
+    return element.value;
+  }
+  var getValue_1 = /* @__PURE__ */ Object.defineProperty({
+    getValue: getValue_2
+  }, "__esModule", { value: true });
+  var isValidDateValue_2 = isValidDateValue$2;
+  function isValidDateValue$2(element, value) {
+    const clone2 = element.cloneNode();
+    clone2.value = value;
+    return clone2.value === value;
+  }
+  var isValidDateValue_1 = /* @__PURE__ */ Object.defineProperty({
+    isValidDateValue: isValidDateValue_2
+  }, "__esModule", { value: true });
+  var isValidInputTimeValue_2 = isValidInputTimeValue$2;
+  function isValidInputTimeValue$2(element, timeValue) {
+    const clone2 = element.cloneNode();
+    clone2.value = timeValue;
+    return clone2.value === timeValue;
+  }
+  var isValidInputTimeValue_1 = /* @__PURE__ */ Object.defineProperty({
+    isValidInputTimeValue: isValidInputTimeValue_2
+  }, "__esModule", { value: true });
+  var calculateNewValue_2 = calculateNewValue$2;
+  function calculateNewValue$2(newEntry, element, value = (() => {
+    var _getValue3;
+    return (_getValue3 = (0, getValue_1.getValue)(element)) != null ? _getValue3 : (
+      /* istanbul ignore next */
+      ""
+    );
+  })(), selectionRange$1$1 = (0, selectionRange$1.getSelectionRange)(element), deleteContent) {
+    const selectionStart = selectionRange$1$1.selectionStart === null ? value.length : selectionRange$1$1.selectionStart;
+    const selectionEnd = selectionRange$1$1.selectionEnd === null ? value.length : selectionRange$1$1.selectionEnd;
+    const prologEnd = Math.max(0, selectionStart === selectionEnd && deleteContent === "backward" ? selectionStart - 1 : selectionStart);
+    const prolog = value.substring(0, prologEnd);
+    const epilogStart = Math.min(value.length, selectionStart === selectionEnd && deleteContent === "forward" ? selectionEnd + 1 : selectionEnd);
+    const epilog = value.substring(epilogStart, value.length);
+    let newValue = `${prolog}${newEntry}${epilog}`;
+    const newSelectionStart = prologEnd + newEntry.length;
+    if (element.type === "date" && !(0, isValidDateValue_1.isValidDateValue)(element, newValue)) {
+      newValue = value;
+    }
+    if (element.type === "time" && !(0, isValidInputTimeValue_1.isValidInputTimeValue)(element, newValue)) {
+      if ((0, isValidInputTimeValue_1.isValidInputTimeValue)(element, newEntry)) {
+        newValue = newEntry;
+      } else {
+        newValue = value;
+      }
+    }
+    return {
+      newValue,
+      newSelectionStart
+    };
+  }
+  var calculateNewValue_1 = /* @__PURE__ */ Object.defineProperty({
+    calculateNewValue: calculateNewValue_2
+  }, "__esModule", { value: true });
+  var isCursorAtEnd_1 = isCursorAtEnd$1;
+  var isCursorAtStart_1 = isCursorAtStart$1;
+  function isCursorAtEnd$1(element) {
+    var _getValue3;
+    const {
+      selectionStart,
+      selectionEnd
+    } = (0, selectionRange$1.getSelectionRange)(element);
+    return selectionStart === selectionEnd && (selectionStart != null ? selectionStart : (
+      /* istanbul ignore next */
+      0
+    )) === ((_getValue3 = (0, getValue_1.getValue)(element)) != null ? _getValue3 : (
+      /* istanbul ignore next */
+      ""
+    )).length;
+  }
+  function isCursorAtStart$1(element) {
+    const {
+      selectionStart,
+      selectionEnd
+    } = (0, selectionRange$1.getSelectionRange)(element);
+    return selectionStart === selectionEnd && (selectionStart != null ? selectionStart : (
+      /* istanbul ignore next */
+      0
+    )) === 0;
+  }
+  var cursorPosition$1 = /* @__PURE__ */ Object.defineProperty({
+    isCursorAtEnd: isCursorAtEnd_1,
+    isCursorAtStart: isCursorAtStart_1
+  }, "__esModule", { value: true });
+  var hasUnreliableEmptyValue_2 = hasUnreliableEmptyValue$2;
+  var unreliableValueInputTypes$1;
+  (function(unreliableValueInputTypes2) {
+    unreliableValueInputTypes2["number"] = "number";
+  })(unreliableValueInputTypes$1 || (unreliableValueInputTypes$1 = {}));
+  function hasUnreliableEmptyValue$2(element) {
+    return (0, isElementType_1.isElementType)(element, "input") && Boolean(unreliableValueInputTypes$1[element.type]);
+  }
+  var hasUnreliableEmptyValue_1 = /* @__PURE__ */ Object.defineProperty({
+    hasUnreliableEmptyValue: hasUnreliableEmptyValue_2
+  }, "__esModule", { value: true });
+  var isEditable_1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.editableInputTypes = void 0;
+    exports2.isEditable = isEditable2;
+    exports2.isEditableInput = isEditableInput2;
+    function isEditable2(element) {
+      return isEditableInput2(element) || (0, isElementType_1.isElementType)(element, "textarea", {
+        readOnly: false
+      }) || (0, isContentEditable_1.isContentEditable)(element);
+    }
+    let editableInputTypes2;
+    exports2.editableInputTypes = editableInputTypes2;
+    (function(editableInputTypes3) {
+      editableInputTypes3["text"] = "text";
+      editableInputTypes3["date"] = "date";
+      editableInputTypes3["datetime-local"] = "datetime-local";
+      editableInputTypes3["email"] = "email";
+      editableInputTypes3["month"] = "month";
+      editableInputTypes3["number"] = "number";
+      editableInputTypes3["password"] = "password";
+      editableInputTypes3["search"] = "search";
+      editableInputTypes3["tel"] = "tel";
+      editableInputTypes3["time"] = "time";
+      editableInputTypes3["url"] = "url";
+      editableInputTypes3["week"] = "week";
+    })(editableInputTypes2 || (exports2.editableInputTypes = editableInputTypes2 = {}));
+    function isEditableInput2(element) {
+      return (0, isElementType_1.isElementType)(element, "input", {
+        readOnly: false
+      }) && Boolean(editableInputTypes2[element.type]);
+    }
+  });
+  var getSpaceUntilMaxLength_1 = getSpaceUntilMaxLength$1;
+  var maxLengthSupportedTypes$1;
+  (function(maxLengthSupportedTypes2) {
+    maxLengthSupportedTypes2["email"] = "email";
+    maxLengthSupportedTypes2["password"] = "password";
+    maxLengthSupportedTypes2["search"] = "search";
+    maxLengthSupportedTypes2["telephone"] = "telephone";
+    maxLengthSupportedTypes2["text"] = "text";
+    maxLengthSupportedTypes2["url"] = "url";
+  })(maxLengthSupportedTypes$1 || (maxLengthSupportedTypes$1 = {}));
+  function getSpaceUntilMaxLength$1(element) {
+    const value = (0, getValue_1.getValue)(element);
+    if (value === null) {
+      return void 0;
+    }
+    const maxLength2 = getSanitizedMaxLength$1(element);
+    return maxLength2 ? maxLength2 - value.length : void 0;
+  }
+  function getSanitizedMaxLength$1(element) {
+    var _element$getAttribute;
+    if (!supportsMaxLength$1(element)) {
+      return void 0;
+    }
+    const attr = (_element$getAttribute = element.getAttribute("maxlength")) != null ? _element$getAttribute : "";
+    return /^\d+$/.test(attr) && Number(attr) >= 0 ? Number(attr) : void 0;
+  }
+  function supportsMaxLength$1(element) {
+    return (0, isElementType_1.isElementType)(element, "textarea") || (0, isElementType_1.isElementType)(element, "input") && Boolean(maxLengthSupportedTypes$1[element.type]);
+  }
+  var maxLength$1 = /* @__PURE__ */ Object.defineProperty({
+    getSpaceUntilMaxLength: getSpaceUntilMaxLength_1
+  }, "__esModule", { value: true });
+  var isDisabled_2 = isDisabled$2;
+  function isDisabled$2(element) {
+    return Boolean(element && element.disabled);
+  }
+  var isDisabled_1 = /* @__PURE__ */ Object.defineProperty({
+    isDisabled: isDisabled_2
+  }, "__esModule", { value: true });
+  var getActiveElement_2 = getActiveElement$2;
+  function getActiveElement$2(document2) {
+    const activeElement = document2.activeElement;
+    if (activeElement != null && activeElement.shadowRoot) {
+      return getActiveElement$2(activeElement.shadowRoot);
+    } else {
+      if ((0, isDisabled_1.isDisabled)(activeElement)) {
+        return document2.ownerDocument ? (
+          // TODO: verify behavior in ShadowRoot
+          /* istanbul ignore next */
+          document2.ownerDocument.body
+        ) : document2.body;
+      }
+      return activeElement;
+    }
+  }
+  var getActiveElement_1 = /* @__PURE__ */ Object.defineProperty({
+    getActiveElement: getActiveElement_2
+  }, "__esModule", { value: true });
+  var isLabelWithInternallyDisabledControl_2 = isLabelWithInternallyDisabledControl$2;
+  function isLabelWithInternallyDisabledControl$2(element) {
+    if (!(0, isElementType_1.isElementType)(element, "label")) {
+      return false;
+    }
+    const control2 = element.control;
+    return Boolean(control2 && element.contains(control2) && (0, isDisabled_1.isDisabled)(control2));
+  }
+  var isLabelWithInternallyDisabledControl_1 = /* @__PURE__ */ Object.defineProperty({
+    isLabelWithInternallyDisabledControl: isLabelWithInternallyDisabledControl_2
+  }, "__esModule", { value: true });
+  var selector$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.FOCUSABLE_SELECTOR = void 0;
+    const FOCUSABLE_SELECTOR2 = ["input:not([type=hidden]):not([disabled])", "button:not([disabled])", "select:not([disabled])", "textarea:not([disabled])", '[contenteditable=""]', '[contenteditable="true"]', "a[href]", "[tabindex]:not([disabled])"].join(", ");
+    exports2.FOCUSABLE_SELECTOR = FOCUSABLE_SELECTOR2;
+  });
+  var isFocusable_2 = isFocusable$2;
+  function isFocusable$2(element) {
+    return !(0, isLabelWithInternallyDisabledControl_1.isLabelWithInternallyDisabledControl)(element) && element.matches(selector$1.FOCUSABLE_SELECTOR);
+  }
+  var isFocusable_1 = /* @__PURE__ */ Object.defineProperty({
+    isFocusable: isFocusable_2
+  }, "__esModule", { value: true });
+  var _dom$d = /* @__PURE__ */ getAugmentedNamespace$1(dom_esm$1);
+  var eventWrapper_2 = eventWrapper$2;
+  function eventWrapper$2(cb) {
+    let result;
+    (0, _dom$d.getConfig)().eventWrapper(() => {
+      result = cb();
+    });
+    return result;
+  }
+  var eventWrapper_1 = /* @__PURE__ */ Object.defineProperty({
+    eventWrapper: eventWrapper_2
+  }, "__esModule", { value: true });
+  var helpers$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.getWindowFromNode = getWindowFromNode2;
+    exports2.getDocument = getDocument2;
+    exports2.runWithRealTimers = runWithRealTimers2;
+    exports2.checkContainerType = checkContainerType2;
+    exports2.jestFakeTimersAreEnabled = jestFakeTimersAreEnabled2;
+    exports2.TEXT_NODE = exports2.setTimeout = exports2.setImmediate = exports2.clearTimeout = void 0;
+    const globalObj2 = typeof window === "undefined" ? global$1$1 : window;
+    const TEXT_NODE2 = 3;
+    exports2.TEXT_NODE = TEXT_NODE2;
+    function runWithRealTimers2(callback) {
+      return hasJestTimers2() ? runWithJestRealTimers2(callback).callbackReturnValue : (
+        // istanbul ignore next
+        callback()
+      );
+    }
+    function hasJestTimers2() {
+      return typeof jest !== "undefined" && jest !== null && typeof jest.useRealTimers === "function";
+    }
+    function runWithJestRealTimers2(callback) {
+      const timerAPI = {
+        clearInterval,
+        clearTimeout,
+        setInterval,
+        setTimeout
+      };
+      if (typeof setImmediate === "function") {
+        timerAPI.setImmediate = setImmediate;
+      }
+      if (typeof clearImmediate === "function") {
+        timerAPI.clearImmediate = clearImmediate;
+      }
+      jest.useRealTimers();
+      const callbackReturnValue = callback();
+      const usedFakeTimers = Object.entries(timerAPI).some(([name, func]) => func !== globalObj2[name]);
+      if (usedFakeTimers) {
+        var _timerAPI$setTimeout;
+        jest.useFakeTimers((_timerAPI$setTimeout = timerAPI.setTimeout) != null && _timerAPI$setTimeout.clock ? "modern" : "legacy");
+      }
+      return {
+        callbackReturnValue,
+        usedFakeTimers
+      };
+    }
+    function jestFakeTimersAreEnabled2() {
+      return hasJestTimers2() ? runWithJestRealTimers2(() => {
+      }).usedFakeTimers : (
+        // istanbul ignore next
+        false
+      );
+    }
+    function setImmediatePolyfill2(fn2) {
+      return globalObj2.setTimeout(fn2, 0);
+    }
+    function getTimeFunctions2() {
+      return {
+        clearTimeoutFn: globalObj2.clearTimeout,
+        setImmediateFn: globalObj2.setImmediate || setImmediatePolyfill2,
+        setTimeoutFn: globalObj2.setTimeout
+      };
+    }
+    const {
+      clearTimeoutFn: clearTimeoutFn2,
+      setImmediateFn: setImmediateFn2,
+      setTimeoutFn: setTimeoutFn2
+    } = runWithRealTimers2(getTimeFunctions2);
+    exports2.setTimeout = setTimeoutFn2;
+    exports2.setImmediate = setImmediateFn2;
+    exports2.clearTimeout = clearTimeoutFn2;
+    function getDocument2() {
+      if (typeof window === "undefined") {
+        throw new Error("Could not find default container");
+      }
+      return window.document;
+    }
+    function getWindowFromNode2(node) {
+      if (node.defaultView) {
+        return node.defaultView;
+      } else if (node.ownerDocument && node.ownerDocument.defaultView) {
+        return node.ownerDocument.defaultView;
+      } else if (node.window) {
+        return node.window;
+      } else if (node.then instanceof Function) {
+        throw new Error(`It looks like you passed a Promise object instead of a DOM node. Did you do something like \`fireEvent.click(screen.findBy...\` when you meant to use a \`getBy\` query \`fireEvent.click(screen.getBy...\`, or await the findBy query \`fireEvent.click(await screen.findBy...\`?`);
+      } else if (Array.isArray(node)) {
+        throw new Error(`It looks like you passed an Array instead of a DOM node. Did you do something like \`fireEvent.click(screen.getAllBy...\` when you meant to use a \`getBy\` query \`fireEvent.click(screen.getBy...\`?`);
+      } else if (typeof node.debug === "function" && typeof node.logTestingPlaygroundURL === "function") {
+        throw new Error(`It looks like you passed a \`screen\` object. Did you do something like \`fireEvent.click(screen, ...\` when you meant to use a query, e.g. \`fireEvent.click(screen.getBy..., \`?`);
+      } else {
+        throw new Error(`Unable to find the "window" object for the given node. Please file an issue with the code that's causing you to see this error: https://github.com/testing-library/dom-testing-library/issues/new`);
+      }
+    }
+    function checkContainerType2(container) {
+      if (!container || !(typeof container.querySelector === "function") || !(typeof container.querySelectorAll === "function")) {
+        throw new TypeError(`Expected container to be an Element, a Document or a DocumentFragment but got ${getTypeName(container)}.`);
+      }
+      function getTypeName(object) {
+        if (typeof object === "object") {
+          return object === null ? "null" : object.constructor.name;
+        }
+        return typeof object;
+      }
+    }
+  });
+  var isVisible_2 = isVisible$2;
+  function isVisible$2(element) {
+    const window2 = (0, helpers$1.getWindowFromNode)(element);
+    for (let el = element; (_el = el) != null && _el.ownerDocument; el = el.parentElement) {
+      var _el;
+      const display = window2.getComputedStyle(el).display;
+      if (display === "none") {
+        return false;
+      }
+    }
+    return true;
+  }
+  var isVisible_1 = /* @__PURE__ */ Object.defineProperty({
+    isVisible: isVisible_2
+  }, "__esModule", { value: true });
+  var isDocument_2 = isDocument$2;
+  function isDocument$2(el) {
+    return el.nodeType === el.DOCUMENT_NODE;
+  }
+  var isDocument_1 = /* @__PURE__ */ Object.defineProperty({
+    isDocument: isDocument_2
+  }, "__esModule", { value: true });
+  var wait_2 = wait$2;
+  function wait$2(time) {
+    return new Promise((resolve) => setTimeout(() => resolve(), time));
+  }
+  var wait_1 = /* @__PURE__ */ Object.defineProperty({
+    wait: wait_2
+  }, "__esModule", { value: true });
+  var hasPointerEvents_2 = hasPointerEvents$2;
+  function hasPointerEvents$2(element) {
+    const window2 = (0, helpers$1.getWindowFromNode)(element);
+    for (let el = element; (_el = el) != null && _el.ownerDocument; el = el.parentElement) {
+      var _el;
+      const pointerEvents = window2.getComputedStyle(el).pointerEvents;
+      if (pointerEvents && !["inherit", "unset"].includes(pointerEvents)) {
+        return pointerEvents !== "none";
+      }
+    }
+    return true;
+  }
+  var hasPointerEvents_1 = /* @__PURE__ */ Object.defineProperty({
+    hasPointerEvents: hasPointerEvents_2
+  }, "__esModule", { value: true });
+  var hasFormSubmit_1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.hasFormSubmit = void 0;
+    const hasFormSubmit2 = (form) => !!(form && (form.querySelector('input[type="submit"]') || form.querySelector('button[type="submit"]')));
+    exports2.hasFormSubmit = hasFormSubmit2;
+  });
+  var utils$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    Object.keys(getMouseEventOptions_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === getMouseEventOptions_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return getMouseEventOptions_1[key2];
+        }
+      });
+    });
+    Object.keys(isClickableInput_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === isClickableInput_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return isClickableInput_1[key2];
+        }
+      });
+    });
+    Object.keys(buildTimeValue_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === buildTimeValue_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return buildTimeValue_1[key2];
+        }
+      });
+    });
+    Object.keys(calculateNewValue_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === calculateNewValue_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return calculateNewValue_1[key2];
+        }
+      });
+    });
+    Object.keys(cursorPosition$1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === cursorPosition$1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return cursorPosition$1[key2];
+        }
+      });
+    });
+    Object.keys(getValue_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === getValue_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return getValue_1[key2];
+        }
+      });
+    });
+    Object.keys(hasUnreliableEmptyValue_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === hasUnreliableEmptyValue_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return hasUnreliableEmptyValue_1[key2];
+        }
+      });
+    });
+    Object.keys(isContentEditable_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === isContentEditable_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return isContentEditable_1[key2];
+        }
+      });
+    });
+    Object.keys(isEditable_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === isEditable_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return isEditable_1[key2];
+        }
+      });
+    });
+    Object.keys(isValidDateValue_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === isValidDateValue_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return isValidDateValue_1[key2];
+        }
+      });
+    });
+    Object.keys(isValidInputTimeValue_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === isValidInputTimeValue_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return isValidInputTimeValue_1[key2];
+        }
+      });
+    });
+    Object.keys(maxLength$1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === maxLength$1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return maxLength$1[key2];
+        }
+      });
+    });
+    Object.keys(selectionRange$1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === selectionRange$1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return selectionRange$1[key2];
+        }
+      });
+    });
+    Object.keys(getActiveElement_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === getActiveElement_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return getActiveElement_1[key2];
+        }
+      });
+    });
+    Object.keys(isFocusable_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === isFocusable_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return isFocusable_1[key2];
+        }
+      });
+    });
+    Object.keys(selector$1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === selector$1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return selector$1[key2];
+        }
+      });
+    });
+    Object.keys(eventWrapper_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === eventWrapper_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return eventWrapper_1[key2];
+        }
+      });
+    });
+    Object.keys(isElementType_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === isElementType_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return isElementType_1[key2];
+        }
+      });
+    });
+    Object.keys(isLabelWithInternallyDisabledControl_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === isLabelWithInternallyDisabledControl_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return isLabelWithInternallyDisabledControl_1[key2];
+        }
+      });
+    });
+    Object.keys(isVisible_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === isVisible_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return isVisible_1[key2];
+        }
+      });
+    });
+    Object.keys(isDisabled_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === isDisabled_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return isDisabled_1[key2];
+        }
+      });
+    });
+    Object.keys(isDocument_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === isDocument_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return isDocument_1[key2];
+        }
+      });
+    });
+    Object.keys(wait_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === wait_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return wait_1[key2];
+        }
+      });
+    });
+    Object.keys(hasPointerEvents_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === hasPointerEvents_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return hasPointerEvents_1[key2];
+        }
+      });
+    });
+    Object.keys(hasFormSubmit_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === hasFormSubmit_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return hasFormSubmit_1[key2];
+        }
+      });
+    });
+  });
+  var hover_2 = hover$2;
+  var unhover_1 = unhover$1;
+  function getParentElements$1(element) {
+    const parentElements = [element];
+    let currentElement = element;
+    while ((currentElement = currentElement.parentElement) != null) {
+      parentElements.push(currentElement);
+    }
+    return parentElements;
+  }
+  function hover$2(element, init, {
+    skipPointerEventsCheck = false
+  } = {}) {
+    if (!skipPointerEventsCheck && !(0, utils$1.hasPointerEvents)(element)) {
+      throw new Error('unable to hover element as it has or inherits pointer-events set to "none".');
+    }
+    if ((0, utils$1.isLabelWithInternallyDisabledControl)(element)) return;
+    const parentElements = getParentElements$1(element).reverse();
+    _dom$d.fireEvent.pointerOver(element, init);
+    for (const el of parentElements) {
+      _dom$d.fireEvent.pointerEnter(el, init);
+    }
+    if (!(0, utils$1.isDisabled)(element)) {
+      _dom$d.fireEvent.mouseOver(element, (0, utils$1.getMouseEventOptions)("mouseover", init));
+      for (const el of parentElements) {
+        _dom$d.fireEvent.mouseEnter(el, (0, utils$1.getMouseEventOptions)("mouseenter", init));
+      }
+    }
+    _dom$d.fireEvent.pointerMove(element, init);
+    if (!(0, utils$1.isDisabled)(element)) {
+      _dom$d.fireEvent.mouseMove(element, (0, utils$1.getMouseEventOptions)("mousemove", init));
+    }
+  }
+  function unhover$1(element, init, {
+    skipPointerEventsCheck = false
+  } = {}) {
+    if (!skipPointerEventsCheck && !(0, utils$1.hasPointerEvents)(element)) {
+      throw new Error('unable to unhover element as it has or inherits pointer-events set to "none".');
+    }
+    if ((0, utils$1.isLabelWithInternallyDisabledControl)(element)) return;
+    const parentElements = getParentElements$1(element);
+    _dom$d.fireEvent.pointerMove(element, init);
+    if (!(0, utils$1.isDisabled)(element)) {
+      _dom$d.fireEvent.mouseMove(element, (0, utils$1.getMouseEventOptions)("mousemove", init));
+    }
+    _dom$d.fireEvent.pointerOut(element, init);
+    for (const el of parentElements) {
+      _dom$d.fireEvent.pointerLeave(el, init);
+    }
+    if (!(0, utils$1.isDisabled)(element)) {
+      _dom$d.fireEvent.mouseOut(element, (0, utils$1.getMouseEventOptions)("mouseout", init));
+      for (const el of parentElements) {
+        _dom$d.fireEvent.mouseLeave(el, (0, utils$1.getMouseEventOptions)("mouseleave", init));
+      }
+    }
+  }
+  var hover_1 = /* @__PURE__ */ Object.defineProperty({
+    hover: hover_2,
+    unhover: unhover_1
+  }, "__esModule", { value: true });
+  var blur_2 = blur$3;
+  function blur$3(element) {
+    if (!(0, utils$1.isFocusable)(element)) return;
+    const wasActive = (0, utils$1.getActiveElement)(element.ownerDocument) === element;
+    if (!wasActive) return;
+    (0, utils$1.eventWrapper)(() => element.blur());
+  }
+  var blur_1 = /* @__PURE__ */ Object.defineProperty({
+    blur: blur_2
+  }, "__esModule", { value: true });
+  var focus_2 = focus$3;
+  function focus$3(element) {
+    if (!(0, utils$1.isFocusable)(element)) return;
+    const isAlreadyActive = (0, utils$1.getActiveElement)(element.ownerDocument) === element;
+    if (isAlreadyActive) return;
+    (0, utils$1.eventWrapper)(() => element.focus());
+  }
+  var focus_1 = /* @__PURE__ */ Object.defineProperty({
+    focus: focus_2
+  }, "__esModule", { value: true });
+  var click_2 = click$2;
+  var dblClick_1 = dblClick$1;
+  function getPreviouslyFocusedElement$1(element) {
+    const focusedElement = element.ownerDocument.activeElement;
+    const wasAnotherElementFocused = focusedElement && focusedElement !== element.ownerDocument.body && focusedElement !== element;
+    return wasAnotherElementFocused ? focusedElement : null;
+  }
+  function clickLabel$1(label, init, {
+    clickCount
+  }) {
+    if ((0, utils$1.isLabelWithInternallyDisabledControl)(label)) return;
+    _dom$d.fireEvent.pointerDown(label, init);
+    _dom$d.fireEvent.mouseDown(label, (0, utils$1.getMouseEventOptions)("mousedown", init, clickCount));
+    _dom$d.fireEvent.pointerUp(label, init);
+    _dom$d.fireEvent.mouseUp(label, (0, utils$1.getMouseEventOptions)("mouseup", init, clickCount));
+    fireClick$1(label, (0, utils$1.getMouseEventOptions)("click", init, clickCount));
+    if (label.control) (0, focus_1.focus)(label.control);
+  }
+  function clickBooleanElement$1(element, init, {
+    clickCount
+  }) {
+    _dom$d.fireEvent.pointerDown(element, init);
+    if (!element.disabled) {
+      _dom$d.fireEvent.mouseDown(element, (0, utils$1.getMouseEventOptions)("mousedown", init, clickCount));
+    }
+    (0, focus_1.focus)(element);
+    _dom$d.fireEvent.pointerUp(element, init);
+    if (!element.disabled) {
+      _dom$d.fireEvent.mouseUp(element, (0, utils$1.getMouseEventOptions)("mouseup", init, clickCount));
+      fireClick$1(element, (0, utils$1.getMouseEventOptions)("click", init, clickCount));
+    }
+  }
+  function clickElement$1(element, init, {
+    clickCount
+  }) {
+    const previousElement = getPreviouslyFocusedElement$1(element);
+    _dom$d.fireEvent.pointerDown(element, init);
+    if (!(0, utils$1.isDisabled)(element)) {
+      const continueDefaultHandling = _dom$d.fireEvent.mouseDown(element, (0, utils$1.getMouseEventOptions)("mousedown", init, clickCount));
+      if (continueDefaultHandling) {
+        const closestFocusable = findClosest$1(element, utils$1.isFocusable);
+        if (previousElement && !closestFocusable) {
+          (0, blur_1.blur)(previousElement);
+        } else if (closestFocusable) {
+          (0, focus_1.focus)(closestFocusable);
+        }
+      }
+    }
+    _dom$d.fireEvent.pointerUp(element, init);
+    if (!(0, utils$1.isDisabled)(element)) {
+      _dom$d.fireEvent.mouseUp(element, (0, utils$1.getMouseEventOptions)("mouseup", init, clickCount));
+      fireClick$1(element, (0, utils$1.getMouseEventOptions)("click", init, clickCount));
+      const parentLabel = element.closest("label");
+      if (parentLabel != null && parentLabel.control) (0, focus_1.focus)(parentLabel.control);
+    }
+  }
+  function findClosest$1(element, callback) {
+    let el = element;
+    do {
+      if (callback(el)) {
+        return el;
+      }
+      el = el.parentElement;
+    } while (el && el !== element.ownerDocument.body);
+    return void 0;
+  }
+  function click$2(element, init, {
+    skipHover = false,
+    clickCount = 0,
+    skipPointerEventsCheck = false
+  } = {}) {
+    if (!skipPointerEventsCheck && !(0, utils$1.hasPointerEvents)(element)) {
+      throw new Error('unable to click element as it has or inherits pointer-events set to "none".');
+    }
+    if (!skipHover) (0, hover_1.hover)(element, init, {
+      skipPointerEventsCheck: true
+    });
+    if ((0, utils$1.isElementType)(element, "label")) {
+      clickLabel$1(element, init, {
+        clickCount
+      });
+    } else if ((0, utils$1.isElementType)(element, "input")) {
+      if (element.type === "checkbox" || element.type === "radio") {
+        clickBooleanElement$1(element, init, {
+          clickCount
+        });
+      } else {
+        clickElement$1(element, init, {
+          clickCount
+        });
+      }
+    } else {
+      clickElement$1(element, init, {
+        clickCount
+      });
+    }
+  }
+  function fireClick$1(element, mouseEventOptions) {
+    if (mouseEventOptions.button === 2) {
+      _dom$d.fireEvent.contextMenu(element, mouseEventOptions);
+    } else {
+      _dom$d.fireEvent.click(element, mouseEventOptions);
+    }
+  }
+  function dblClick$1(element, init, {
+    skipPointerEventsCheck = false
+  } = {}) {
+    if (!skipPointerEventsCheck && !(0, utils$1.hasPointerEvents)(element)) {
+      throw new Error('unable to double-click element as it has or inherits pointer-events set to "none".');
+    }
+    (0, hover_1.hover)(element, init, {
+      skipPointerEventsCheck
+    });
+    click$2(element, init, {
+      skipHover: true,
+      clickCount: 0,
+      skipPointerEventsCheck
+    });
+    click$2(element, init, {
+      skipHover: true,
+      clickCount: 1,
+      skipPointerEventsCheck
+    });
+    _dom$d.fireEvent.dblClick(element, (0, utils$1.getMouseEventOptions)("dblclick", init, 2));
+  }
+  var click_1 = /* @__PURE__ */ Object.defineProperty({
+    click: click_2,
+    dblClick: dblClick_1
+  }, "__esModule", { value: true });
+  var getNextKeyDef_2 = getNextKeyDef$2;
+  var bracketDict$1;
+  (function(bracketDict2) {
+    bracketDict2["{"] = "}";
+    bracketDict2["["] = "]";
+  })(bracketDict$1 || (bracketDict$1 = {}));
+  var legacyModifiers$1;
+  (function(legacyModifiers2) {
+    legacyModifiers2["alt"] = "alt";
+    legacyModifiers2["ctrl"] = "ctrl";
+    legacyModifiers2["meta"] = "meta";
+    legacyModifiers2["shift"] = "shift";
+  })(legacyModifiers$1 || (legacyModifiers$1 = {}));
+  var legacyKeyMap$1;
+  (function(legacyKeyMap2) {
+    legacyKeyMap2["ctrl"] = "Control";
+    legacyKeyMap2["del"] = "Delete";
+    legacyKeyMap2["esc"] = "Escape";
+    legacyKeyMap2["space"] = " ";
+  })(legacyKeyMap$1 || (legacyKeyMap$1 = {}));
+  function getNextKeyDef$2(text, options) {
+    var _options$keyboardMap$;
+    const {
+      type: type2,
+      descriptor,
+      consumedLength,
+      releasePrevious,
+      releaseSelf,
+      repeat: repeat2
+    } = readNextDescriptor$1(text);
+    const keyDef = (_options$keyboardMap$ = options.keyboardMap.find((def) => {
+      if (type2 === "[") {
+        var _def$code;
+        return ((_def$code = def.code) == null ? void 0 : _def$code.toLowerCase()) === descriptor.toLowerCase();
+      } else if (type2 === "{") {
+        var _def$key;
+        const key2 = mapLegacyKey$1(descriptor);
+        return ((_def$key = def.key) == null ? void 0 : _def$key.toLowerCase()) === key2.toLowerCase();
+      }
+      return def.key === descriptor;
+    })) != null ? _options$keyboardMap$ : {
+      key: "Unknown",
+      code: "Unknown",
+      [type2 === "[" ? "code" : "key"]: descriptor
+    };
+    return {
+      keyDef,
+      consumedLength,
+      releasePrevious,
+      releaseSelf,
+      repeat: repeat2
+    };
+  }
+  function readNextDescriptor$1(text) {
+    let pos = 0;
+    const startBracket = text[pos] in bracketDict$1 ? text[pos] : "";
+    pos += startBracket.length;
+    const startBracketRepeated = startBracket ? text.match(new RegExp(`^\\${startBracket}+`))[0].length : 0;
+    const isEscapedChar = startBracketRepeated === 2 || startBracket === "{" && startBracketRepeated > 3;
+    const type2 = isEscapedChar ? "" : startBracket;
+    return {
+      type: type2,
+      ...type2 === "" ? readPrintableChar$1(text, pos) : readTag$1(text, pos, type2)
+    };
+  }
+  function readPrintableChar$1(text, pos) {
+    const descriptor = text[pos];
+    assertDescriptor$1(descriptor, text, pos);
+    pos += descriptor.length;
+    return {
+      consumedLength: pos,
+      descriptor,
+      releasePrevious: false,
+      releaseSelf: true,
+      repeat: 1
+    };
+  }
+  function readTag$1(text, pos, startBracket) {
+    var _text$slice$match, _text$slice$match$, _text$slice$match2;
+    const releasePreviousModifier = text[pos] === "/" ? "/" : "";
+    pos += releasePreviousModifier.length;
+    const descriptor = (_text$slice$match = text.slice(pos).match(/^\w+/)) == null ? void 0 : _text$slice$match[0];
+    assertDescriptor$1(descriptor, text, pos);
+    pos += descriptor.length;
+    const repeatModifier = (_text$slice$match$ = (_text$slice$match2 = text.slice(pos).match(/^>\d+/)) == null ? void 0 : _text$slice$match2[0]) != null ? _text$slice$match$ : "";
+    pos += repeatModifier.length;
+    const releaseSelfModifier = text[pos] === "/" || !repeatModifier && text[pos] === ">" ? text[pos] : "";
+    pos += releaseSelfModifier.length;
+    const expectedEndBracket = bracketDict$1[startBracket];
+    const endBracket = text[pos] === expectedEndBracket ? expectedEndBracket : "";
+    if (!endBracket) {
+      throw new Error(getErrorMessage$1([!repeatModifier && "repeat modifier", !releaseSelfModifier && "release modifier", `"${expectedEndBracket}"`].filter(Boolean).join(" or "), text[pos], text));
+    }
+    pos += endBracket.length;
+    return {
+      consumedLength: pos,
+      descriptor,
+      releasePrevious: !!releasePreviousModifier,
+      repeat: repeatModifier ? Math.max(Number(repeatModifier.substr(1)), 1) : 1,
+      releaseSelf: hasReleaseSelf$1(startBracket, descriptor, releaseSelfModifier, repeatModifier)
+    };
+  }
+  function assertDescriptor$1(descriptor, text, pos) {
+    if (!descriptor) {
+      throw new Error(getErrorMessage$1("key descriptor", text[pos], text));
+    }
+  }
+  function getEnumValue$1(f2, key2) {
+    return f2[key2];
+  }
+  function hasReleaseSelf$1(startBracket, descriptor, releaseSelfModifier, repeatModifier) {
+    if (releaseSelfModifier) {
+      return releaseSelfModifier === "/";
+    }
+    if (repeatModifier) {
+      return false;
+    }
+    if (startBracket === "{" && getEnumValue$1(legacyModifiers$1, descriptor.toLowerCase())) {
+      return false;
+    }
+    return true;
+  }
+  function mapLegacyKey$1(descriptor) {
+    var _getEnumValue;
+    return (_getEnumValue = getEnumValue$1(legacyKeyMap$1, descriptor)) != null ? _getEnumValue : descriptor;
+  }
+  function getErrorMessage$1(expected, found, text) {
+    return `Expected ${expected} but found "${found != null ? found : ""}" in "${text}"
+    See https://github.com/testing-library/user-event/blob/main/README.md#keyboardtext-options
+    for more information about how userEvent parses your input.`;
+  }
+  var getNextKeyDef_1 = /* @__PURE__ */ Object.defineProperty({
+    getNextKeyDef: getNextKeyDef_2
+  }, "__esModule", { value: true });
+  var arrow$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.keydownBehavior = void 0;
+    const keydownBehavior2 = [{
+      // TODO: implement for contentEditable
+      matches: (keyDef, element) => (keyDef.key === "ArrowLeft" || keyDef.key === "ArrowRight") && (0, utils$1.isElementType)(element, ["input", "textarea"]),
+      handle: (keyDef, element) => {
+        var _ref;
+        const {
+          selectionStart,
+          selectionEnd
+        } = (0, utils$1.getSelectionRange)(element);
+        const direction = keyDef.key === "ArrowLeft" ? -1 : 1;
+        const newPos = (_ref = selectionStart === selectionEnd ? (selectionStart != null ? selectionStart : (
+          /* istanbul ignore next */
+          0
+        )) + direction : direction < 0 ? selectionStart : selectionEnd) != null ? _ref : (
+          /* istanbul ignore next */
+          0
+        );
+        (0, utils$1.setSelectionRange)(element, newPos, newPos);
+      }
+    }];
+    exports2.keydownBehavior = keydownBehavior2;
+  });
+  var carryValue_2 = carryValue$2;
+  function carryValue$2(element, state, newValue) {
+    const value = (0, utils$1.getValue)(element);
+    state.carryValue = value !== newValue && value === "" && (0, utils$1.hasUnreliableEmptyValue)(element) ? newValue : void 0;
+  }
+  var carryValue_1 = /* @__PURE__ */ Object.defineProperty({
+    carryValue: carryValue_2
+  }, "__esModule", { value: true });
+  var fireChangeForInputTimeIfValid_2 = fireChangeForInputTimeIfValid$2;
+  function fireChangeForInputTimeIfValid$2(el, prevValue, timeNewEntry) {
+    if ((0, utils$1.isValidInputTimeValue)(el, timeNewEntry) && prevValue !== timeNewEntry) {
+      _dom$d.fireEvent.change(el, {
+        target: {
+          value: timeNewEntry
+        }
+      });
+    }
+  }
+  var fireChangeForInputTimeIfValid_1 = /* @__PURE__ */ Object.defineProperty({
+    fireChangeForInputTimeIfValid: fireChangeForInputTimeIfValid_2
+  }, "__esModule", { value: true });
+  var fireInputEvent_2 = fireInputEvent$2;
+  function fireInputEvent$2(element, {
+    newValue,
+    newSelectionStart,
+    eventOverrides
+  }) {
+    if ((0, utils$1.isContentEditable)(element)) {
+      applyNative$1(element, "textContent", newValue);
+    } else if ((0, utils$1.isElementType)(element, ["input", "textarea"])) {
+      applyNative$1(element, "value", newValue);
+    } else {
+      throw new Error("Invalid Element");
+    }
+    setSelectionRangeAfterInput$1(element, newSelectionStart);
+    _dom$d.fireEvent.input(element, {
+      ...eventOverrides
+    });
+    setSelectionRangeAfterInputHandler$1(element, newValue, newSelectionStart);
+  }
+  function setSelectionRangeAfterInput$1(element, newSelectionStart) {
+    (0, utils$1.setSelectionRange)(element, newSelectionStart, newSelectionStart);
+  }
+  function setSelectionRangeAfterInputHandler$1(element, newValue, newSelectionStart) {
+    const value = (0, utils$1.getValue)(element);
+    const isUnreliableValue = value === "" && (0, utils$1.hasUnreliableEmptyValue)(element);
+    if (!isUnreliableValue && value === newValue) {
+      const {
+        selectionStart
+      } = (0, utils$1.getSelectionRange)(element);
+      if (selectionStart === value.length) {
+        (0, utils$1.setSelectionRange)(element, newSelectionStart, newSelectionStart);
+      }
+    }
+  }
+  const initial$1 = Symbol("initial input value/textContent");
+  const onBlur$1 = Symbol("onBlur");
+  function applyNative$1(element, propName, propValue) {
+    const descriptor = Object.getOwnPropertyDescriptor(element, propName);
+    const nativeDescriptor = Object.getOwnPropertyDescriptor(element.constructor.prototype, propName);
+    if (descriptor && nativeDescriptor) {
+      Object.defineProperty(element, propName, nativeDescriptor);
+    }
+    if (element[initial$1] === void 0) {
+      element[initial$1] = String(element[propName]);
+    }
+    element[propName] = propValue;
+    if (!element[onBlur$1]) {
+      var _element$ownerDocumen;
+      (_element$ownerDocumen = element.ownerDocument.defaultView) == null ? void 0 : _element$ownerDocumen.addEventListener("blur", element[onBlur$1] = () => {
+        const initV = element[initial$1];
+        delete element[onBlur$1];
+        delete element[initial$1];
+        if (String(element[propName]) !== initV) {
+          _dom$d.fireEvent.change(element);
+        }
+      }, {
+        capture: true,
+        once: true
+      });
+    }
+    if (descriptor) {
+      Object.defineProperty(element, propName, descriptor);
+    }
+  }
+  var fireInputEvent_1 = /* @__PURE__ */ Object.defineProperty({
+    fireInputEvent: fireInputEvent_2
+  }, "__esModule", { value: true });
+  var shared$3 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    Object.keys(carryValue_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === carryValue_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return carryValue_1[key2];
+        }
+      });
+    });
+    Object.keys(fireChangeForInputTimeIfValid_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === fireChangeForInputTimeIfValid_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return fireChangeForInputTimeIfValid_1[key2];
+        }
+      });
+    });
+    Object.keys(fireInputEvent_1).forEach(function(key2) {
+      if (key2 === "default" || key2 === "__esModule") return;
+      if (key2 in exports2 && exports2[key2] === fireInputEvent_1[key2]) return;
+      Object.defineProperty(exports2, key2, {
+        enumerable: true,
+        get: function() {
+          return fireInputEvent_1[key2];
+        }
+      });
+    });
+  });
+  var control$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.keydownBehavior = void 0;
+    const keydownBehavior2 = [{
+      matches: (keyDef, element) => (keyDef.key === "Home" || keyDef.key === "End") && ((0, utils$1.isElementType)(element, ["input", "textarea"]) || (0, utils$1.isContentEditable)(element)),
+      handle: (keyDef, element) => {
+        if (keyDef.key === "Home") {
+          (0, utils$1.setSelectionRange)(element, 0, 0);
+        } else {
+          var _getValue$length, _getValue3;
+          const newPos = (_getValue$length = (_getValue3 = (0, utils$1.getValue)(element)) == null ? void 0 : _getValue3.length) != null ? _getValue$length : (
+            /* istanbul ignore next */
+            0
+          );
+          (0, utils$1.setSelectionRange)(element, newPos, newPos);
+        }
+      }
+    }, {
+      matches: (keyDef, element) => (keyDef.key === "PageUp" || keyDef.key === "PageDown") && (0, utils$1.isElementType)(element, ["input"]),
+      handle: (keyDef, element) => {
+        if (keyDef.key === "PageUp") {
+          (0, utils$1.setSelectionRange)(element, 0, 0);
+        } else {
+          var _getValue$length2, _getValue22;
+          const newPos = (_getValue$length2 = (_getValue22 = (0, utils$1.getValue)(element)) == null ? void 0 : _getValue22.length) != null ? _getValue$length2 : (
+            /* istanbul ignore next */
+            0
+          );
+          (0, utils$1.setSelectionRange)(element, newPos, newPos);
+        }
+      }
+    }, {
+      matches: (keyDef, element) => keyDef.key === "Delete" && (0, utils$1.isEditable)(element) && !(0, utils$1.isCursorAtEnd)(element),
+      handle: (keDef, element, options, state) => {
+        const {
+          newValue,
+          newSelectionStart
+        } = (0, utils$1.calculateNewValue)("", element, state.carryValue, void 0, "forward");
+        (0, shared$3.fireInputEvent)(element, {
+          newValue,
+          newSelectionStart,
+          eventOverrides: {
+            inputType: "deleteContentForward"
+          }
+        });
+        (0, shared$3.carryValue)(element, state, newValue);
+      }
+    }];
+    exports2.keydownBehavior = keydownBehavior2;
+  });
+  var character$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.keypressBehavior = void 0;
+    const keypressBehavior2 = [{
+      matches: (keyDef, element) => {
+        var _keyDef$key;
+        return ((_keyDef$key = keyDef.key) == null ? void 0 : _keyDef$key.length) === 1 && (0, utils$1.isElementType)(element, "input", {
+          type: "time",
+          readOnly: false
+        });
+      },
+      handle: (keyDef, element, options, state) => {
+        var _state$carryValue;
+        let newEntry = keyDef.key;
+        const textToBeTyped = ((_state$carryValue = state.carryValue) != null ? _state$carryValue : "") + newEntry;
+        const timeNewEntry = (0, utils$1.buildTimeValue)(textToBeTyped);
+        if ((0, utils$1.isValidInputTimeValue)(element, timeNewEntry)) {
+          newEntry = timeNewEntry;
+        }
+        const {
+          newValue,
+          newSelectionStart
+        } = (0, utils$1.calculateNewValue)(newEntry, element);
+        const prevValue = (0, utils$1.getValue)(element);
+        if (prevValue !== newValue) {
+          (0, shared$3.fireInputEvent)(element, {
+            newValue,
+            newSelectionStart,
+            eventOverrides: {
+              data: keyDef.key,
+              inputType: "insertText"
+            }
+          });
+        }
+        (0, shared$3.fireChangeForInputTimeIfValid)(element, prevValue, timeNewEntry);
+        state.carryValue = textToBeTyped;
+      }
+    }, {
+      matches: (keyDef, element) => {
+        var _keyDef$key2;
+        return ((_keyDef$key2 = keyDef.key) == null ? void 0 : _keyDef$key2.length) === 1 && (0, utils$1.isElementType)(element, "input", {
+          type: "date",
+          readOnly: false
+        });
+      },
+      handle: (keyDef, element, options, state) => {
+        var _state$carryValue2;
+        let newEntry = keyDef.key;
+        const textToBeTyped = ((_state$carryValue2 = state.carryValue) != null ? _state$carryValue2 : "") + newEntry;
+        const isValidToBeTyped = (0, utils$1.isValidDateValue)(element, textToBeTyped);
+        if (isValidToBeTyped) {
+          newEntry = textToBeTyped;
+        }
+        const {
+          newValue,
+          newSelectionStart
+        } = (0, utils$1.calculateNewValue)(newEntry, element);
+        const prevValue = (0, utils$1.getValue)(element);
+        if (prevValue !== newValue) {
+          (0, shared$3.fireInputEvent)(element, {
+            newValue,
+            newSelectionStart,
+            eventOverrides: {
+              data: keyDef.key,
+              inputType: "insertText"
+            }
+          });
+        }
+        if (isValidToBeTyped) {
+          _dom$d.fireEvent.change(element, {
+            target: {
+              value: textToBeTyped
+            }
+          });
+        }
+        state.carryValue = textToBeTyped;
+      }
+    }, {
+      matches: (keyDef, element) => {
+        var _keyDef$key3;
+        return ((_keyDef$key3 = keyDef.key) == null ? void 0 : _keyDef$key3.length) === 1 && (0, utils$1.isElementType)(element, "input", {
+          type: "number",
+          readOnly: false
+        });
+      },
+      handle: (keyDef, element, options, state) => {
+        var _ref, _state$carryValue3, _newValue$match, _newValue$match2;
+        if (!/[\d.\-e]/.test(keyDef.key)) {
+          return;
+        }
+        const oldValue = (_ref = (_state$carryValue3 = state.carryValue) != null ? _state$carryValue3 : (0, utils$1.getValue)(element)) != null ? _ref : (
+          /* istanbul ignore next */
+          ""
+        );
+        const {
+          newValue,
+          newSelectionStart
+        } = (0, utils$1.calculateNewValue)(keyDef.key, element, oldValue);
+        const valueParts = newValue.split("e", 2);
+        if (Number((_newValue$match = newValue.match(/-/g)) == null ? void 0 : _newValue$match.length) > 2 || Number((_newValue$match2 = newValue.match(/\./g)) == null ? void 0 : _newValue$match2.length) > 1 || valueParts[1] && !/^-?\d*$/.test(valueParts[1])) {
+          return;
+        }
+        (0, shared$3.fireInputEvent)(element, {
+          newValue,
+          newSelectionStart,
+          eventOverrides: {
+            data: keyDef.key,
+            inputType: "insertText"
+          }
+        });
+        const appliedValue = (0, utils$1.getValue)(element);
+        if (appliedValue === newValue) {
+          state.carryValue = void 0;
+        } else {
+          state.carryValue = newValue;
+        }
+      }
+    }, {
+      matches: (keyDef, element) => {
+        var _keyDef$key4;
+        return ((_keyDef$key4 = keyDef.key) == null ? void 0 : _keyDef$key4.length) === 1 && ((0, utils$1.isElementType)(element, ["input", "textarea"], {
+          readOnly: false
+        }) && !(0, utils$1.isClickableInput)(element) || (0, utils$1.isContentEditable)(element)) && (0, utils$1.getSpaceUntilMaxLength)(element) !== 0;
+      },
+      handle: (keyDef, element) => {
+        const {
+          newValue,
+          newSelectionStart
+        } = (0, utils$1.calculateNewValue)(keyDef.key, element);
+        (0, shared$3.fireInputEvent)(element, {
+          newValue,
+          newSelectionStart,
+          eventOverrides: {
+            data: keyDef.key,
+            inputType: "insertText"
+          }
+        });
+      }
+    }, {
+      matches: (keyDef, element) => keyDef.key === "Enter" && ((0, utils$1.isElementType)(element, "textarea", {
+        readOnly: false
+      }) || (0, utils$1.isContentEditable)(element)) && (0, utils$1.getSpaceUntilMaxLength)(element) !== 0,
+      handle: (keyDef, element, options, state) => {
+        const {
+          newValue,
+          newSelectionStart
+        } = (0, utils$1.calculateNewValue)("\n", element);
+        const inputType = (0, utils$1.isContentEditable)(element) && !state.modifiers.shift ? "insertParagraph" : "insertLineBreak";
+        (0, shared$3.fireInputEvent)(element, {
+          newValue,
+          newSelectionStart,
+          eventOverrides: {
+            inputType
+          }
+        });
+      }
+    }];
+    exports2.keypressBehavior = keypressBehavior2;
+  });
+  var getKeyEventProps_1 = getKeyEventProps$1;
+  var getMouseEventProps_1 = getMouseEventProps$1;
+  function getKeyEventProps$1(keyDef, state) {
+    var _keyDef$keyCode, _keyDef$key;
+    return {
+      key: keyDef.key,
+      code: keyDef.code,
+      altKey: state.modifiers.alt,
+      ctrlKey: state.modifiers.ctrl,
+      metaKey: state.modifiers.meta,
+      shiftKey: state.modifiers.shift,
+      /** @deprecated use code instead */
+      keyCode: (_keyDef$keyCode = keyDef.keyCode) != null ? _keyDef$keyCode : (
+        // istanbul ignore next
+        ((_keyDef$key = keyDef.key) == null ? void 0 : _keyDef$key.length) === 1 ? keyDef.key.charCodeAt(0) : void 0
+      )
+    };
+  }
+  function getMouseEventProps$1(state) {
+    return {
+      altKey: state.modifiers.alt,
+      ctrlKey: state.modifiers.ctrl,
+      metaKey: state.modifiers.meta,
+      shiftKey: state.modifiers.shift
+    };
+  }
+  var getEventProps$1 = /* @__PURE__ */ Object.defineProperty({
+    getKeyEventProps: getKeyEventProps_1,
+    getMouseEventProps: getMouseEventProps_1
+  }, "__esModule", { value: true });
+  var functional$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.preKeyupBehavior = exports2.preKeydownBehavior = exports2.postKeyupBehavior = exports2.keyupBehavior = exports2.keypressBehavior = exports2.keydownBehavior = void 0;
+    const modifierKeys2 = {
+      Alt: "alt",
+      Control: "ctrl",
+      Shift: "shift",
+      Meta: "meta"
+    };
+    const preKeydownBehavior2 = [
+      // modifierKeys switch on the modifier BEFORE the keydown event
+      ...Object.entries(modifierKeys2).map(([key2, modKey]) => ({
+        matches: (keyDef) => keyDef.key === key2,
+        handle: (keyDef, element, options, state) => {
+          state.modifiers[modKey] = true;
+        }
+      })),
+      // AltGraph produces an extra keydown for Control
+      // The modifier does not change
+      {
+        matches: (keyDef) => keyDef.key === "AltGraph",
+        handle: (keyDef, element, options, state) => {
+          var _options$keyboardMap$;
+          const ctrlKeyDef = (_options$keyboardMap$ = options.keyboardMap.find((k2) => k2.key === "Control")) != null ? _options$keyboardMap$ : (
+            /* istanbul ignore next */
+            {
+              key: "Control",
+              code: "Control"
+            }
+          );
+          _dom$d.fireEvent.keyDown(element, (0, getEventProps$1.getKeyEventProps)(ctrlKeyDef, state));
+        }
+      }
+    ];
+    exports2.preKeydownBehavior = preKeydownBehavior2;
+    const keydownBehavior2 = [{
+      matches: (keyDef) => keyDef.key === "CapsLock",
+      handle: (keyDef, element, options, state) => {
+        state.modifiers.caps = !state.modifiers.caps;
+      }
+    }, {
+      matches: (keyDef, element) => keyDef.key === "Backspace" && (0, utils$1.isEditable)(element) && !(0, utils$1.isCursorAtStart)(element),
+      handle: (keyDef, element, options, state) => {
+        const {
+          newValue,
+          newSelectionStart
+        } = (0, utils$1.calculateNewValue)("", element, state.carryValue, void 0, "backward");
+        (0, shared$3.fireInputEvent)(element, {
+          newValue,
+          newSelectionStart,
+          eventOverrides: {
+            inputType: "deleteContentBackward"
+          }
+        });
+        (0, shared$3.carryValue)(element, state, newValue);
+      }
+    }];
+    exports2.keydownBehavior = keydownBehavior2;
+    const keypressBehavior2 = [{
+      matches: (keyDef, element) => keyDef.key === "Enter" && (0, utils$1.isElementType)(element, "input") && ["checkbox", "radio"].includes(element.type),
+      handle: (keyDef, element) => {
+        const form = element.form;
+        if ((0, utils$1.hasFormSubmit)(form)) {
+          _dom$d.fireEvent.submit(form);
+        }
+      }
+    }, {
+      matches: (keyDef, element) => keyDef.key === "Enter" && ((0, utils$1.isClickableInput)(element) || // Links with href defined should handle Enter the same as a click
+      (0, utils$1.isElementType)(element, "a") && Boolean(element.href)),
+      handle: (keyDef, element, options, state) => {
+        _dom$d.fireEvent.click(element, (0, getEventProps$1.getMouseEventProps)(state));
+      }
+    }, {
+      matches: (keyDef, element) => keyDef.key === "Enter" && (0, utils$1.isElementType)(element, "input"),
+      handle: (keyDef, element) => {
+        const form = element.form;
+        if (form && (form.querySelectorAll("input").length === 1 || (0, utils$1.hasFormSubmit)(form))) {
+          _dom$d.fireEvent.submit(form);
+        }
+      }
+    }];
+    exports2.keypressBehavior = keypressBehavior2;
+    const preKeyupBehavior2 = [
+      // modifierKeys switch off the modifier BEFORE the keyup event
+      ...Object.entries(modifierKeys2).map(([key2, modKey]) => ({
+        matches: (keyDef) => keyDef.key === key2,
+        handle: (keyDef, element, options, state) => {
+          state.modifiers[modKey] = false;
+        }
+      }))
+    ];
+    exports2.preKeyupBehavior = preKeyupBehavior2;
+    const keyupBehavior2 = [{
+      matches: (keyDef, element) => keyDef.key === " " && (0, utils$1.isClickableInput)(element),
+      handle: (keyDef, element, options, state) => {
+        _dom$d.fireEvent.click(element, (0, getEventProps$1.getMouseEventProps)(state));
+      }
+    }];
+    exports2.keyupBehavior = keyupBehavior2;
+    const postKeyupBehavior2 = [
+      // AltGraph produces an extra keyup for Control
+      // The modifier does not change
+      {
+        matches: (keyDef) => keyDef.key === "AltGraph",
+        handle: (keyDef, element, options, state) => {
+          var _options$keyboardMap$2;
+          const ctrlKeyDef = (_options$keyboardMap$2 = options.keyboardMap.find((k2) => k2.key === "Control")) != null ? _options$keyboardMap$2 : (
+            /* istanbul ignore next */
+            {
+              key: "Control",
+              code: "Control"
+            }
+          );
+          _dom$d.fireEvent.keyUp(element, (0, getEventProps$1.getKeyEventProps)(ctrlKeyDef, state));
+        }
+      }
+    ];
+    exports2.postKeyupBehavior = postKeyupBehavior2;
+  });
+  var plugins$1$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.replaceBehavior = exports2.preKeyupBehavior = exports2.preKeydownBehavior = exports2.postKeyupBehavior = exports2.keyupBehavior = exports2.keypressBehavior = exports2.keydownBehavior = void 0;
+    var arrowKeys2 = _interopRequireWildcard2(arrow$1);
+    var controlKeys2 = _interopRequireWildcard2(control$1);
+    var characterKeys2 = _interopRequireWildcard2(character$1);
+    var functionalKeys2 = _interopRequireWildcard2(functional$1);
+    function _getRequireWildcardCache2(nodeInterop) {
+      if (typeof WeakMap !== "function") return null;
+      var cacheBabelInterop = /* @__PURE__ */ new WeakMap();
+      var cacheNodeInterop = /* @__PURE__ */ new WeakMap();
+      return (_getRequireWildcardCache2 = function(nodeInterop2) {
+        return nodeInterop2 ? cacheNodeInterop : cacheBabelInterop;
+      })(nodeInterop);
+    }
+    function _interopRequireWildcard2(obj, nodeInterop) {
+      if (obj && obj.__esModule) {
+        return obj;
+      }
+      if (obj === null || typeof obj !== "object" && typeof obj !== "function") {
+        return { default: obj };
+      }
+      var cache2 = _getRequireWildcardCache2(nodeInterop);
+      if (cache2 && cache2.has(obj)) {
+        return cache2.get(obj);
+      }
+      var newObj = {};
+      var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor;
+      for (var key2 in obj) {
+        if (key2 !== "default" && Object.prototype.hasOwnProperty.call(obj, key2)) {
+          var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key2) : null;
+          if (desc && (desc.get || desc.set)) {
+            Object.defineProperty(newObj, key2, desc);
+          } else {
+            newObj[key2] = obj[key2];
+          }
+        }
+      }
+      newObj.default = obj;
+      if (cache2) {
+        cache2.set(obj, newObj);
+      }
+      return newObj;
+    }
+    const replaceBehavior2 = [{
+      matches: (keyDef, element) => keyDef.key === "selectall" && (0, utils$1.isElementType)(element, ["input", "textarea"]),
+      handle: (keyDef, element, options, state) => {
+        var _state$carryValue;
+        (0, utils$1.setSelectionRange)(element, 0, ((_state$carryValue = state.carryValue) != null ? _state$carryValue : element.value).length);
+      }
+    }];
+    exports2.replaceBehavior = replaceBehavior2;
+    const preKeydownBehavior2 = [...functionalKeys2.preKeydownBehavior];
+    exports2.preKeydownBehavior = preKeydownBehavior2;
+    const keydownBehavior2 = [...arrowKeys2.keydownBehavior, ...controlKeys2.keydownBehavior, ...functionalKeys2.keydownBehavior];
+    exports2.keydownBehavior = keydownBehavior2;
+    const keypressBehavior2 = [...functionalKeys2.keypressBehavior, ...characterKeys2.keypressBehavior];
+    exports2.keypressBehavior = keypressBehavior2;
+    const preKeyupBehavior2 = [...functionalKeys2.preKeyupBehavior];
+    exports2.preKeyupBehavior = preKeyupBehavior2;
+    const keyupBehavior2 = [...functionalKeys2.keyupBehavior];
+    exports2.keyupBehavior = keyupBehavior2;
+    const postKeyupBehavior2 = [...functionalKeys2.postKeyupBehavior];
+    exports2.postKeyupBehavior = postKeyupBehavior2;
+  });
+  var keyboardImplementation_2 = keyboardImplementation$2;
+  var releaseAllKeys_1 = releaseAllKeys$1;
+  var plugins$3 = _interopRequireWildcard$3(plugins$1$1);
+  function _getRequireWildcardCache$3(nodeInterop) {
+    if (typeof WeakMap !== "function") return null;
+    var cacheBabelInterop = /* @__PURE__ */ new WeakMap();
+    var cacheNodeInterop = /* @__PURE__ */ new WeakMap();
+    return (_getRequireWildcardCache$3 = function(nodeInterop2) {
+      return nodeInterop2 ? cacheNodeInterop : cacheBabelInterop;
+    })(nodeInterop);
+  }
+  function _interopRequireWildcard$3(obj, nodeInterop) {
+    if (obj && obj.__esModule) {
+      return obj;
+    }
+    if (obj === null || typeof obj !== "object" && typeof obj !== "function") {
+      return { default: obj };
+    }
+    var cache2 = _getRequireWildcardCache$3(nodeInterop);
+    if (cache2 && cache2.has(obj)) {
+      return cache2.get(obj);
+    }
+    var newObj = {};
+    var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor;
+    for (var key2 in obj) {
+      if (key2 !== "default" && Object.prototype.hasOwnProperty.call(obj, key2)) {
+        var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key2) : null;
+        if (desc && (desc.get || desc.set)) {
+          Object.defineProperty(newObj, key2, desc);
+        } else {
+          newObj[key2] = obj[key2];
+        }
+      }
+    }
+    newObj.default = obj;
+    if (cache2) {
+      cache2.set(obj, newObj);
+    }
+    return newObj;
+  }
+  async function keyboardImplementation$2(text, options, state) {
+    var _state$repeatKey;
+    const {
+      document: document2
+    } = options;
+    const getCurrentElement = () => getActive$1(document2);
+    const {
+      keyDef,
+      consumedLength,
+      releasePrevious,
+      releaseSelf,
+      repeat: repeat2
+    } = (_state$repeatKey = state.repeatKey) != null ? _state$repeatKey : (0, getNextKeyDef_1.getNextKeyDef)(text, options);
+    const replace2 = applyPlugins$1(plugins$3.replaceBehavior, keyDef, getCurrentElement(), options, state);
+    if (!replace2) {
+      const pressed = state.pressed.find((p2) => p2.keyDef === keyDef);
+      if (pressed && !state.repeatKey) {
+        keyup$1(keyDef, getCurrentElement, options, state, pressed.unpreventedDefault);
+      }
+      if (!releasePrevious) {
+        const unpreventedDefault = keydown$1(keyDef, getCurrentElement, options, state);
+        if (unpreventedDefault && hasKeyPress$1(keyDef, state)) {
+          keypress$1(keyDef, getCurrentElement, options, state);
+        }
+        if (releaseSelf && repeat2 <= 1) {
+          keyup$1(keyDef, getCurrentElement, options, state, unpreventedDefault);
+        }
+      }
+    }
+    if (repeat2 > 1) {
+      state.repeatKey = {
+        // don't consume again on the next iteration
+        consumedLength: 0,
+        keyDef,
+        releasePrevious,
+        releaseSelf,
+        repeat: repeat2 - 1
+      };
+    } else {
+      delete state.repeatKey;
+    }
+    if (text.length > consumedLength || repeat2 > 1) {
+      if (options.delay > 0) {
+        await (0, utils$1.wait)(options.delay);
+      }
+      return keyboardImplementation$2(text.slice(consumedLength), options, state);
+    }
+    return void 0;
+  }
+  function getActive$1(document2) {
+    var _getActiveElement;
+    return (_getActiveElement = (0, utils$1.getActiveElement)(document2)) != null ? _getActiveElement : (
+      /* istanbul ignore next */
+      document2.body
+    );
+  }
+  function releaseAllKeys$1(options, state) {
+    const getCurrentElement = () => getActive$1(options.document);
+    for (const k2 of state.pressed) {
+      keyup$1(k2.keyDef, getCurrentElement, options, state, k2.unpreventedDefault);
+    }
+  }
+  function keydown$1(keyDef, getCurrentElement, options, state) {
+    const element = getCurrentElement();
+    if (element !== state.activeElement) {
+      state.carryValue = void 0;
+      state.carryChar = "";
+    }
+    state.activeElement = element;
+    applyPlugins$1(plugins$3.preKeydownBehavior, keyDef, element, options, state);
+    const unpreventedDefault = _dom$d.fireEvent.keyDown(element, (0, getEventProps$1.getKeyEventProps)(keyDef, state));
+    state.pressed.push({
+      keyDef,
+      unpreventedDefault
+    });
+    if (unpreventedDefault) {
+      applyPlugins$1(plugins$3.keydownBehavior, keyDef, getCurrentElement(), options, state);
+    }
+    return unpreventedDefault;
+  }
+  function keypress$1(keyDef, getCurrentElement, options, state) {
+    const element = getCurrentElement();
+    const unpreventedDefault = _dom$d.fireEvent.keyPress(element, (0, getEventProps$1.getKeyEventProps)(keyDef, state));
+    if (unpreventedDefault) {
+      applyPlugins$1(plugins$3.keypressBehavior, keyDef, getCurrentElement(), options, state);
+    }
+  }
+  function keyup$1(keyDef, getCurrentElement, options, state, unprevented) {
+    const element = getCurrentElement();
+    applyPlugins$1(plugins$3.preKeyupBehavior, keyDef, element, options, state);
+    const unpreventedDefault = _dom$d.fireEvent.keyUp(element, (0, getEventProps$1.getKeyEventProps)(keyDef, state));
+    if (unprevented && unpreventedDefault) {
+      applyPlugins$1(plugins$3.keyupBehavior, keyDef, getCurrentElement(), options, state);
+    }
+    state.pressed = state.pressed.filter((k2) => k2.keyDef !== keyDef);
+    applyPlugins$1(plugins$3.postKeyupBehavior, keyDef, element, options, state);
+  }
+  function applyPlugins$1(pluginCollection, keyDef, element, options, state) {
+    const plugin2 = pluginCollection.find((p2) => p2.matches(keyDef, element, options, state));
+    if (plugin2) {
+      plugin2.handle(keyDef, element, options, state);
+    }
+    return !!plugin2;
+  }
+  function hasKeyPress$1(keyDef, state) {
+    var _keyDef$key;
+    return (((_keyDef$key = keyDef.key) == null ? void 0 : _keyDef$key.length) === 1 || keyDef.key === "Enter") && !state.modifiers.ctrl && !state.modifiers.alt;
+  }
+  var keyboardImplementation_1 = /* @__PURE__ */ Object.defineProperty({
+    keyboardImplementation: keyboardImplementation_2,
+    releaseAllKeys: releaseAllKeys_1
+  }, "__esModule", { value: true });
+  var types$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.DOM_KEY_LOCATION = void 0;
+    let DOM_KEY_LOCATION2;
+    exports2.DOM_KEY_LOCATION = DOM_KEY_LOCATION2;
+    (function(DOM_KEY_LOCATION3) {
+      DOM_KEY_LOCATION3[DOM_KEY_LOCATION3["STANDARD"] = 0] = "STANDARD";
+      DOM_KEY_LOCATION3[DOM_KEY_LOCATION3["LEFT"] = 1] = "LEFT";
+      DOM_KEY_LOCATION3[DOM_KEY_LOCATION3["RIGHT"] = 2] = "RIGHT";
+      DOM_KEY_LOCATION3[DOM_KEY_LOCATION3["NUMPAD"] = 3] = "NUMPAD";
+    })(DOM_KEY_LOCATION2 || (exports2.DOM_KEY_LOCATION = DOM_KEY_LOCATION2 = {}));
+  });
+  var keyMap$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.defaultKeyMap = void 0;
+    const defaultKeyMap2 = [
+      // alphanumeric keys
+      ..."0123456789".split("").map((c2) => ({
+        code: `Digit${c2}`,
+        key: c2
+      })),
+      ...")!@#$%^&*(".split("").map((c2, i2) => ({
+        code: `Digit${i2}`,
+        key: c2,
+        shiftKey: true
+      })),
+      ..."abcdefghijklmnopqrstuvwxyz".split("").map((c2) => ({
+        code: `Key${c2.toUpperCase()}`,
+        key: c2
+      })),
+      ..."ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("").map((c2) => ({
+        code: `Key${c2}`,
+        key: c2,
+        shiftKey: true
+      })),
+      // alphanumeric block - functional
+      {
+        code: "Space",
+        key: " "
+      },
+      {
+        code: "AltLeft",
+        key: "Alt",
+        location: types$1.DOM_KEY_LOCATION.LEFT,
+        keyCode: 18
+      },
+      {
+        code: "AltRight",
+        key: "Alt",
+        location: types$1.DOM_KEY_LOCATION.RIGHT,
+        keyCode: 18
+      },
+      {
+        code: "ShiftLeft",
+        key: "Shift",
+        location: types$1.DOM_KEY_LOCATION.LEFT,
+        keyCode: 16
+      },
+      {
+        code: "ShiftRight",
+        key: "Shift",
+        location: types$1.DOM_KEY_LOCATION.RIGHT,
+        keyCode: 16
+      },
+      {
+        code: "ControlLeft",
+        key: "Control",
+        location: types$1.DOM_KEY_LOCATION.LEFT,
+        keyCode: 17
+      },
+      {
+        code: "ControlRight",
+        key: "Control",
+        location: types$1.DOM_KEY_LOCATION.RIGHT,
+        keyCode: 17
+      },
+      {
+        code: "MetaLeft",
+        key: "Meta",
+        location: types$1.DOM_KEY_LOCATION.LEFT,
+        keyCode: 93
+      },
+      {
+        code: "MetaRight",
+        key: "Meta",
+        location: types$1.DOM_KEY_LOCATION.RIGHT,
+        keyCode: 93
+      },
+      {
+        code: "OSLeft",
+        key: "OS",
+        location: types$1.DOM_KEY_LOCATION.LEFT,
+        keyCode: 91
+      },
+      {
+        code: "OSRight",
+        key: "OS",
+        location: types$1.DOM_KEY_LOCATION.RIGHT,
+        keyCode: 91
+      },
+      {
+        code: "CapsLock",
+        key: "CapsLock",
+        keyCode: 20
+      },
+      {
+        code: "Backspace",
+        key: "Backspace",
+        keyCode: 8
+      },
+      {
+        code: "Enter",
+        key: "Enter",
+        keyCode: 13
+      },
+      // function
+      {
+        code: "Escape",
+        key: "Escape",
+        keyCode: 27
+      },
+      // arrows
+      {
+        code: "ArrowUp",
+        key: "ArrowUp",
+        keyCode: 38
+      },
+      {
+        code: "ArrowDown",
+        key: "ArrowDown",
+        keyCode: 40
+      },
+      {
+        code: "ArrowLeft",
+        key: "ArrowLeft",
+        keyCode: 37
+      },
+      {
+        code: "ArrowRight",
+        key: "ArrowRight",
+        keyCode: 39
+      },
+      // control pad
+      {
+        code: "Home",
+        key: "Home",
+        keyCode: 36
+      },
+      {
+        code: "End",
+        key: "End",
+        keyCode: 35
+      },
+      {
+        code: "Delete",
+        key: "Delete",
+        keyCode: 46
+      },
+      {
+        code: "PageUp",
+        key: "PageUp",
+        keyCode: 33
+      },
+      {
+        code: "PageDown",
+        key: "PageDown",
+        keyCode: 34
+      }
+      // TODO: add mappings
+    ];
+    exports2.defaultKeyMap = defaultKeyMap2;
+  });
+  var specialCharMap_1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.specialCharMap = void 0;
+    const specialCharMap2 = {
+      arrowLeft: "{arrowleft}",
+      arrowRight: "{arrowright}",
+      arrowDown: "{arrowdown}",
+      arrowUp: "{arrowup}",
+      enter: "{enter}",
+      escape: "{esc}",
+      delete: "{del}",
+      backspace: "{backspace}",
+      home: "{home}",
+      end: "{end}",
+      selectAll: "{selectall}",
+      space: "{space}",
+      whitespace: " ",
+      pageUp: "{pageUp}",
+      pageDown: "{pageDown}"
+    };
+    exports2.specialCharMap = specialCharMap2;
+  });
+  var keyboard_1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.keyboard = keyboard2;
+    exports2.keyboardImplementationWrapper = keyboardImplementationWrapper;
+    Object.defineProperty(exports2, "specialCharMap", {
+      enumerable: true,
+      get: function() {
+        return specialCharMap_1.specialCharMap;
+      }
+    });
+    function keyboard2(text, options) {
+      var _options$delay;
+      const {
+        promise,
+        state
+      } = keyboardImplementationWrapper(text, options);
+      if (((_options$delay = options == null ? void 0 : options.delay) != null ? _options$delay : 0) > 0) {
+        return (0, _dom$d.getConfig)().asyncWrapper(() => promise.then(() => state));
+      } else {
+        promise.catch(console.error);
+        return state;
+      }
+    }
+    function keyboardImplementationWrapper(text, config2 = {}) {
+      const {
+        keyboardState: state = createKeyboardState(),
+        delay = 0,
+        document: doc = document,
+        autoModify = false,
+        keyboardMap = keyMap$1.defaultKeyMap
+      } = config2;
+      const options = {
+        delay,
+        document: doc,
+        autoModify,
+        keyboardMap
+      };
+      return {
+        promise: (0, keyboardImplementation_1.keyboardImplementation)(text, options, state),
+        state,
+        releaseAllKeys: () => (0, keyboardImplementation_1.releaseAllKeys)(options, state)
+      };
+    }
+    function createKeyboardState() {
+      return {
+        activeElement: null,
+        pressed: [],
+        carryChar: "",
+        modifiers: {
+          alt: false,
+          caps: false,
+          ctrl: false,
+          meta: false,
+          shift: false
+        }
+      };
+    }
+  });
+  var typeImplementation_2 = typeImplementation$2;
+  async function typeImplementation$2(element, text, {
+    delay,
+    skipClick = false,
+    skipAutoClose = false,
+    initialSelectionStart = void 0,
+    initialSelectionEnd = void 0
+  }) {
+    if (element.disabled) return;
+    if (!skipClick) (0, click_1.click)(element);
+    const currentElement = () => (0, utils$1.getActiveElement)(element.ownerDocument);
+    const value = (0, utils$1.getValue)(currentElement());
+    const {
+      selectionStart,
+      selectionEnd
+    } = (0, utils$1.getSelectionRange)(element);
+    if (value != null && (selectionStart === null || selectionStart === 0) && (selectionEnd === null || selectionEnd === 0)) {
+      (0, utils$1.setSelectionRange)(currentElement(), initialSelectionStart != null ? initialSelectionStart : value.length, initialSelectionEnd != null ? initialSelectionEnd : value.length);
+    }
+    const {
+      promise,
+      releaseAllKeys: releaseAllKeys2
+    } = (0, keyboard_1.keyboardImplementationWrapper)(text, {
+      delay,
+      document: element.ownerDocument
+    });
+    if (delay > 0) {
+      await promise;
+    }
+    if (!skipAutoClose) {
+      releaseAllKeys2();
+    }
+    return promise;
+  }
+  var typeImplementation_1 = /* @__PURE__ */ Object.defineProperty({
+    typeImplementation: typeImplementation_2
+  }, "__esModule", { value: true });
+  var type_2 = type$3;
+  function type$3(element, text, {
+    delay = 0,
+    ...options
+  } = {}) {
+    if (delay > 0) {
+      return (0, _dom$d.getConfig)().asyncWrapper(() => (0, typeImplementation_1.typeImplementation)(element, text, {
+        delay,
+        ...options
+      }));
+    } else {
+      return void (0, typeImplementation_1.typeImplementation)(element, text, {
+        delay,
+        ...options
+      }).catch(console.error);
+    }
+  }
+  var type_1 = /* @__PURE__ */ Object.defineProperty({
+    type: type_2
+  }, "__esModule", { value: true });
+  var clear_2 = clear$2;
+  function clear$2(element) {
+    var _element$selectionSta, _element$selectionEnd;
+    if (!(0, utils$1.isElementType)(element, ["input", "textarea"])) {
+      throw new Error("clear currently only supports input and textarea elements.");
+    }
+    if ((0, utils$1.isDisabled)(element)) {
+      return;
+    }
+    const elementType = element.type;
+    if (elementType !== "textarea") {
+      element.type = "text";
+    }
+    (0, type_1.type)(element, "{selectall}{del}", {
+      delay: 0,
+      initialSelectionStart: (_element$selectionSta = element.selectionStart) != null ? _element$selectionSta : (
+        /* istanbul ignore next */
+        void 0
+      ),
+      initialSelectionEnd: (_element$selectionEnd = element.selectionEnd) != null ? _element$selectionEnd : (
+        /* istanbul ignore next */
+        void 0
+      )
+    });
+    if (elementType !== "textarea") {
+      element.type = elementType;
+    }
+  }
+  var clear_1 = /* @__PURE__ */ Object.defineProperty({
+    clear: clear_2
+  }, "__esModule", { value: true });
+  var tab_2 = tab$2;
+  function getNextElement$1(currentIndex, shift, elements, focusTrap) {
+    if ((0, utils$1.isDocument)(focusTrap) && (currentIndex === 0 && shift || currentIndex === elements.length - 1 && !shift)) {
+      return focusTrap.body;
+    }
+    const nextIndex = shift ? currentIndex - 1 : currentIndex + 1;
+    const defaultIndex = shift ? elements.length - 1 : 0;
+    return elements[nextIndex] || elements[defaultIndex];
+  }
+  function tab$2({
+    shift = false,
+    focusTrap
+  } = {}) {
+    var _focusTrap$ownerDocum, _focusTrap;
+    const doc = (_focusTrap$ownerDocum = (_focusTrap = focusTrap) == null ? void 0 : _focusTrap.ownerDocument) != null ? _focusTrap$ownerDocum : document;
+    const previousElement = (0, utils$1.getActiveElement)(doc);
+    if (!focusTrap) {
+      focusTrap = doc;
+    }
+    const focusableElements = focusTrap.querySelectorAll(utils$1.FOCUSABLE_SELECTOR);
+    const enabledElements = Array.from(focusableElements).filter((el) => el === previousElement || el.getAttribute("tabindex") !== "-1" && !(0, utils$1.isDisabled)(el) && // Hidden elements are not tabable
+    (0, utils$1.isVisible)(el));
+    if (enabledElements.length === 0) return;
+    const orderedElements = enabledElements.map((el, idx) => ({
+      el,
+      idx
+    })).sort((a, b2) => {
+      if (previousElement && previousElement.getAttribute("tabindex") === "-1") {
+        return a.idx - b2.idx;
+      }
+      const tabIndexA = Number(a.el.getAttribute("tabindex"));
+      const tabIndexB = Number(b2.el.getAttribute("tabindex"));
+      const diff = tabIndexA - tabIndexB;
+      return diff === 0 ? a.idx - b2.idx : diff;
+    }).map(({
+      el
+    }) => el);
+    const checkedRadio = {};
+    let prunedElements = [];
+    orderedElements.forEach((currentElement) => {
+      const el = currentElement;
+      if (el.type === "radio" && el.name) {
+        const prev = previousElement;
+        if (prev && prev.type === el.type && prev.name === el.name) {
+          if (el === prev) {
+            prunedElements.push(el);
+          }
+          return;
+        }
+        if (el.checked) {
+          prunedElements = prunedElements.filter((e2) => e2.type !== el.type || e2.name !== el.name);
+          prunedElements.push(el);
+          checkedRadio[el.name] = el;
+          return;
+        }
+        if (typeof checkedRadio[el.name] !== "undefined") {
+          return;
+        }
+      }
+      prunedElements.push(el);
+    });
+    const index2 = prunedElements.findIndex((el) => el === previousElement);
+    const nextElement = getNextElement$1(index2, shift, prunedElements, focusTrap);
+    const shiftKeyInit = {
+      key: "Shift",
+      keyCode: 16,
+      shiftKey: true
+    };
+    const tabKeyInit = {
+      key: "Tab",
+      keyCode: 9,
+      shiftKey: shift
+    };
+    let continueToTab = true;
+    if (previousElement) {
+      if (shift) _dom$d.fireEvent.keyDown(previousElement, {
+        ...shiftKeyInit
+      });
+      continueToTab = _dom$d.fireEvent.keyDown(previousElement, {
+        ...tabKeyInit
+      });
+    }
+    const keyUpTarget = !continueToTab && previousElement ? previousElement : nextElement;
+    if (continueToTab) {
+      if (nextElement === doc.body) {
+        if (previousElement) {
+          (0, blur_1.blur)(previousElement);
+        }
+      } else {
+        (0, focus_1.focus)(nextElement);
+      }
+    }
+    _dom$d.fireEvent.keyUp(keyUpTarget, {
+      ...tabKeyInit
+    });
+    if (shift) {
+      _dom$d.fireEvent.keyUp(keyUpTarget, {
+        ...shiftKeyInit,
+        shiftKey: false
+      });
+    }
+  }
+  var tab_1 = /* @__PURE__ */ Object.defineProperty({
+    tab: tab_2
+  }, "__esModule", { value: true });
+  var upload_2 = upload$2;
+  function upload$2(element, fileOrFiles, init, {
+    applyAccept = false
+  } = {}) {
+    var _input$files;
+    const input = (0, utils$1.isElementType)(element, "label") ? element.control : element;
+    if (!input || !(0, utils$1.isElementType)(input, "input", {
+      type: "file"
+    })) {
+      throw new TypeError(`The ${input === element ? "given" : "associated"} ${input == null ? void 0 : input.tagName} element does not accept file uploads`);
+    }
+    if ((0, utils$1.isDisabled)(element)) return;
+    (0, click_1.click)(element, init == null ? void 0 : init.clickInit);
+    const files = (Array.isArray(fileOrFiles) ? fileOrFiles : [fileOrFiles]).filter((file) => !applyAccept || isAcceptableFile$1(file, input.accept)).slice(0, input.multiple ? void 0 : 1);
+    (0, blur_1.blur)(element);
+    (0, focus_1.focus)(element);
+    if (files.length === ((_input$files = input.files) == null ? void 0 : _input$files.length) && files.every((f2, i2) => {
+      var _input$files2;
+      return f2 === ((_input$files2 = input.files) == null ? void 0 : _input$files2.item(i2));
+    })) {
+      return;
+    }
+    const inputFiles = {
+      ...files,
+      length: files.length,
+      item: (index2) => files[index2],
+      [Symbol.iterator]() {
+        let i2 = 0;
+        return {
+          next: () => ({
+            done: i2 >= files.length,
+            value: files[i2++]
+          })
+        };
+      }
+    };
+    (0, _dom$d.fireEvent)(input, (0, _dom$d.createEvent)("input", input, {
+      target: {
+        files: inputFiles
+      },
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }));
+    _dom$d.fireEvent.change(input, {
+      target: {
+        files: inputFiles
+      },
+      ...init == null ? void 0 : init.changeInit
+    });
+  }
+  function isAcceptableFile$1(file, accept) {
+    if (!accept) {
+      return true;
+    }
+    const wildcards = ["audio/*", "image/*", "video/*"];
+    return accept.split(",").some((acceptToken) => {
+      if (acceptToken.startsWith(".")) {
+        return file.name.endsWith(acceptToken);
+      } else if (wildcards.includes(acceptToken)) {
+        return file.type.startsWith(acceptToken.substr(0, acceptToken.length - 1));
+      }
+      return file.type === acceptToken;
+    });
+  }
+  var upload_1 = /* @__PURE__ */ Object.defineProperty({
+    upload: upload_2
+  }, "__esModule", { value: true });
+  var selectOptions_1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.selectOptions = exports2.deselectOptions = void 0;
+    function selectOptionsBase2(newValue, select2, values, init, {
+      skipPointerEventsCheck = false
+    } = {}) {
+      if (!newValue && !select2.multiple) {
+        throw (0, _dom$d.getConfig)().getElementError(`Unable to deselect an option in a non-multiple select. Use selectOptions to change the selection instead.`, select2);
+      }
+      const valArray = Array.isArray(values) ? values : [values];
+      const allOptions = Array.from(select2.querySelectorAll('option, [role="option"]'));
+      const selectedOptions = valArray.map((val) => {
+        if (typeof val !== "string" && allOptions.includes(val)) {
+          return val;
+        } else {
+          const matchingOption = allOptions.find((o) => o.value === val || o.innerHTML === val);
+          if (matchingOption) {
+            return matchingOption;
+          } else {
+            throw (0, _dom$d.getConfig)().getElementError(`Value "${String(val)}" not found in options`, select2);
+          }
+        }
+      }).filter((option) => !(0, utils$1.isDisabled)(option));
+      if ((0, utils$1.isDisabled)(select2) || !selectedOptions.length) return;
+      if ((0, utils$1.isElementType)(select2, "select")) {
+        if (select2.multiple) {
+          for (const option of selectedOptions) {
+            const withPointerEvents = skipPointerEventsCheck ? true : (0, utils$1.hasPointerEvents)(option);
+            if (withPointerEvents) {
+              _dom$d.fireEvent.pointerOver(option, init);
+              _dom$d.fireEvent.pointerEnter(select2, init);
+              _dom$d.fireEvent.mouseOver(option);
+              _dom$d.fireEvent.mouseEnter(select2);
+              _dom$d.fireEvent.pointerMove(option, init);
+              _dom$d.fireEvent.mouseMove(option, init);
+              _dom$d.fireEvent.pointerDown(option, init);
+              _dom$d.fireEvent.mouseDown(option, init);
+            }
+            (0, focus_1.focus)(select2);
+            if (withPointerEvents) {
+              _dom$d.fireEvent.pointerUp(option, init);
+              _dom$d.fireEvent.mouseUp(option, init);
+            }
+            selectOption(option);
+            if (withPointerEvents) {
+              _dom$d.fireEvent.click(option, init);
+            }
+          }
+        } else if (selectedOptions.length === 1) {
+          const withPointerEvents = skipPointerEventsCheck ? true : (0, utils$1.hasPointerEvents)(select2);
+          if (withPointerEvents) {
+            (0, click_1.click)(select2, init, {
+              skipPointerEventsCheck
+            });
+          } else {
+            (0, focus_1.focus)(select2);
+          }
+          selectOption(selectedOptions[0]);
+          if (withPointerEvents) {
+            _dom$d.fireEvent.pointerOver(select2, init);
+            _dom$d.fireEvent.pointerEnter(select2, init);
+            _dom$d.fireEvent.mouseOver(select2);
+            _dom$d.fireEvent.mouseEnter(select2);
+            _dom$d.fireEvent.pointerUp(select2, init);
+            _dom$d.fireEvent.mouseUp(select2, init);
+            _dom$d.fireEvent.click(select2, init);
+          }
+        } else {
+          throw (0, _dom$d.getConfig)().getElementError(`Cannot select multiple options on a non-multiple select`, select2);
+        }
+      } else if (select2.getAttribute("role") === "listbox") {
+        selectedOptions.forEach((option) => {
+          (0, hover_1.hover)(option, init, {
+            skipPointerEventsCheck
+          });
+          (0, click_1.click)(option, init, {
+            skipPointerEventsCheck
+          });
+          (0, hover_1.unhover)(option, init, {
+            skipPointerEventsCheck
+          });
+        });
+      } else {
+        throw (0, _dom$d.getConfig)().getElementError(`Cannot select options on elements that are neither select nor listbox elements`, select2);
+      }
+      function selectOption(option) {
+        option.selected = newValue;
+        (0, _dom$d.fireEvent)(select2, (0, _dom$d.createEvent)("input", select2, {
+          bubbles: true,
+          cancelable: false,
+          composed: true,
+          ...init
+        }));
+        _dom$d.fireEvent.change(select2, init);
+      }
+    }
+    const selectOptions2 = selectOptionsBase2.bind(null, true);
+    exports2.selectOptions = selectOptions2;
+    const deselectOptions2 = selectOptionsBase2.bind(null, false);
+    exports2.deselectOptions = deselectOptions2;
+  });
+  var paste_2 = paste$2;
+  function isSupportedElement$1(element) {
+    return (0, utils$1.isElementType)(element, "input") && Boolean(utils$1.editableInputTypes[element.type]) || (0, utils$1.isElementType)(element, "textarea");
+  }
+  function paste$2(element, text, init, {
+    initialSelectionStart,
+    initialSelectionEnd
+  } = {}) {
+    if (!isSupportedElement$1(element)) {
+      throw new TypeError(`The given ${element.tagName} element is currently unsupported.
+      A PR extending this implementation would be very much welcome at https://github.com/testing-library/user-event`);
+    }
+    if ((0, utils$1.isDisabled)(element)) {
+      return;
+    }
+    (0, utils$1.eventWrapper)(() => element.focus());
+    if (element.selectionStart === 0 && element.selectionEnd === 0) {
+      (0, utils$1.setSelectionRange)(element, initialSelectionStart != null ? initialSelectionStart : element.value.length, initialSelectionEnd != null ? initialSelectionEnd : element.value.length);
+    }
+    _dom$d.fireEvent.paste(element, init);
+    if (element.readOnly) {
+      return;
+    }
+    text = text.substr(0, (0, utils$1.getSpaceUntilMaxLength)(element));
+    const {
+      newValue,
+      newSelectionStart
+    } = (0, utils$1.calculateNewValue)(text, element);
+    _dom$d.fireEvent.input(element, {
+      inputType: "insertFromPaste",
+      target: {
+        value: newValue
+      }
+    });
+    (0, utils$1.setSelectionRange)(
+      element,
+      // TODO: investigate why the selection caused by invalid parameters was expected
+      {
+        newSelectionStart,
+        selectionEnd: newSelectionStart
+      },
+      {}
+    );
+  }
+  var paste_1 = /* @__PURE__ */ Object.defineProperty({
+    paste: paste_2
+  }, "__esModule", { value: true });
+  var dist$1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.default = void 0;
+    Object.defineProperty(exports2, "specialChars", {
+      enumerable: true,
+      get: function() {
+        return keyboard_1.specialCharMap;
+      }
+    });
+    const userEvent = {
+      click: click_1.click,
+      dblClick: click_1.dblClick,
+      type: type_1.type,
+      clear: clear_1.clear,
+      tab: tab_1.tab,
+      hover: hover_1.hover,
+      unhover: hover_1.unhover,
+      upload: upload_1.upload,
+      selectOptions: selectOptions_1.selectOptions,
+      deselectOptions: selectOptions_1.deselectOptions,
+      paste: paste_1.paste,
+      keyboard: keyboard_1.keyboard
+    };
+    var _default2 = userEvent;
+    exports2.default = _default2;
+  });
+  var index$2 = /* @__PURE__ */ getDefaultExportFromCjs$1(dist$1);
+  var eventMap_1 = createCommonjsModule(function(module2, exports2) {
+    Object.defineProperty(exports2, "__esModule", {
+      value: true
+    });
+    exports2.eventAliasMap = exports2.eventMap = void 0;
+    const eventMap2 = {
+      // Clipboard Events
+      copy: {
+        EventType: "ClipboardEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      cut: {
+        EventType: "ClipboardEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      paste: {
+        EventType: "ClipboardEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      // Composition Events
+      compositionEnd: {
+        EventType: "CompositionEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      compositionStart: {
+        EventType: "CompositionEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      compositionUpdate: {
+        EventType: "CompositionEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      // Keyboard Events
+      keyDown: {
+        EventType: "KeyboardEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          charCode: 0,
+          composed: true
+        }
+      },
+      keyPress: {
+        EventType: "KeyboardEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          charCode: 0,
+          composed: true
+        }
+      },
+      keyUp: {
+        EventType: "KeyboardEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          charCode: 0,
+          composed: true
+        }
+      },
+      // Focus Events
+      focus: {
+        EventType: "FocusEvent",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false,
+          composed: true
+        }
+      },
+      blur: {
+        EventType: "FocusEvent",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false,
+          composed: true
+        }
+      },
+      focusIn: {
+        EventType: "FocusEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: false,
+          composed: true
+        }
+      },
+      focusOut: {
+        EventType: "FocusEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: false,
+          composed: true
+        }
+      },
+      // Form Events
+      change: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: true,
+          cancelable: false
+        }
+      },
+      input: {
+        EventType: "InputEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: false,
+          composed: true
+        }
+      },
+      invalid: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: true
+        }
+      },
+      submit: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true
+        }
+      },
+      reset: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true
+        }
+      },
+      // Mouse Events
+      click: {
+        EventType: "MouseEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          button: 0,
+          composed: true
+        }
+      },
+      contextMenu: {
+        EventType: "MouseEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      dblClick: {
+        EventType: "MouseEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      drag: {
+        EventType: "DragEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      dragEnd: {
+        EventType: "DragEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: false,
+          composed: true
+        }
+      },
+      dragEnter: {
+        EventType: "DragEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      dragExit: {
+        EventType: "DragEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: false,
+          composed: true
+        }
+      },
+      dragLeave: {
+        EventType: "DragEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: false,
+          composed: true
+        }
+      },
+      dragOver: {
+        EventType: "DragEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      dragStart: {
+        EventType: "DragEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      drop: {
+        EventType: "DragEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      mouseDown: {
+        EventType: "MouseEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      mouseEnter: {
+        EventType: "MouseEvent",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false,
+          composed: true
+        }
+      },
+      mouseLeave: {
+        EventType: "MouseEvent",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false,
+          composed: true
+        }
+      },
+      mouseMove: {
+        EventType: "MouseEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      mouseOut: {
+        EventType: "MouseEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      mouseOver: {
+        EventType: "MouseEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      mouseUp: {
+        EventType: "MouseEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      // Selection Events
+      select: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: true,
+          cancelable: false
+        }
+      },
+      // Touch Events
+      touchCancel: {
+        EventType: "TouchEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: false,
+          composed: true
+        }
+      },
+      touchEnd: {
+        EventType: "TouchEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      touchMove: {
+        EventType: "TouchEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      touchStart: {
+        EventType: "TouchEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      // UI Events
+      scroll: {
+        EventType: "UIEvent",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      // Wheel Events
+      wheel: {
+        EventType: "WheelEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      // Media Events
+      abort: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      canPlay: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      canPlayThrough: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      durationChange: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      emptied: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      encrypted: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      ended: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      loadedData: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      loadedMetadata: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      loadStart: {
+        EventType: "ProgressEvent",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      pause: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      play: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      playing: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      progress: {
+        EventType: "ProgressEvent",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      rateChange: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      seeked: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      seeking: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      stalled: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      suspend: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      timeUpdate: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      volumeChange: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      waiting: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      // Image Events
+      load: {
+        EventType: "UIEvent",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      error: {
+        EventType: "Event",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      // Animation Events
+      animationStart: {
+        EventType: "AnimationEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: false
+        }
+      },
+      animationEnd: {
+        EventType: "AnimationEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: false
+        }
+      },
+      animationIteration: {
+        EventType: "AnimationEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: false
+        }
+      },
+      // Transition Events
+      transitionEnd: {
+        EventType: "TransitionEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true
+        }
+      },
+      // pointer events
+      pointerOver: {
+        EventType: "PointerEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      pointerEnter: {
+        EventType: "PointerEvent",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      pointerDown: {
+        EventType: "PointerEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      pointerMove: {
+        EventType: "PointerEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      pointerUp: {
+        EventType: "PointerEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      pointerCancel: {
+        EventType: "PointerEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: false,
+          composed: true
+        }
+      },
+      pointerOut: {
+        EventType: "PointerEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: true,
+          composed: true
+        }
+      },
+      pointerLeave: {
+        EventType: "PointerEvent",
+        defaultInit: {
+          bubbles: false,
+          cancelable: false
+        }
+      },
+      gotPointerCapture: {
+        EventType: "PointerEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: false,
+          composed: true
+        }
+      },
+      lostPointerCapture: {
+        EventType: "PointerEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: false,
+          composed: true
+        }
+      },
+      // history events
+      popState: {
+        EventType: "PopStateEvent",
+        defaultInit: {
+          bubbles: true,
+          cancelable: false
+        }
+      }
+    };
+    exports2.eventMap = eventMap2;
+    const eventAliasMap2 = {
+      doubleClick: "dblClick"
+    };
+    exports2.eventAliasMap = eventAliasMap2;
+  });
+  configure$1({
+    testIdAttribute: "data-test-id",
+    getElementError: buildJsGetElementError$1
+  });
+  var fireEventObj$1 = fireEvent$2;
+  var eventMap$1$1 = eventMap_1.eventMap;
+  const rtl17 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
+    __proto__: null,
+    act: act$1,
+    buildJsGetElementError: buildJsGetElementError$1,
+    buildQueries: buildQueries$1,
+    cleanup: cleanup$1,
+    configure: configure$1,
+    createEvent: createEvent$1,
+    eventMap: eventMap$1$1,
+    findAllByAltText: findAllByAltText$1,
+    findAllByDisplayValue: findAllByDisplayValue$1,
+    findAllByLabelText: findAllByLabelText$1,
+    findAllByPlaceholderText: findAllByPlaceholderText$1,
+    findAllByRole: findAllByRole$1,
+    findAllByTestId: findAllByTestId$1,
+    findAllByText: findAllByText$1,
+    findAllByTitle: findAllByTitle$1,
+    findByAltText: findByAltText$1,
+    findByDisplayValue: findByDisplayValue$1,
+    findByLabelText: findByLabelText$1,
+    findByPlaceholderText: findByPlaceholderText$1,
+    findByRole: findByRole$1,
+    findByTestId: findByTestId$1,
+    findByText: findByText$1,
+    findByTitle: findByTitle$1,
+    fireEvent: fireEvent$2,
+    fireEventObj: fireEventObj$1,
+    getAllByAltText: getAllByAltText$1,
+    getAllByDisplayValue: getAllByDisplayValue$1,
+    getAllByLabelText: getAllByLabelTextWithSuggestions$1,
+    getAllByPlaceholderText: getAllByPlaceholderText$1,
+    getAllByRole: getAllByRole$1,
+    getAllByTestId: getAllByTestId$1,
+    getAllByText: getAllByText$1,
+    getAllByTitle: getAllByTitle$1,
+    getByAltText: getByAltText$1,
+    getByDisplayValue: getByDisplayValue$1,
+    getByLabelText: getByLabelTextWithSuggestions$1,
+    getByPlaceholderText: getByPlaceholderText$1,
+    getByRole: getByRole$1,
+    getByTestId: getByTestId$1,
+    getByText: getByText$1,
+    getByTitle: getByTitle$1,
+    getConfig: getConfig$2,
+    getDefaultNormalizer: getDefaultNormalizer$1,
+    getElementError: getElementError$1,
+    getMultipleElementsFoundError: getMultipleElementsFoundError$1,
+    getNodeText: getNodeText$1,
+    getQueriesForElement: getQueriesForElement$1,
+    getRoles: getRoles$1,
+    getSuggestedQuery: getSuggestedQuery$1,
+    isInaccessible: isInaccessible$1,
+    logDOM: logDOM$1,
+    logRoles: logRoles$1,
+    makeFindQuery: makeFindQuery$1,
+    makeGetAllQuery: makeGetAllQuery$1,
+    makeSingleQuery: makeSingleQuery$1,
+    prettyDOM: prettyDOM$1,
+    prettyFormat: build$1$1,
+    queries: queries$1,
+    queryAllByAltText: queryAllByAltTextWithSuggestions$1,
+    queryAllByAttribute: queryAllByAttribute$1,
+    queryAllByDisplayValue: queryAllByDisplayValueWithSuggestions$1,
+    queryAllByLabelText: queryAllByLabelTextWithSuggestions$1,
+    queryAllByPlaceholderText: queryAllByPlaceholderTextWithSuggestions$1,
+    queryAllByRole: queryAllByRoleWithSuggestions$1,
+    queryAllByTestId: queryAllByTestIdWithSuggestions$1,
+    queryAllByText: queryAllByTextWithSuggestions$1,
+    queryAllByTitle: queryAllByTitleWithSuggestions$1,
+    queryByAltText: queryByAltText$1,
+    queryByAttribute: queryByAttribute$1,
+    queryByDisplayValue: queryByDisplayValue$1,
+    queryByLabelText: queryByLabelText$1,
+    queryByPlaceholderText: queryByPlaceholderText$1,
+    queryByRole: queryByRole$1,
+    queryByTestId: queryByTestId$1,
+    queryByText: queryByText$1,
+    queryByTitle: queryByTitle$1,
+    queryHelpers: queryHelpers$1,
+    render: render$1,
+    screen: screen$1,
+    userEvent: index$2,
+    wait: wait$1$1,
+    waitFor: waitForWrapper$1,
+    waitForDomChange: waitForDomChangeWrapper,
+    waitForElement,
+    waitForElementToBeRemoved: waitForElementToBeRemoved$1,
+    within: getQueriesForElement$1,
+    wrapAllByQueryWithSuggestion: wrapAllByQueryWithSuggestion$1,
+    wrapSingleQueryWithSuggestion: wrapSingleQueryWithSuggestion$1
+  }, Symbol.toStringTag, { value: "Module" }));
   var commonjsGlobal = typeof globalThis !== "undefined" ? globalThis : typeof window !== "undefined" ? window : typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : {};
   function getDefaultExportFromCjs(x2) {
     return x2 && x2.__esModule && Object.prototype.hasOwnProperty.call(x2, "default") ? x2["default"] : x2;
@@ -77,7 +21419,7 @@
    * This source code is licensed under the MIT license found in the
    * LICENSE file in the root directory of this source tree.
    */
-  var k$2 = React, l$1 = ReactDOM;
+  var k$2 = l__default, l$1 = m$1$1;
   function m$2(a) {
     var b2 = a, c2 = a;
     if (a.alternate) for (; b2.return; ) b2 = b2.return;
@@ -536,7 +21878,7 @@
   var testUtilsExports = testUtils.exports;
   var hydrateRoot;
   var createRoot;
-  var m$1 = ReactDOM;
+  var m$1 = m$1$1;
   {
     createRoot = m$1.createRoot;
     hydrateRoot = m$1.hydrateRoot;
@@ -689,17 +22031,17 @@
   const getKeysOfEnumerableProperties = (object, compareKeys) => {
     const keys2 = Object.keys(object).sort(compareKeys);
     if (Object.getOwnPropertySymbols) {
-      Object.getOwnPropertySymbols(object).forEach((symbol) => {
-        if (Object.getOwnPropertyDescriptor(object, symbol).enumerable) {
-          keys2.push(symbol);
+      Object.getOwnPropertySymbols(object).forEach((symbol2) => {
+        if (Object.getOwnPropertyDescriptor(object, symbol2).enumerable) {
+          keys2.push(symbol2);
         }
       });
     }
     return keys2;
   };
-  function printIteratorEntries(iterator, config2, indentation, depth, refs, printer2, separator = ": ") {
+  function printIteratorEntries(iterator2, config2, indentation, depth, refs, printer2, separator = ": ") {
     let result = "";
-    let current = iterator.next();
+    let current = iterator2.next();
     if (!current.done) {
       result += config2.spacingOuter;
       const indentationNext = indentation + config2.indent;
@@ -719,7 +22061,7 @@
           refs
         );
         result += indentationNext + name + separator + value;
-        current = iterator.next();
+        current = iterator2.next();
         if (!current.done) {
           result += "," + config2.spacingInner;
         } else if (!config2.min) {
@@ -730,15 +22072,15 @@
     }
     return result;
   }
-  function printIteratorValues(iterator, config2, indentation, depth, refs, printer2) {
+  function printIteratorValues(iterator2, config2, indentation, depth, refs, printer2) {
     let result = "";
-    let current = iterator.next();
+    let current = iterator2.next();
     if (!current.done) {
       result += config2.spacingOuter;
       const indentationNext = indentation + config2.indent;
       while (!current.done) {
         result += indentationNext + printer2(current.value, config2, indentationNext, depth, refs);
-        current = iterator.next();
+        current = iterator2.next();
         if (!current.done) {
           result += "," + config2.spacingInner;
         } else if (!config2.min) {
@@ -874,8 +22216,8 @@
   function _interopRequireDefault$d(obj) {
     return obj && obj.__esModule ? obj : { default: obj };
   }
-  const toHumanReadableAnsi = (text) => text.replace((0, _ansiRegex.default)(), (match) => {
-    switch (match) {
+  const toHumanReadableAnsi = (text) => text.replace((0, _ansiRegex.default)(), (match2) => {
+    switch (match2) {
       case _ansiStyles$1.default.red.close:
       case _ansiStyles$1.default.green.close:
       case _ansiStyles$1.default.cyan.close:
@@ -941,24 +22283,24 @@
   const testName = (name) => OBJECT_NAMES.indexOf(name) !== -1 || ARRAY_REGEXP.test(name);
   const test$4 = (val) => val && val.constructor && !!val.constructor.name && testName(val.constructor.name);
   DOMCollection$1.test = test$4;
-  const isNamedNodeMap = (collection) => collection.constructor.name === "NamedNodeMap";
-  const serialize$4 = (collection, config2, indentation, depth, refs, printer2) => {
-    const name = collection.constructor.name;
+  const isNamedNodeMap = (collection2) => collection2.constructor.name === "NamedNodeMap";
+  const serialize$4 = (collection2, config2, indentation, depth, refs, printer2) => {
+    const name = collection2.constructor.name;
     if (++depth > config2.maxDepth) {
       return "[" + name + "]";
     }
     return (config2.min ? "" : name + SPACE$1) + (OBJECT_NAMES.indexOf(name) !== -1 ? "{" + (0, _collections$2.printObjectProperties)(
-      isNamedNodeMap(collection) ? Array.from(collection).reduce((props, attribute) => {
+      isNamedNodeMap(collection2) ? Array.from(collection2).reduce((props, attribute) => {
         props[attribute.name] = attribute.value;
         return props;
-      }, {}) : { ...collection },
+      }, {}) : { ...collection2 },
       config2,
       indentation,
       depth,
       refs,
       printer2
     ) + "}" : "[" + (0, _collections$2.printListItems)(
-      Array.from(collection),
+      Array.from(collection2),
       config2,
       indentation,
       depth,
@@ -1461,12 +22803,12 @@
         if (type2.displayName) {
           return type2.displayName;
         }
-        const functionName = type2.render.displayName || type2.render.name || "";
-        return functionName !== "" ? "ForwardRef(" + functionName + ")" : "ForwardRef";
+        const functionName2 = type2.render.displayName || type2.render.name || "";
+        return functionName2 !== "" ? "ForwardRef(" + functionName2 + ")" : "ForwardRef";
       }
       if (ReactIs.isMemo(element)) {
-        const functionName = type2.displayName || type2.type.displayName || type2.type.name || "";
-        return functionName !== "" ? "Memo(" + functionName + ")" : "Memo";
+        const functionName2 = type2.displayName || type2.type.displayName || type2.type.name || "";
+        return functionName2 !== "" ? "Memo(" + functionName2 + ")" : "Memo";
       }
     }
     return "UNDEFINED";
@@ -1630,23 +22972,23 @@
     if (val === null) {
       return "null";
     }
-    const typeOf = typeof val;
-    if (typeOf === "number") {
+    const typeOf2 = typeof val;
+    if (typeOf2 === "number") {
       return printNumber(val);
     }
-    if (typeOf === "bigint") {
+    if (typeOf2 === "bigint") {
       return printBigInt(val);
     }
-    if (typeOf === "string") {
+    if (typeOf2 === "string") {
       if (escapeString) {
         return '"' + val.replace(/"|\\/g, "\\$&") + '"';
       }
       return '"' + val + '"';
     }
-    if (typeOf === "function") {
+    if (typeOf2 === "function") {
       return printFunction(val, printFunctionName);
     }
-    if (typeOf === "symbol") {
+    if (typeOf2 === "symbol") {
       return printSymbol(val);
     }
     const toStringed = toString$1.call(val);
@@ -1942,9 +23284,9 @@
       return plugins_1;
     }
   }, [build$1]);
-  var toStr$7 = Object.prototype.toString;
+  var toStr$6 = Object.prototype.toString;
   function isCallable$2(fn2) {
-    return typeof fn2 === "function" || toStr$7.call(fn2) === "[object Function]";
+    return typeof fn2 === "function" || toStr$6.call(fn2) === "[object Function]";
   }
   function toInteger(value) {
     var number = Number(value);
@@ -2040,7 +23382,7 @@
     }
     _createClass(SetLike2, [{
       key: "add",
-      value: function add(value) {
+      value: function add2(value) {
         if (this.has(value) === false) {
           this.items.push(value);
         }
@@ -2313,8 +23655,8 @@
     if (isElement$1(node) && node.hasAttribute(attributeName)) {
       var ids = node.getAttribute(attributeName).split(" ");
       var root = node.getRootNode ? node.getRootNode() : node.ownerDocument;
-      return ids.map(function(id) {
-        return root.getElementById(id);
+      return ids.map(function(id2) {
+        return root.getElementById(id2);
       }).filter(
         function(element) {
           return element !== null;
@@ -2757,8 +24099,8 @@
       }));
     }).join(" ");
     if (description === "") {
-      var title = root.getAttribute("title");
-      description = title === null ? "" : title;
+      var title2 = root.getAttribute("title");
+      description = title2 === null ? "" : title2;
     }
     return description;
   }
@@ -2784,7 +24126,7 @@
     var values = this;
     var index2 = 0;
     var iter = {
-      "@@iterator": function iterator() {
+      "@@iterator": function iterator2() {
         return iter;
       },
       next: function next() {
@@ -2822,13 +24164,13 @@
       return obj2 && "function" == typeof Symbol && obj2.constructor === Symbol && obj2 !== Symbol.prototype ? "symbol" : typeof obj2;
     }, _typeof(obj);
   }
-  function iterationDecorator(collection, entries) {
+  function iterationDecorator(collection2, entries2) {
     if (typeof Symbol === "function" && _typeof(Symbol.iterator) === "symbol") {
-      Object.defineProperty(collection, Symbol.iterator, {
-        value: _iteratorProxy.default.bind(entries)
+      Object.defineProperty(collection2, Symbol.iterator, {
+        value: _iteratorProxy.default.bind(entries2)
       });
     }
-    return collection;
+    return collection2;
   }
   Object.defineProperty(ariaPropsMap$1, "__esModule", {
     value: true
@@ -3032,7 +24374,7 @@
     "type": "string"
   }]];
   var ariaPropsMap = {
-    entries: function entries() {
+    entries: function entries2() {
       return properties;
     },
     forEach: function forEach2(fn2) {
@@ -3425,7 +24767,7 @@
     reserved: false
   }]];
   var domMap = {
-    entries: function entries() {
+    entries: function entries2() {
       return dom$1;
     },
     forEach: function forEach2(fn2) {
@@ -8322,7 +29664,7 @@
     }
   });
   var rolesMap = {
-    entries: function entries() {
+    entries: function entries2() {
       return roles$1;
     },
     forEach: function forEach2(fn2) {
@@ -8364,20 +29706,20 @@
   var _default$2 = (0, _iterationDecorator$2.default)(rolesMap, rolesMap.entries());
   rolesMap$1.default = _default$2;
   var elementRoleMap$1 = {};
-  var toStr$6 = Object.prototype.toString;
+  var toStr$5 = Object.prototype.toString;
   var isArguments$3 = function isArguments2(value) {
-    var str = toStr$6.call(value);
+    var str = toStr$5.call(value);
     var isArgs2 = str === "[object Arguments]";
     if (!isArgs2) {
-      isArgs2 = str !== "[object Array]" && value !== null && typeof value === "object" && typeof value.length === "number" && value.length >= 0 && toStr$6.call(value.callee) === "[object Function]";
+      isArgs2 = str !== "[object Array]" && value !== null && typeof value === "object" && typeof value.length === "number" && value.length >= 0 && toStr$5.call(value.callee) === "[object Function]";
     }
     return isArgs2;
   };
-  var implementation$b;
-  var hasRequiredImplementation;
-  function requireImplementation() {
-    if (hasRequiredImplementation) return implementation$b;
-    hasRequiredImplementation = 1;
+  var implementation$a;
+  var hasRequiredImplementation$1;
+  function requireImplementation$1() {
+    if (hasRequiredImplementation$1) return implementation$a;
+    hasRequiredImplementation$1 = 1;
     var keysShim2;
     if (!Object.keys) {
       var has2 = Object.prototype.hasOwnProperty;
@@ -8455,12 +29797,12 @@
         }
       };
       keysShim2 = function keys2(object) {
-        var isObject = object !== null && typeof object === "object";
+        var isObject2 = object !== null && typeof object === "object";
         var isFunction2 = toStr2.call(object) === "[object Function]";
         var isArguments2 = isArgs2(object);
-        var isString2 = isObject && toStr2.call(object) === "[object String]";
+        var isString2 = isObject2 && toStr2.call(object) === "[object String]";
         var theKeys = [];
-        if (!isObject && !isFunction2 && !isArguments2) {
+        if (!isObject2 && !isFunction2 && !isArguments2) {
           throw new TypeError("Object.keys called on a non-object");
         }
         var skipProto = hasProtoEnumBug && isFunction2;
@@ -8491,15 +29833,15 @@
         return theKeys;
       };
     }
-    implementation$b = keysShim2;
-    return implementation$b;
+    implementation$a = keysShim2;
+    return implementation$a;
   }
   var slice = Array.prototype.slice;
   var isArgs = isArguments$3;
   var origKeys = Object.keys;
   var keysShim = origKeys ? function keys2(o) {
     return origKeys(o);
-  } : requireImplementation();
+  } : requireImplementation$1();
   var originalKeys = Object.keys;
   keysShim.shim = function shimObjectKeys() {
     if (Object.keys) {
@@ -8600,11 +29942,11 @@
   var hasPropertyDescriptors_1 = hasPropertyDescriptors;
   var keys$2 = objectKeys$2;
   var hasSymbols$5 = typeof Symbol === "function" && typeof Symbol("foo") === "symbol";
-  var toStr$5 = Object.prototype.toString;
+  var toStr$4 = Object.prototype.toString;
   var concat = Array.prototype.concat;
   var defineDataProperty = defineDataProperty$1;
   var isFunction = function(fn2) {
-    return typeof fn2 === "function" && toStr$5.call(fn2) === "[object Function]";
+    return typeof fn2 === "function" && toStr$4.call(fn2) === "[object Function]";
   };
   var supportsDescriptors$2 = hasPropertyDescriptors_1();
   var defineProperty$1 = function(object, name, value, predicate) {
@@ -8623,14 +29965,14 @@
       defineDataProperty(object, name, value);
     }
   };
-  var defineProperties$1 = function(object, map) {
+  var defineProperties$1 = function(object, map2) {
     var predicates = arguments.length > 2 ? arguments[2] : {};
-    var props = keys$2(map);
+    var props = keys$2(map2);
     if (hasSymbols$5) {
-      props = concat.call(props, Object.getOwnPropertySymbols(map));
+      props = concat.call(props, Object.getOwnPropertySymbols(map2));
     }
     for (var i2 = 0; i2 < props.length; i2 += 1) {
-      defineProperty$1(object, props[i2], map[props[i2]], predicates[props[i2]]);
+      defineProperty$1(object, props[i2], map2[props[i2]], predicates[props[i2]]);
     }
   };
   defineProperties$1.supportsDescriptors = !!supportsDescriptors$2;
@@ -8644,7 +29986,7 @@
   var uri = URIError;
   var abs$1 = Math.abs;
   var floor$1 = Math.floor;
-  var max$2 = Math.max;
+  var max$1 = Math.max;
   var min$1 = Math.min;
   var pow$1 = Math.pow;
   var shams$1 = function hasSymbols2() {
@@ -8712,77 +30054,91 @@
     }
     return hasSymbolSham();
   };
-  var ERROR_MESSAGE = "Function.prototype.bind called on incompatible ";
-  var toStr$4 = Object.prototype.toString;
-  var max$1 = Math.max;
-  var funcType = "[object Function]";
-  var concatty = function concatty2(a, b2) {
-    var arr = [];
-    for (var i2 = 0; i2 < a.length; i2 += 1) {
-      arr[i2] = a[i2];
-    }
-    for (var j = 0; j < b2.length; j += 1) {
-      arr[j + a.length] = b2[j];
-    }
-    return arr;
-  };
-  var slicy = function slicy2(arrLike, offset) {
-    var arr = [];
-    for (var i2 = offset, j = 0; i2 < arrLike.length; i2 += 1, j += 1) {
-      arr[j] = arrLike[i2];
-    }
-    return arr;
-  };
-  var joiny = function(arr, joiner) {
-    var str = "";
-    for (var i2 = 0; i2 < arr.length; i2 += 1) {
-      str += arr[i2];
-      if (i2 + 1 < arr.length) {
-        str += joiner;
+  var implementation$9;
+  var hasRequiredImplementation;
+  function requireImplementation() {
+    if (hasRequiredImplementation) return implementation$9;
+    hasRequiredImplementation = 1;
+    var ERROR_MESSAGE = "Function.prototype.bind called on incompatible ";
+    var toStr2 = Object.prototype.toString;
+    var max2 = Math.max;
+    var funcType = "[object Function]";
+    var concatty = function concatty2(a, b2) {
+      var arr = [];
+      for (var i2 = 0; i2 < a.length; i2 += 1) {
+        arr[i2] = a[i2];
       }
-    }
-    return str;
-  };
-  var implementation$a = function bind2(that) {
-    var target = this;
-    if (typeof target !== "function" || toStr$4.apply(target) !== funcType) {
-      throw new TypeError(ERROR_MESSAGE + target);
-    }
-    var args = slicy(arguments, 1);
-    var bound2;
-    var binder = function() {
-      if (this instanceof bound2) {
-        var result = target.apply(
-          this,
+      for (var j = 0; j < b2.length; j += 1) {
+        arr[j + a.length] = b2[j];
+      }
+      return arr;
+    };
+    var slicy = function slicy2(arrLike, offset) {
+      var arr = [];
+      for (var i2 = offset, j = 0; i2 < arrLike.length; i2 += 1, j += 1) {
+        arr[j] = arrLike[i2];
+      }
+      return arr;
+    };
+    var joiny = function(arr, joiner) {
+      var str = "";
+      for (var i2 = 0; i2 < arr.length; i2 += 1) {
+        str += arr[i2];
+        if (i2 + 1 < arr.length) {
+          str += joiner;
+        }
+      }
+      return str;
+    };
+    implementation$9 = function bind2(that) {
+      var target = this;
+      if (typeof target !== "function" || toStr2.apply(target) !== funcType) {
+        throw new TypeError(ERROR_MESSAGE + target);
+      }
+      var args = slicy(arguments, 1);
+      var bound2;
+      var binder = function() {
+        if (this instanceof bound2) {
+          var result = target.apply(
+            this,
+            concatty(args, arguments)
+          );
+          if (Object(result) === result) {
+            return result;
+          }
+          return this;
+        }
+        return target.apply(
+          that,
           concatty(args, arguments)
         );
-        if (Object(result) === result) {
-          return result;
-        }
-        return this;
-      }
-      return target.apply(
-        that,
-        concatty(args, arguments)
-      );
-    };
-    var boundLength = max$1(0, target.length - args.length);
-    var boundArgs = [];
-    for (var i2 = 0; i2 < boundLength; i2++) {
-      boundArgs[i2] = "$" + i2;
-    }
-    bound2 = Function("binder", "return function (" + joiny(boundArgs, ",") + "){ return binder.apply(this,arguments); }")(binder);
-    if (target.prototype) {
-      var Empty = function Empty2() {
       };
-      Empty.prototype = target.prototype;
-      bound2.prototype = new Empty();
-      Empty.prototype = null;
-    }
-    return bound2;
-  };
-  var implementation$9 = implementation$a;
-  var functionBind = Function.prototype.bind || implementation$9;
+      var boundLength = max2(0, target.length - args.length);
+      var boundArgs = [];
+      for (var i2 = 0; i2 < boundLength; i2++) {
+        boundArgs[i2] = "$" + i2;
+      }
+      bound2 = Function("binder", "return function (" + joiny(boundArgs, ",") + "){ return binder.apply(this,arguments); }")(binder);
+      if (target.prototype) {
+        var Empty = function Empty2() {
+        };
+        Empty.prototype = target.prototype;
+        bound2.prototype = new Empty();
+        Empty.prototype = null;
+      }
+      return bound2;
+    };
+    return implementation$9;
+  }
+  var functionBind;
+  var hasRequiredFunctionBind;
+  function requireFunctionBind() {
+    if (hasRequiredFunctionBind) return functionBind;
+    hasRequiredFunctionBind = 1;
+    var implementation2 = requireImplementation();
+    functionBind = Function.prototype.bind || implementation2;
+    return functionBind;
+  }
   var functionCall;
   var hasRequiredFunctionCall;
   function requireFunctionCall() {
@@ -8800,12 +30156,12 @@
     return functionApply;
   }
   var reflectApply$1 = typeof Reflect !== "undefined" && Reflect && Reflect.apply;
-  var bind$4 = functionBind;
+  var bind$4 = requireFunctionBind();
   var $apply$2 = requireFunctionApply();
   var $call$2 = requireFunctionCall();
   var $reflectApply = reflectApply$1;
   var actualApply$1 = $reflectApply || bind$4.call($call$2, $apply$2);
-  var bind$3 = functionBind;
+  var bind$3 = requireFunctionBind();
   var $TypeError$9 = type$2;
   var $call$1 = requireFunctionCall();
   var $actualApply = actualApply$1;
@@ -8848,7 +30204,7 @@
   }
   var call = Function.prototype.call;
   var $hasOwn = Object.prototype.hasOwnProperty;
-  var bind$2 = functionBind;
+  var bind$2 = requireFunctionBind();
   var hasown = bind$2.call(call, $hasOwn);
   var undefined$1;
   var $Object$2 = esObjectAtoms;
@@ -8861,7 +30217,7 @@
   var $URIError = uri;
   var abs = abs$1;
   var floor = floor$1;
-  var max = max$2;
+  var max = max$1;
   var min = min$1;
   var pow = pow$1;
   var $Function = Function;
@@ -9058,7 +30414,7 @@
     "%WeakMapPrototype%": ["WeakMap", "prototype"],
     "%WeakSetPrototype%": ["WeakSet", "prototype"]
   };
-  var bind$1 = functionBind;
+  var bind$1 = requireFunctionBind();
   var hasOwn$3 = hasown;
   var $concat$1 = bind$1.call($call, Array.prototype.concat);
   var $spliceApply = bind$1.call($apply$1, Array.prototype.splice);
@@ -9076,8 +30432,8 @@
       throw new $SyntaxError$1("invalid intrinsic syntax, expected opening `%`");
     }
     var result = [];
-    $replace$1(string, rePropName, function(match, number, quote2, subString) {
-      result[result.length] = quote2 ? $replace$1(subString, reEscapeChar, "$1") : number || match;
+    $replace$1(string, rePropName, function(match2, number, quote2, subString) {
+      result[result.length] = quote2 ? $replace$1(subString, reEscapeChar, "$1") : number || match2;
     });
     return result;
   };
@@ -9211,7 +30567,7 @@
     }
     return fn2;
   };
-  var bind = functionBind;
+  var bind = requireFunctionBind();
   var $apply = requireFunctionApply();
   var actualApply = actualApply$1;
   var applyBind = function applyBind2() {
@@ -9267,22 +30623,22 @@
       return to;
     }
     for (var s = 1; s < arguments.length; ++s) {
-      var from = $Object$1(arguments[s]);
-      var keys2 = objectKeys$1(from);
+      var from2 = $Object$1(arguments[s]);
+      var keys2 = objectKeys$1(from2);
       var getSymbols = hasSymbols$2 && ($Object$1.getOwnPropertySymbols || originalGetSymbols);
       if (getSymbols) {
-        var syms = getSymbols(from);
+        var syms = getSymbols(from2);
         for (var j = 0; j < syms.length; ++j) {
           var key2 = syms[j];
-          if ($propIsEnumerable(from, key2)) {
+          if ($propIsEnumerable(from2, key2)) {
             $push(keys2, key2);
           }
         }
       }
       for (var i2 = 0; i2 < keys2.length; ++i2) {
         var nextKey = keys2[i2];
-        if ($propIsEnumerable(from, nextKey)) {
-          var propValue = from[nextKey];
+        if ($propIsEnumerable(from2, nextKey)) {
+          var propValue = from2[nextKey];
           to[nextKey] = propValue;
         }
       }
@@ -9296,11 +30652,11 @@
     }
     var str = "abcdefghijklmnopqrst";
     var letters = str.split("");
-    var map = {};
+    var map2 = {};
     for (var i2 = 0; i2 < letters.length; ++i2) {
-      map[letters[i2]] = letters[i2];
+      map2[letters[i2]] = letters[i2];
     }
-    var obj = Object.assign({}, map);
+    var obj = Object.assign({}, map2);
     var actual = "";
     for (var k2 in obj) {
       actual += k2;
@@ -9671,10 +31027,10 @@
     } else if (indexOf(seen, obj) >= 0) {
       return "[Circular]";
     }
-    function inspect2(value, from, noIndent) {
-      if (from) {
+    function inspect2(value, from2, noIndent) {
+      if (from2) {
         seen = $arrSlice.call(seen);
-        seen.push(from);
+        seen.push(from2);
       }
       if (noIndent) {
         var newOpts = {
@@ -10000,9 +31356,9 @@
   function weakCollectionOf(type2) {
     return type2 + " { ? }";
   }
-  function collectionOf(type2, size, entries, indent) {
-    var joinedEntries = indent ? indentedJoin(entries, indent) : $join.call(entries, ", ");
-    return type2 + " (" + size + ") {" + joinedEntries + "}";
+  function collectionOf(type2, size2, entries2, indent) {
+    var joinedEntries = indent ? indentedJoin(entries2, indent) : $join.call(entries2, ", ");
+    return type2 + " (" + size2 + ") {" + joinedEntries + "}";
   }
   function singleLineValues(xs) {
     for (var i2 = 0; i2 < xs.length; i2++) {
@@ -10385,22 +31741,22 @@
       next: (
         /** @type {() => IteratorResult<T>} */
         function next() {
-          var iterator = (
+          var iterator2 = (
             /** @type {typeof origIterator} */
             SLOT.get(this, "[[Iterator]]")
           );
-          var done = !!SLOT.get(iterator, "[[Done]]");
+          var done = !!SLOT.get(iterator2, "[[Done]]");
           try {
             return {
               done,
               // eslint-disable-next-line no-extra-parens
               value: done ? void 0 : (
                 /** @type {T} */
-                iterator.next()
+                iterator2.next()
               )
             };
           } catch (e2) {
-            SLOT.set(iterator, "[[Done]]", true);
+            SLOT.set(iterator2, "[[Done]]", true);
             if (e2 !== $StopIteration) {
               throw e2;
             }
@@ -10609,11 +31965,11 @@
             return $mapAtAtIterator(iterable);
           }
           if ($mapForEach) {
-            var entries = [];
+            var entries2 = [];
             $mapForEach(iterable, function(v2, k2) {
-              $arrayPush(entries, [k2, v2]);
+              $arrayPush(entries2, [k2, v2]);
             });
-            return getArrayIterator(entries);
+            return getArrayIterator(entries2);
           }
         }
         if (isSet$1(iterable)) {
@@ -11147,39 +32503,39 @@
   var isCallable = isCallable$1;
   var toStr = Object.prototype.toString;
   var hasOwnProperty = Object.prototype.hasOwnProperty;
-  var forEachArray = function forEachArray2(array, iterator, receiver) {
+  var forEachArray = function forEachArray2(array, iterator2, receiver) {
     for (var i2 = 0, len = array.length; i2 < len; i2++) {
       if (hasOwnProperty.call(array, i2)) {
         if (receiver == null) {
-          iterator(array[i2], i2, array);
+          iterator2(array[i2], i2, array);
         } else {
-          iterator.call(receiver, array[i2], i2, array);
+          iterator2.call(receiver, array[i2], i2, array);
         }
       }
     }
   };
-  var forEachString = function forEachString2(string, iterator, receiver) {
+  var forEachString = function forEachString2(string, iterator2, receiver) {
     for (var i2 = 0, len = string.length; i2 < len; i2++) {
       if (receiver == null) {
-        iterator(string.charAt(i2), i2, string);
+        iterator2(string.charAt(i2), i2, string);
       } else {
-        iterator.call(receiver, string.charAt(i2), i2, string);
+        iterator2.call(receiver, string.charAt(i2), i2, string);
       }
     }
   };
-  var forEachObject = function forEachObject2(object, iterator, receiver) {
+  var forEachObject = function forEachObject2(object, iterator2, receiver) {
     for (var k2 in object) {
       if (hasOwnProperty.call(object, k2)) {
         if (receiver == null) {
-          iterator(object[k2], k2, object);
+          iterator2(object[k2], k2, object);
         } else {
-          iterator.call(receiver, object[k2], k2, object);
+          iterator2.call(receiver, object[k2], k2, object);
         }
       }
     }
   };
-  var forEach$1 = function forEach2(list, iterator, thisArg) {
-    if (!isCallable(iterator)) {
+  var forEach$1 = function forEach2(list, iterator2, thisArg) {
+    if (!isCallable(iterator2)) {
       throw new TypeError("iterator must be a function");
     }
     var receiver;
@@ -11187,11 +32543,11 @@
       receiver = thisArg;
     }
     if (toStr.call(list) === "[object Array]") {
-      forEachArray(list, iterator, receiver);
+      forEachArray(list, iterator2, receiver);
     } else if (typeof list === "string") {
-      forEachString(list, iterator, receiver);
+      forEachString(list, iterator2, receiver);
     } else {
-      forEachObject(list, iterator, receiver);
+      forEachObject(list, iterator2, receiver);
     }
   };
   var forEach_1 = forEach$1;
@@ -11360,12 +32716,12 @@
   var $setDelete = callBound("Set.prototype.delete", true);
   var $setHas = callBound("Set.prototype.has", true);
   var $setSize = callBound("Set.prototype.size", true);
-  function setHasEqualElement(set, val1, opts, channel2) {
-    var i2 = getIterator(set);
+  function setHasEqualElement(set2, val1, opts, channel2) {
+    var i2 = getIterator(set2);
     var result;
     while ((result = i2.next()) && !result.done) {
       if (internalDeepEqual(val1, result.value, opts, channel2)) {
-        $setDelete(set, result.value);
+        $setDelete(set2, result.value);
         return true;
       }
     }
@@ -11405,17 +32761,17 @@
     }
     return $setHas(b2, altValue) && !$setHas(a, altValue);
   }
-  function mapHasEqualEntry(set, map, key1, item1, opts, channel2) {
-    var i2 = getIterator(set);
+  function mapHasEqualEntry(set2, map2, key1, item1, opts, channel2) {
+    var i2 = getIterator(set2);
     var result;
     var key2;
     while ((result = i2.next()) && !result.done) {
       key2 = result.value;
       if (
         // eslint-disable-next-line no-use-before-define
-        internalDeepEqual(key1, key2, opts, channel2) && internalDeepEqual(item1, $mapGet(map, key2), opts, channel2)
+        internalDeepEqual(key1, key2, opts, channel2) && internalDeepEqual(item1, $mapGet(map2, key2), opts, channel2)
       ) {
-        $setDelete(set, key2);
+        $setDelete(set2, key2);
         return true;
       }
     }
@@ -11472,13 +32828,13 @@
     var iB = getIterator(b2);
     var resultA;
     var resultB;
-    var set;
+    var set2;
     while ((resultA = iA.next()) && !resultA.done) {
       if (resultA.value && typeof resultA.value === "object") {
-        if (!set) {
-          set = new $Set();
+        if (!set2) {
+          set2 = new $Set();
         }
-        $setAdd(set, resultA.value);
+        $setAdd(set2, resultA.value);
       } else if (!$setHas(b2, resultA.value)) {
         if (opts.strict) {
           return false;
@@ -11486,23 +32842,23 @@
         if (!setMightHaveLoosePrim(a, b2, resultA.value)) {
           return false;
         }
-        if (!set) {
-          set = new $Set();
+        if (!set2) {
+          set2 = new $Set();
         }
-        $setAdd(set, resultA.value);
+        $setAdd(set2, resultA.value);
       }
     }
-    if (set) {
+    if (set2) {
       while ((resultB = iB.next()) && !resultB.done) {
         if (resultB.value && typeof resultB.value === "object") {
-          if (!setHasEqualElement(set, resultB.value, opts.strict, channel2)) {
+          if (!setHasEqualElement(set2, resultB.value, opts.strict, channel2)) {
             return false;
           }
-        } else if (!opts.strict && !$setHas(a, resultB.value) && !setHasEqualElement(set, resultB.value, opts.strict, channel2)) {
+        } else if (!opts.strict && !$setHas(a, resultB.value) && !setHasEqualElement(set2, resultB.value, opts.strict, channel2)) {
           return false;
         }
       }
-      return $setSize(set) === 0;
+      return $setSize(set2) === 0;
     }
     return true;
   }
@@ -11514,7 +32870,7 @@
     var iB = getIterator(b2);
     var resultA;
     var resultB;
-    var set;
+    var set2;
     var key2;
     var item1;
     var item2;
@@ -11522,10 +32878,10 @@
       key2 = resultA.value[0];
       item1 = resultA.value[1];
       if (key2 && typeof key2 === "object") {
-        if (!set) {
-          set = new $Set();
+        if (!set2) {
+          set2 = new $Set();
         }
-        $setAdd(set, key2);
+        $setAdd(set2, key2);
       } else {
         item2 = $mapGet(b2, key2);
         if (typeof item2 === "undefined" && !$mapHas(b2, key2) || !internalDeepEqual(item1, item2, opts, channel2)) {
@@ -11535,26 +32891,26 @@
           if (!mapMightHaveLoosePrim(a, b2, key2, item1, opts, channel2)) {
             return false;
           }
-          if (!set) {
-            set = new $Set();
+          if (!set2) {
+            set2 = new $Set();
           }
-          $setAdd(set, key2);
+          $setAdd(set2, key2);
         }
       }
     }
-    if (set) {
+    if (set2) {
       while ((resultB = iB.next()) && !resultB.done) {
         key2 = resultB.value[0];
         item2 = resultB.value[1];
         if (key2 && typeof key2 === "object") {
-          if (!mapHasEqualEntry(set, a, key2, item2, opts, channel2)) {
+          if (!mapHasEqualEntry(set2, a, key2, item2, opts, channel2)) {
             return false;
           }
-        } else if (!opts.strict && (!a.has(key2) || !internalDeepEqual($mapGet(a, key2), item2, opts, channel2)) && !mapHasEqualEntry(set, a, key2, item2, assign({}, opts, { strict: false }), channel2)) {
+        } else if (!opts.strict && (!a.has(key2) || !internalDeepEqual($mapGet(a, key2), item2, opts, channel2)) && !mapHasEqualEntry(set2, a, key2, item2, assign({}, opts, { strict: false }), channel2)) {
           return false;
         }
       }
-      return $setSize(set) === 0;
+      return $setSize(set2) === 0;
     }
     return true;
   }
@@ -11833,7 +33189,7 @@
     }
   }
   var elementRoleMap = {
-    entries: function entries() {
+    entries: function entries2() {
       return elementRoles$1;
     },
     forEach: function forEach2(fn2) {
@@ -11999,7 +33355,7 @@
     _loop(i);
   }
   var roleElementMap = {
-    entries: function entries() {
+    entries: function entries2() {
       return roleElement;
     },
     forEach: function forEach2(fn2) {
@@ -12363,7 +33719,7 @@
           });
         },
         _decompress: function(length, resetValue, getNextValue) {
-          var dictionary = [], enlargeIn = 4, dictSize = 4, numBits = 3, entry = "", result = [], i2, w2, bits, resb, maxpower, power, c2, data = { val: getNextValue(0), position: resetValue, index: 1 };
+          var dictionary = [], enlargeIn = 4, dictSize = 4, numBits = 3, entry = "", result = [], i2, w2, bits, resb, maxpower, power, c2, data2 = { val: getNextValue(0), position: resetValue, index: 1 };
           for (i2 = 0; i2 < 3; i2 += 1) {
             dictionary[i2] = i2;
           }
@@ -12371,11 +33727,11 @@
           maxpower = Math.pow(2, 2);
           power = 1;
           while (power != maxpower) {
-            resb = data.val & data.position;
-            data.position >>= 1;
-            if (data.position == 0) {
-              data.position = resetValue;
-              data.val = getNextValue(data.index++);
+            resb = data2.val & data2.position;
+            data2.position >>= 1;
+            if (data2.position == 0) {
+              data2.position = resetValue;
+              data2.val = getNextValue(data2.index++);
             }
             bits |= (resb > 0 ? 1 : 0) * power;
             power <<= 1;
@@ -12386,11 +33742,11 @@
               maxpower = Math.pow(2, 8);
               power = 1;
               while (power != maxpower) {
-                resb = data.val & data.position;
-                data.position >>= 1;
-                if (data.position == 0) {
-                  data.position = resetValue;
-                  data.val = getNextValue(data.index++);
+                resb = data2.val & data2.position;
+                data2.position >>= 1;
+                if (data2.position == 0) {
+                  data2.position = resetValue;
+                  data2.val = getNextValue(data2.index++);
                 }
                 bits |= (resb > 0 ? 1 : 0) * power;
                 power <<= 1;
@@ -12402,11 +33758,11 @@
               maxpower = Math.pow(2, 16);
               power = 1;
               while (power != maxpower) {
-                resb = data.val & data.position;
-                data.position >>= 1;
-                if (data.position == 0) {
-                  data.position = resetValue;
-                  data.val = getNextValue(data.index++);
+                resb = data2.val & data2.position;
+                data2.position >>= 1;
+                if (data2.position == 0) {
+                  data2.position = resetValue;
+                  data2.val = getNextValue(data2.index++);
                 }
                 bits |= (resb > 0 ? 1 : 0) * power;
                 power <<= 1;
@@ -12420,18 +33776,18 @@
           w2 = c2;
           result.push(c2);
           while (true) {
-            if (data.index > length) {
+            if (data2.index > length) {
               return "";
             }
             bits = 0;
             maxpower = Math.pow(2, numBits);
             power = 1;
             while (power != maxpower) {
-              resb = data.val & data.position;
-              data.position >>= 1;
-              if (data.position == 0) {
-                data.position = resetValue;
-                data.val = getNextValue(data.index++);
+              resb = data2.val & data2.position;
+              data2.position >>= 1;
+              if (data2.position == 0) {
+                data2.position = resetValue;
+                data2.val = getNextValue(data2.index++);
               }
               bits |= (resb > 0 ? 1 : 0) * power;
               power <<= 1;
@@ -12442,11 +33798,11 @@
                 maxpower = Math.pow(2, 8);
                 power = 1;
                 while (power != maxpower) {
-                  resb = data.val & data.position;
-                  data.position >>= 1;
-                  if (data.position == 0) {
-                    data.position = resetValue;
-                    data.val = getNextValue(data.index++);
+                  resb = data2.val & data2.position;
+                  data2.position >>= 1;
+                  if (data2.position == 0) {
+                    data2.position = resetValue;
+                    data2.val = getNextValue(data2.index++);
                   }
                   bits |= (resb > 0 ? 1 : 0) * power;
                   power <<= 1;
@@ -12460,11 +33816,11 @@
                 maxpower = Math.pow(2, 16);
                 power = 1;
                 while (power != maxpower) {
-                  resb = data.val & data.position;
-                  data.position >>= 1;
-                  if (data.position == 0) {
-                    data.position = resetValue;
-                    data.val = getNextValue(data.index++);
+                  resb = data2.val & data2.position;
+                  data2.position >>= 1;
+                  if (data2.position == 0) {
+                    data2.position = resetValue;
+                    data2.val = getNextValue(data2.index++);
                   }
                   bits |= (resb > 0 ? 1 : 0) * power;
                   power <<= 1;
@@ -12605,10 +33961,10 @@
   let readFileSync = null;
   let codeFrameColumns = null;
   try {
-    const nodeRequire = module && module.require;
-    readFileSync = nodeRequire.call(module, "fs").readFileSync;
-    codeFrameColumns = nodeRequire.call(module, "@babel/code-frame").codeFrameColumns;
-    chalk = nodeRequire.call(module, "chalk");
+    const nodeRequire2 = module && module.require;
+    readFileSync = nodeRequire2.call(module, "fs").readFileSync;
+    codeFrameColumns = nodeRequire2.call(module, "@babel/code-frame").codeFrameColumns;
+    chalk = nodeRequire2.call(module, "chalk");
   } catch {
   }
   function getCodeFrame(frame) {
@@ -12926,12 +34282,12 @@
     return normalizer;
   }
   function matchRegExp(matcher, text) {
-    const match = matcher.test(text);
+    const match2 = matcher.test(text);
     if (matcher.global && matcher.lastIndex !== 0) {
       console.warn("To match all elements we had to reset the lastIndex of the RegExp because the global flag is enabled. We encourage to remove the global flag from the RegExp.");
       matcher.lastIndex = 0;
     }
-    return match;
+    return match2;
   }
   function getNodeText(node) {
     if (node.matches("input[type=submit], input[type=button], input[type=reset]")) {
@@ -12975,10 +34331,10 @@
   }
   function getImplicitAriaRoles(currentNode) {
     for (const {
-      match,
+      match: match2,
       roles: roles2
     } of elementRoleList) {
-      if (match(currentNode)) {
+      if (match2(currentNode)) {
         return [...roles2];
       }
     }
@@ -13021,7 +34377,7 @@
       } = _ref5;
       return rightSpecificity - leftSpecificity;
     }
-    function match(element) {
+    function match2(element) {
       let {
         attributes = []
       } = element;
@@ -13043,7 +34399,7 @@
     let result = [];
     for (const [element, roles2] of elementRolesMap.entries()) {
       result = [...result, {
-        match: match(element),
+        match: match2(element),
         roles: Array.from(roles2),
         specificity: getSelectorSpecificity(element)
       }];
@@ -13206,10 +34562,10 @@
       }
     };
   }
-  function canSuggest(currentMethod, requestedMethod, data) {
-    return data && (!requestedMethod || requestedMethod.toLowerCase() === currentMethod.toLowerCase());
+  function canSuggest(currentMethod, requestedMethod, data2) {
+    return data2 && (!requestedMethod || requestedMethod.toLowerCase() === currentMethod.toLowerCase());
   }
-  function getSuggestedQuery(element, variant, method) {
+  function getSuggestedQuery(element, variant, method2) {
     var _element$getAttribute, _getImplicitAriaRoles;
     if (variant === void 0) {
       variant = "get";
@@ -13218,7 +34574,7 @@
       return void 0;
     }
     const role2 = (_element$getAttribute = element.getAttribute("role")) != null ? _element$getAttribute : (_getImplicitAriaRoles = getImplicitAriaRoles(element)) == null ? void 0 : _getImplicitAriaRoles[0];
-    if (role2 !== "generic" && canSuggest("Role", method, role2)) {
+    if (role2 !== "generic" && canSuggest("Role", method2, role2)) {
       return makeSuggestion("Role", element, role2, {
         variant,
         name: computeAccessibleName(element, {
@@ -13227,42 +34583,42 @@
       });
     }
     const labelText = getLabels(document, element).map((label) => label.content).join(" ");
-    if (canSuggest("LabelText", method, labelText)) {
+    if (canSuggest("LabelText", method2, labelText)) {
       return makeSuggestion("LabelText", element, labelText, {
         variant
       });
     }
     const placeholderText = element.getAttribute("placeholder");
-    if (canSuggest("PlaceholderText", method, placeholderText)) {
+    if (canSuggest("PlaceholderText", method2, placeholderText)) {
       return makeSuggestion("PlaceholderText", element, placeholderText, {
         variant
       });
     }
     const textContent = normalize(getNodeText(element));
-    if (canSuggest("Text", method, textContent)) {
+    if (canSuggest("Text", method2, textContent)) {
       return makeSuggestion("Text", element, textContent, {
         variant
       });
     }
-    if (canSuggest("DisplayValue", method, element.value)) {
+    if (canSuggest("DisplayValue", method2, element.value)) {
       return makeSuggestion("DisplayValue", element, normalize(element.value), {
         variant
       });
     }
     const alt = element.getAttribute("alt");
-    if (canSuggest("AltText", method, alt)) {
+    if (canSuggest("AltText", method2, alt)) {
       return makeSuggestion("AltText", element, alt, {
         variant
       });
     }
-    const title = element.getAttribute("title");
-    if (canSuggest("Title", method, title)) {
-      return makeSuggestion("Title", element, title, {
+    const title2 = element.getAttribute("title");
+    if (canSuggest("Title", method2, title2)) {
+      return makeSuggestion("Title", element, title2, {
         variant
       });
     }
     const testId = element.getAttribute(getConfig().testIdAttribute);
-    if (canSuggest("TestId", method, testId)) {
+    if (canSuggest("TestId", method2, testId)) {
       return makeSuggestion("TestId", element, testId, {
         variant
       });
@@ -13770,8 +35126,8 @@
     });
     return Array.from(container.querySelectorAll("[title], svg > title")).filter((node) => matcher(node.getAttribute("title"), node, text, matchNormalizer) || isSvgTitle(node) && matcher(getNodeText(node), node, text, matchNormalizer));
   };
-  const getMultipleError$2 = (c2, title) => "Found multiple elements with the title: " + title + ".";
-  const getMissingError$2 = (c2, title) => "Unable to find an element with the title: " + title + ".";
+  const getMultipleError$2 = (c2, title2) => "Found multiple elements with the title: " + title2 + ".";
+  const getMissingError$2 = (c2, title2) => "Unable to find an element with the title: " + title2 + ".";
   const queryAllByTitleWithSuggestions = wrapAllByQueryWithSuggestion(queryAllByTitle, queryAllByTitle.name, "queryAll");
   const [queryByTitle, getAllByTitle, getByTitle, findAllByTitle, findByTitle] = buildQueries(queryAllByTitle, getMultipleError$2, getMissingError$2);
   function queryAllByRole(container, role2, _temp) {
@@ -13984,8 +35340,8 @@
     checkContainerType$1(args[0]);
     return queryAllByAttribute(getTestIdAttribute(), ...args);
   };
-  const getMultipleError = (c2, id) => "Found multiple elements by: [" + getTestIdAttribute() + '="' + id + '"]';
-  const getMissingError = (c2, id) => "Unable to find an element by: [" + getTestIdAttribute() + '="' + id + '"]';
+  const getMultipleError = (c2, id2) => "Found multiple elements by: [" + getTestIdAttribute() + '="' + id2 + '"]';
+  const getMissingError = (c2, id2) => "Unable to find an element by: [" + getTestIdAttribute() + '="' + id2 + '"]';
   const queryAllByTestIdWithSuggestions = wrapAllByQueryWithSuggestion(queryAllByTestId, queryAllByTestId.name, "queryAll");
   const [queryByTestId, getAllByTestId, getByTestId, findAllByTestId, findByTestId] = buildQueries(queryAllByTestId, getMultipleError, getMissingError);
   var queries = /* @__PURE__ */ Object.freeze({
@@ -14039,15 +35395,15 @@
     findAllByTestId,
     findByTestId
   });
-  function getQueriesForElement(element, queries$1, initialValue2) {
-    if (queries$1 === void 0) {
-      queries$1 = queries;
+  function getQueriesForElement(element, queries$12, initialValue2) {
+    if (queries$12 === void 0) {
+      queries$12 = queries;
     }
     if (initialValue2 === void 0) {
       initialValue2 = {};
     }
-    return Object.keys(queries$1).reduce((helpers2, key2) => {
-      const fn2 = queries$1[key2];
+    return Object.keys(queries$12).reduce((helpers2, key2) => {
+      const fn2 = queries$12[key2];
       helpers2[key2] = fn2.bind(null, element);
       return helpers2;
     }, initialValue2);
@@ -14064,10 +35420,10 @@
       initialCheck(callback);
       const elements = Array.isArray(callback) ? callback : [callback];
       const getRemainingElements = elements.map((element) => {
-        let parent = element.parentElement;
-        if (parent === null) return () => null;
-        while (parent.parentElement) parent = parent.parentElement;
-        return () => parent.contains(element) ? element : null;
+        let parent2 = element.parentElement;
+        if (parent2 === null) return () => null;
+        while (parent2.parentElement) parent2 = parent2.parentElement;
+        return () => parent2.contains(element) ? element : null;
       });
       callback = () => getRemainingElements.map((c2) => c2()).filter(Boolean);
     }
@@ -15152,7 +36508,7 @@
     let root;
     if (hydrate) {
       act(() => {
-        root = hydrateRoot(container, WrapperComponent ? /* @__PURE__ */ React__namespace.createElement(WrapperComponent, null, ui) : ui);
+        root = hydrateRoot(container, WrapperComponent ? /* @__PURE__ */ l__default__namespace.createElement(WrapperComponent, null, ui) : ui);
       });
     } else {
       root = createRoot(container);
@@ -15174,13 +36530,13 @@
   function createLegacyRoot(container) {
     return {
       hydrate(element) {
-        ReactDOM.hydrate(element, container);
+        m$1$1.hydrate(element, container);
       },
       render(element) {
-        ReactDOM.render(element, container);
+        m$1$1.render(element, container);
       },
       unmount() {
-        ReactDOM.unmountComponentAtNode(container);
+        m$1$1.unmountComponentAtNode(container);
       }
     };
   }
@@ -15193,7 +36549,7 @@
       root,
       wrapper: WrapperComponent
     } = _ref2;
-    const wrapUiIfNeeded = (innerElement) => WrapperComponent ? /* @__PURE__ */ React__namespace.createElement(WrapperComponent, null, innerElement) : innerElement;
+    const wrapUiIfNeeded = (innerElement) => WrapperComponent ? /* @__PURE__ */ l__default__namespace.createElement(WrapperComponent, null, innerElement) : innerElement;
     act(() => {
       if (hydrate) {
         root.hydrate(wrapUiIfNeeded(ui), container);
@@ -15308,13 +36664,13 @@
       initialProps,
       ...renderOptions
     } = options;
-    const result = /* @__PURE__ */ React__namespace.createRef();
+    const result = /* @__PURE__ */ l__default__namespace.createRef();
     function TestComponent(_ref4) {
       let {
         renderCallbackProps
       } = _ref4;
       const pendingResult = renderCallback(renderCallbackProps);
-      React__namespace.useEffect(() => {
+      l__default__namespace.useEffect(() => {
         result.current = pendingResult;
       });
       return null;
@@ -15322,11 +36678,11 @@
     const {
       rerender: baseRerender,
       unmount
-    } = render(/* @__PURE__ */ React__namespace.createElement(TestComponent, {
+    } = render(/* @__PURE__ */ l__default__namespace.createElement(TestComponent, {
       renderCallbackProps: initialProps
     }), renderOptions);
     function rerender(rerenderCallbackProps) {
-      return baseRerender(/* @__PURE__ */ React__namespace.createElement(TestComponent, {
+      return baseRerender(/* @__PURE__ */ l__default__namespace.createElement(TestComponent, {
         renderCallbackProps: rerenderCallbackProps
       }));
     }
@@ -15392,9 +36748,9 @@
     auxiliary: 1,
     secondary: 2
   };
-  function translateButtonNumber(value, from) {
+  function translateButtonNumber(value, from2) {
     var _Object$entries$find;
-    const [mapIn, mapOut] = from === "button" ? [BUTTON_NAMES, BUTTONS_NAMES] : [BUTTONS_NAMES, BUTTON_NAMES];
+    const [mapIn, mapOut] = from2 === "button" ? [BUTTON_NAMES, BUTTONS_NAMES] : [BUTTONS_NAMES, BUTTON_NAMES];
     const name = (_Object$entries$find = Object.entries(mapIn).find(([, i2]) => i2 === value)) == null ? void 0 : _Object$entries$find[0];
     return name && Object.prototype.hasOwnProperty.call(mapOut, name) ? mapOut[name] : 0;
   }
@@ -15594,9 +36950,9 @@
   });
   isValidDateValue$1.isValidDateValue = isValidDateValue;
   function isValidDateValue(element, value) {
-    const clone = element.cloneNode();
-    clone.value = value;
-    return clone.value === value;
+    const clone2 = element.cloneNode();
+    clone2.value = value;
+    return clone2.value === value;
   }
   var isValidInputTimeValue$1 = {};
   Object.defineProperty(isValidInputTimeValue$1, "__esModule", {
@@ -15604,9 +36960,9 @@
   });
   isValidInputTimeValue$1.isValidInputTimeValue = isValidInputTimeValue;
   function isValidInputTimeValue(element, timeValue) {
-    const clone = element.cloneNode();
-    clone.value = timeValue;
-    return clone.value === timeValue;
+    const clone2 = element.cloneNode();
+    clone2.value = timeValue;
+    return clone2.value === timeValue;
   }
   Object.defineProperty(calculateNewValue$1, "__esModule", {
     value: true
@@ -15948,15 +37304,15 @@
   hasFormSubmit$1.hasFormSubmit = void 0;
   const hasFormSubmit = (form) => !!(form && (form.querySelector('input[type="submit"]') || form.querySelector('button[type="submit"]')));
   hasFormSubmit$1.hasFormSubmit = hasFormSubmit;
-  (function(exports3) {
-    Object.defineProperty(exports3, "__esModule", {
+  (function(exports2) {
+    Object.defineProperty(exports2, "__esModule", {
       value: true
     });
     var _getMouseEventOptions = getMouseEventOptions$1;
     Object.keys(_getMouseEventOptions).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _getMouseEventOptions[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _getMouseEventOptions[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _getMouseEventOptions[key2];
@@ -15966,8 +37322,8 @@
     var _isClickableInput = isClickableInput$1;
     Object.keys(_isClickableInput).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _isClickableInput[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _isClickableInput[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _isClickableInput[key2];
@@ -15977,8 +37333,8 @@
     var _buildTimeValue = buildTimeValue$1;
     Object.keys(_buildTimeValue).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _buildTimeValue[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _buildTimeValue[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _buildTimeValue[key2];
@@ -15988,8 +37344,8 @@
     var _calculateNewValue = calculateNewValue$1;
     Object.keys(_calculateNewValue).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _calculateNewValue[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _calculateNewValue[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _calculateNewValue[key2];
@@ -15999,8 +37355,8 @@
     var _cursorPosition = cursorPosition;
     Object.keys(_cursorPosition).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _cursorPosition[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _cursorPosition[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _cursorPosition[key2];
@@ -16010,8 +37366,8 @@
     var _getValue3 = getValue$1;
     Object.keys(_getValue3).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _getValue3[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _getValue3[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _getValue3[key2];
@@ -16021,8 +37377,8 @@
     var _hasUnreliableEmptyValue = hasUnreliableEmptyValue$1;
     Object.keys(_hasUnreliableEmptyValue).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _hasUnreliableEmptyValue[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _hasUnreliableEmptyValue[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _hasUnreliableEmptyValue[key2];
@@ -16032,8 +37388,8 @@
     var _isContentEditable2 = isContentEditable$1;
     Object.keys(_isContentEditable2).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _isContentEditable2[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _isContentEditable2[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _isContentEditable2[key2];
@@ -16043,8 +37399,8 @@
     var _isEditable = isEditable$1;
     Object.keys(_isEditable).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _isEditable[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _isEditable[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _isEditable[key2];
@@ -16054,8 +37410,8 @@
     var _isValidDateValue2 = isValidDateValue$1;
     Object.keys(_isValidDateValue2).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _isValidDateValue2[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _isValidDateValue2[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _isValidDateValue2[key2];
@@ -16065,8 +37421,8 @@
     var _isValidInputTimeValue2 = isValidInputTimeValue$1;
     Object.keys(_isValidInputTimeValue2).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _isValidInputTimeValue2[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _isValidInputTimeValue2[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _isValidInputTimeValue2[key2];
@@ -16076,8 +37432,8 @@
     var _maxLength = maxLength;
     Object.keys(_maxLength).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _maxLength[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _maxLength[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _maxLength[key2];
@@ -16087,8 +37443,8 @@
     var _selectionRange2 = selectionRange;
     Object.keys(_selectionRange2).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _selectionRange2[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _selectionRange2[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _selectionRange2[key2];
@@ -16098,8 +37454,8 @@
     var _getActiveElement = getActiveElement$1;
     Object.keys(_getActiveElement).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _getActiveElement[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _getActiveElement[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _getActiveElement[key2];
@@ -16109,8 +37465,8 @@
     var _isFocusable = isFocusable$1;
     Object.keys(_isFocusable).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _isFocusable[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _isFocusable[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _isFocusable[key2];
@@ -16120,8 +37476,8 @@
     var _selector2 = selector;
     Object.keys(_selector2).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _selector2[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _selector2[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _selector2[key2];
@@ -16131,8 +37487,8 @@
     var _eventWrapper = eventWrapper$1;
     Object.keys(_eventWrapper).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _eventWrapper[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _eventWrapper[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _eventWrapper[key2];
@@ -16142,8 +37498,8 @@
     var _isElementType2 = isElementType$1;
     Object.keys(_isElementType2).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _isElementType2[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _isElementType2[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _isElementType2[key2];
@@ -16153,8 +37509,8 @@
     var _isLabelWithInternallyDisabledControl2 = isLabelWithInternallyDisabledControl$1;
     Object.keys(_isLabelWithInternallyDisabledControl2).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _isLabelWithInternallyDisabledControl2[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _isLabelWithInternallyDisabledControl2[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _isLabelWithInternallyDisabledControl2[key2];
@@ -16164,8 +37520,8 @@
     var _isVisible = isVisible$1;
     Object.keys(_isVisible).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _isVisible[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _isVisible[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _isVisible[key2];
@@ -16175,8 +37531,8 @@
     var _isDisabled2 = isDisabled$1;
     Object.keys(_isDisabled2).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _isDisabled2[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _isDisabled2[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _isDisabled2[key2];
@@ -16186,8 +37542,8 @@
     var _isDocument = isDocument$1;
     Object.keys(_isDocument).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _isDocument[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _isDocument[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _isDocument[key2];
@@ -16197,8 +37553,8 @@
     var _wait = wait$1;
     Object.keys(_wait).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _wait[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _wait[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _wait[key2];
@@ -16208,8 +37564,8 @@
     var _hasPointerEvents = hasPointerEvents$1;
     Object.keys(_hasPointerEvents).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _hasPointerEvents[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _hasPointerEvents[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _hasPointerEvents[key2];
@@ -16219,8 +37575,8 @@
     var _hasFormSubmit = hasFormSubmit$1;
     Object.keys(_hasFormSubmit).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _hasFormSubmit[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _hasFormSubmit[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _hasFormSubmit[key2];
@@ -16483,7 +37839,7 @@
       consumedLength,
       releasePrevious,
       releaseSelf,
-      repeat
+      repeat: repeat2
     } = readNextDescriptor(text);
     const keyDef = (_options$keyboardMap$ = options.keyboardMap.find((def) => {
       if (type2 === "[") {
@@ -16505,7 +37861,7 @@
       consumedLength,
       releasePrevious,
       releaseSelf,
-      repeat
+      repeat: repeat2
     };
   }
   function readNextDescriptor(text) {
@@ -16712,15 +38068,15 @@
       Object.defineProperty(element, propName, descriptor);
     }
   }
-  (function(exports3) {
-    Object.defineProperty(exports3, "__esModule", {
+  (function(exports2) {
+    Object.defineProperty(exports2, "__esModule", {
       value: true
     });
     var _carryValue = carryValue$1;
     Object.keys(_carryValue).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _carryValue[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _carryValue[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _carryValue[key2];
@@ -16730,8 +38086,8 @@
     var _fireChangeForInputTimeIfValid = fireChangeForInputTimeIfValid$1;
     Object.keys(_fireChangeForInputTimeIfValid).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _fireChangeForInputTimeIfValid[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _fireChangeForInputTimeIfValid[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _fireChangeForInputTimeIfValid[key2];
@@ -16741,8 +38097,8 @@
     var _fireInputEvent = fireInputEvent$1;
     Object.keys(_fireInputEvent).forEach(function(key2) {
       if (key2 === "default" || key2 === "__esModule") return;
-      if (key2 in exports3 && exports3[key2] === _fireInputEvent[key2]) return;
-      Object.defineProperty(exports3, key2, {
+      if (key2 in exports2 && exports2[key2] === _fireInputEvent[key2]) return;
+      Object.defineProperty(exports2, key2, {
         enumerable: true,
         get: function() {
           return _fireInputEvent[key2];
@@ -17243,10 +38599,10 @@
       consumedLength,
       releasePrevious,
       releaseSelf,
-      repeat
+      repeat: repeat2
     } = (_state$repeatKey = state.repeatKey) != null ? _state$repeatKey : (0, _getNextKeyDef.getNextKeyDef)(text, options);
-    const replace = applyPlugins(plugins.replaceBehavior, keyDef, getCurrentElement(), options, state);
-    if (!replace) {
+    const replace2 = applyPlugins(plugins.replaceBehavior, keyDef, getCurrentElement(), options, state);
+    if (!replace2) {
       const pressed = state.pressed.find((p2) => p2.keyDef === keyDef);
       if (pressed && !state.repeatKey) {
         keyup(keyDef, getCurrentElement, options, state, pressed.unpreventedDefault);
@@ -17256,24 +38612,24 @@
         if (unpreventedDefault && hasKeyPress(keyDef, state)) {
           keypress(keyDef, getCurrentElement, options, state);
         }
-        if (releaseSelf && repeat <= 1) {
+        if (releaseSelf && repeat2 <= 1) {
           keyup(keyDef, getCurrentElement, options, state, unpreventedDefault);
         }
       }
     }
-    if (repeat > 1) {
+    if (repeat2 > 1) {
       state.repeatKey = {
         // don't consume again on the next iteration
         consumedLength: 0,
         keyDef,
         releasePrevious,
         releaseSelf,
-        repeat: repeat - 1
+        repeat: repeat2 - 1
       };
     } else {
       delete state.repeatKey;
     }
-    if (text.length > consumedLength || repeat > 1) {
+    if (text.length > consumedLength || repeat2 > 1) {
       if (options.delay > 0) {
         await (0, _utils$6.wait)(options.delay);
       }
@@ -17538,13 +38894,13 @@
     pageDown: "{pageDown}"
   };
   specialCharMap$1.specialCharMap = specialCharMap;
-  (function(exports3) {
-    Object.defineProperty(exports3, "__esModule", {
+  (function(exports2) {
+    Object.defineProperty(exports2, "__esModule", {
       value: true
     });
-    exports3.keyboard = keyboard2;
-    exports3.keyboardImplementationWrapper = keyboardImplementationWrapper;
-    Object.defineProperty(exports3, "specialCharMap", {
+    exports2.keyboard = keyboard2;
+    exports2.keyboardImplementationWrapper = keyboardImplementationWrapper;
+    Object.defineProperty(exports2, "specialCharMap", {
       enumerable: true,
       get: function() {
         return _specialCharMap.specialCharMap;
@@ -18039,12 +39395,12 @@
       {}
     );
   }
-  (function(exports3) {
-    Object.defineProperty(exports3, "__esModule", {
+  (function(exports2) {
+    Object.defineProperty(exports2, "__esModule", {
       value: true
     });
-    exports3.default = void 0;
-    Object.defineProperty(exports3, "specialChars", {
+    exports2.default = void 0;
+    Object.defineProperty(exports2, "specialChars", {
       enumerable: true,
       get: function() {
         return _keyboard2.specialCharMap;
@@ -18074,14 +39430,14 @@
       keyboard: _keyboard2.keyboard
     };
     var _default2 = userEvent;
-    exports3.default = _default2;
+    exports2.default = _default2;
   })(dist);
   const index = /* @__PURE__ */ getDefaultExportFromCjs(dist);
   var eventMap$1 = {};
   Object.defineProperty(eventMap$1, "__esModule", {
     value: true
   });
-  exports2.eventMap = eventMap$1.eventMap = eventMap$1.eventAliasMap = void 0;
+  var eventMap_2 = eventMap$1.eventMap = eventMap$1.eventAliasMap = void 0;
   const eventMap = {
     // Clipboard Events
     copy: {
@@ -18770,7 +40126,7 @@
       }
     }
   };
-  exports2.eventMap = eventMap$1.eventMap = eventMap;
+  eventMap_2 = eventMap$1.eventMap = eventMap;
   const eventAliasMap = {
     doubleClick: "dblClick"
   };
@@ -18780,90 +40136,108 @@
     getElementError: buildJsGetElementError
   });
   const fireEventObj = fireEvent;
-  exports2.act = act;
-  exports2.buildJsGetElementError = buildJsGetElementError;
-  exports2.buildQueries = buildQueries;
-  exports2.cleanup = cleanup;
-  exports2.configure = configure;
-  exports2.createEvent = createEvent;
-  exports2.findAllByAltText = findAllByAltText;
-  exports2.findAllByDisplayValue = findAllByDisplayValue;
-  exports2.findAllByLabelText = findAllByLabelText;
-  exports2.findAllByPlaceholderText = findAllByPlaceholderText;
-  exports2.findAllByRole = findAllByRole;
-  exports2.findAllByTestId = findAllByTestId;
-  exports2.findAllByText = findAllByText;
-  exports2.findAllByTitle = findAllByTitle;
-  exports2.findByAltText = findByAltText;
-  exports2.findByDisplayValue = findByDisplayValue;
-  exports2.findByLabelText = findByLabelText;
-  exports2.findByPlaceholderText = findByPlaceholderText;
-  exports2.findByRole = findByRole;
-  exports2.findByTestId = findByTestId;
-  exports2.findByText = findByText;
-  exports2.findByTitle = findByTitle;
-  exports2.fireEvent = fireEvent;
-  exports2.fireEventObj = fireEventObj;
-  exports2.getAllByAltText = getAllByAltText;
-  exports2.getAllByDisplayValue = getAllByDisplayValue;
-  exports2.getAllByLabelText = getAllByLabelTextWithSuggestions;
-  exports2.getAllByPlaceholderText = getAllByPlaceholderText;
-  exports2.getAllByRole = getAllByRole;
-  exports2.getAllByTestId = getAllByTestId;
-  exports2.getAllByText = getAllByText;
-  exports2.getAllByTitle = getAllByTitle;
-  exports2.getByAltText = getByAltText;
-  exports2.getByDisplayValue = getByDisplayValue;
-  exports2.getByLabelText = getByLabelTextWithSuggestions;
-  exports2.getByPlaceholderText = getByPlaceholderText;
-  exports2.getByRole = getByRole;
-  exports2.getByTestId = getByTestId;
-  exports2.getByText = getByText;
-  exports2.getByTitle = getByTitle;
-  exports2.getConfig = getConfig;
-  exports2.getDefaultNormalizer = getDefaultNormalizer;
-  exports2.getElementError = getElementError;
-  exports2.getMultipleElementsFoundError = getMultipleElementsFoundError;
-  exports2.getNodeText = getNodeText;
-  exports2.getQueriesForElement = getQueriesForElement;
-  exports2.getRoles = getRoles;
-  exports2.getSuggestedQuery = getSuggestedQuery;
-  exports2.isInaccessible = isInaccessible;
-  exports2.logDOM = logDOM;
-  exports2.logRoles = logRoles;
-  exports2.makeFindQuery = makeFindQuery;
-  exports2.makeGetAllQuery = makeGetAllQuery;
-  exports2.makeSingleQuery = makeSingleQuery;
-  exports2.prettyDOM = prettyDOM;
-  exports2.prettyFormat = index$1;
-  exports2.queries = queries;
-  exports2.queryAllByAltText = queryAllByAltTextWithSuggestions;
-  exports2.queryAllByAttribute = queryAllByAttribute;
-  exports2.queryAllByDisplayValue = queryAllByDisplayValueWithSuggestions;
-  exports2.queryAllByLabelText = queryAllByLabelTextWithSuggestions;
-  exports2.queryAllByPlaceholderText = queryAllByPlaceholderTextWithSuggestions;
-  exports2.queryAllByRole = queryAllByRoleWithSuggestions;
-  exports2.queryAllByTestId = queryAllByTestIdWithSuggestions;
-  exports2.queryAllByText = queryAllByTextWithSuggestions;
-  exports2.queryAllByTitle = queryAllByTitleWithSuggestions;
-  exports2.queryByAltText = queryByAltText;
-  exports2.queryByAttribute = queryByAttribute;
-  exports2.queryByDisplayValue = queryByDisplayValue;
-  exports2.queryByLabelText = queryByLabelText;
-  exports2.queryByPlaceholderText = queryByPlaceholderText;
-  exports2.queryByRole = queryByRole;
-  exports2.queryByTestId = queryByTestId;
-  exports2.queryByText = queryByText;
-  exports2.queryByTitle = queryByTitle;
-  exports2.queryHelpers = queryHelpers;
-  exports2.render = render;
-  exports2.renderHook = renderHook;
-  exports2.screen = screen;
-  exports2.userEvent = index;
-  exports2.waitFor = waitForWrapper;
-  exports2.waitForElementToBeRemoved = waitForElementToBeRemoved;
-  exports2.within = getQueriesForElement;
-  exports2.wrapAllByQueryWithSuggestion = wrapAllByQueryWithSuggestion;
-  exports2.wrapSingleQueryWithSuggestion = wrapSingleQueryWithSuggestion;
-  Object.defineProperty(exports2, Symbol.toStringTag, { value: "Module" });
+  const rtl18 = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
+    __proto__: null,
+    act,
+    buildJsGetElementError,
+    buildQueries,
+    cleanup,
+    configure,
+    createEvent,
+    get eventMap() {
+      return eventMap_2;
+    },
+    findAllByAltText,
+    findAllByDisplayValue,
+    findAllByLabelText,
+    findAllByPlaceholderText,
+    findAllByRole,
+    findAllByTestId,
+    findAllByText,
+    findAllByTitle,
+    findByAltText,
+    findByDisplayValue,
+    findByLabelText,
+    findByPlaceholderText,
+    findByRole,
+    findByTestId,
+    findByText,
+    findByTitle,
+    fireEvent,
+    fireEventObj,
+    getAllByAltText,
+    getAllByDisplayValue,
+    getAllByLabelText: getAllByLabelTextWithSuggestions,
+    getAllByPlaceholderText,
+    getAllByRole,
+    getAllByTestId,
+    getAllByText,
+    getAllByTitle,
+    getByAltText,
+    getByDisplayValue,
+    getByLabelText: getByLabelTextWithSuggestions,
+    getByPlaceholderText,
+    getByRole,
+    getByTestId,
+    getByText,
+    getByTitle,
+    getConfig,
+    getDefaultNormalizer,
+    getElementError,
+    getMultipleElementsFoundError,
+    getNodeText,
+    getQueriesForElement,
+    getRoles,
+    getSuggestedQuery,
+    isInaccessible,
+    logDOM,
+    logRoles,
+    makeFindQuery,
+    makeGetAllQuery,
+    makeSingleQuery,
+    prettyDOM,
+    prettyFormat: index$1,
+    queries,
+    queryAllByAltText: queryAllByAltTextWithSuggestions,
+    queryAllByAttribute,
+    queryAllByDisplayValue: queryAllByDisplayValueWithSuggestions,
+    queryAllByLabelText: queryAllByLabelTextWithSuggestions,
+    queryAllByPlaceholderText: queryAllByPlaceholderTextWithSuggestions,
+    queryAllByRole: queryAllByRoleWithSuggestions,
+    queryAllByTestId: queryAllByTestIdWithSuggestions,
+    queryAllByText: queryAllByTextWithSuggestions,
+    queryAllByTitle: queryAllByTitleWithSuggestions,
+    queryByAltText,
+    queryByAttribute,
+    queryByDisplayValue,
+    queryByLabelText,
+    queryByPlaceholderText,
+    queryByRole,
+    queryByTestId,
+    queryByText,
+    queryByTitle,
+    queryHelpers,
+    render,
+    renderHook,
+    screen,
+    userEvent: index,
+    waitFor: waitForWrapper,
+    waitForElementToBeRemoved,
+    within: getQueriesForElement,
+    wrapAllByQueryWithSuggestion,
+    wrapSingleQueryWithSuggestion
+  }, Symbol.toStringTag, { value: "Module" }));
+  const reactVersion = (_a = window.React) == null ? void 0 : _a.version;
+  const isReact17 = typeof reactVersion === "string" && reactVersion.startsWith("17.");
+  console.log(`RTL: isReact17: ${isReact17}`);
+  let rtl;
+  if (isReact17) {
+    console.log("RTL: selected React-17-compatible version.");
+    rtl = rtl17;
+  } else {
+    console.log("RTL: selected React-18-compatible version.");
+    rtl = rtl18;
+  }
+  const rtl$1 = rtl;
+  return rtl$1;
 });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,3 +22,10 @@ dev_dependencies:
   test_html_builder: ^3.0.0
   workiva_analysis_options: ^1.0.0
 
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/workiva/react-dart.git
+      ref: react-18-2-0
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,10 +22,3 @@ dev_dependencies:
   test_html_builder: ^3.0.0
   workiva_analysis_options: ^1.0.0
 
-
-dependency_overrides:
-  react:
-    git:
-      url: https://github.com/workiva/react-dart.git
-      ref: react-18-2-0
-

--- a/test/unit/react_version_test.dart
+++ b/test/unit/react_version_test.dart
@@ -7,8 +7,8 @@ import 'package:test/test.dart';
 void main() {
   // This test helps us verify our test setup, ensuring
   // we're running on the React version we expect to be.
-  test('Setup check: window.React is React 18', () {
-    expect(reactVersion, startsWith('18.'));
+  test('Setup check: window.React is React 17', () {
+    expect(reactVersion, startsWith('17.'));
   });
 
   // TODO: Once we do a dual-CI setup, we can conditionall verify this using tags

--- a/test/unit/react_version_test.dart
+++ b/test/unit/react_version_test.dart
@@ -7,8 +7,8 @@ import 'package:test/test.dart';
 void main() {
   // This test helps us verify our test setup, ensuring
   // we're running on the React version we expect to be.
-  test('Setup check: window.React is React 17', () {
-    expect(reactVersion, startsWith('17.'));
+  test('Setup check: window.React is React 18', () {
+    expect(reactVersion, startsWith('18.'));
   });
 
   // TODO: Once we do a dual-CI setup, we can conditionall verify this using tags

--- a/test/unit/react_version_test.dart
+++ b/test/unit/react_version_test.dart
@@ -1,0 +1,27 @@
+@JS()
+library react_version_test;
+
+import 'package:js/js.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // This test helps us verify our test setup, ensuring
+  // we're running on the React version we expect to be.
+  test('Setup check: window.React is React 18', () {
+    expect(reactVersion, startsWith('18.'));
+  });
+
+  // TODO: Once we do a dual-CI setup, we can conditionall verify this using tags
+  // test('Setup check: window.React is React 17', () {
+  //   expect(reactVersion, startsWith('17.'));
+  // }, tags: 'react-17');
+  // test('Setup check: window.React is React 18', () {
+  //   expect(reactVersion, startsWith('18.'));
+  // }, tags: 'react-18');
+  // Then, when running tests:
+  // - on React 17: `dart run build_runner test -- ... --exclude-tags=react-18`
+  // - on React 18: `dart run build_runner test -- ... --exclude-tags=react-17`
+}
+
+@JS('React.version')
+external String get reactVersion;


### PR DESCRIPTION
## Motivation
We wanted to spike out updating the existing RTL JS assets be compatible with both React 17 and 18, to make the migration to React 18 easier.

With that in place, we wouldn't have to worry about dual-JS files or separate release lines, or coordinating them with the react-dart version used when testing.

**This is just a spike branch; not for merging.**

## Solution
- Spike out solution that bundles both 17- and 18-compatible versions of RTL into the existing JS file, and loads the correct one conditionally based on `window.React.version`
- Add test to validate current React version
- Add example used to do help debug during development

## Testing steps
- Verify React 18 branch this PR is based on has passing CI: https://github.com/Workiva/react_testing_library/pull/81
- Verify CI passes and `react_version_test.dart` test run
    - When using React 17: https://github.com/Workiva/react_testing_library/pull/82/commits/fd02c66d647db13b1c1014e8dc71ed4c064db5f5
    - When using React 18: https://github.com/Workiva/react_testing_library/pull/82/commits/dac2b64da94f6d1e2486a5a0b98caadaa40d72b6
