### PR TITLE
no_entrypoint_imports

### DIFF
--- a/lib/src/dom/fire_event.dart
+++ b/lib/src/dom/fire_event.dart
@@ -41,7 +41,7 @@ import '../user_event/user_event.dart';
 ///
 /// ```dart
 /// import 'package:react/react.dart' as react;
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
 /// import 'package:test/test.dart';
 ///
 /// void main() {

--- a/lib/src/dom/pretty_dom.dart
+++ b/lib/src/dom/pretty_dom.dart
@@ -24,7 +24,7 @@ import 'package:js/js.dart';
 /// This can be helpful when debugging tests:
 ///
 /// ```dart
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
 /// import 'package:test/test.dart';
 ///
 /// main() {

--- a/lib/src/dom/queries/by_alt_text.dart
+++ b/lib/src/dom/queries/by_alt_text.dart
@@ -65,8 +65,8 @@ mixin ByAltTextQueries on IQueries {
   ///
   /// ```dart
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show isInTheDocument;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// main() {

--- a/lib/src/dom/queries/by_display_value.dart
+++ b/lib/src/dom/queries/by_display_value.dart
@@ -71,8 +71,8 @@ mixin ByDisplayValueQueries on IQueries {
   ///
   /// ```dart
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show isInTheDocument;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// main() {

--- a/lib/src/dom/queries/by_label_text.dart
+++ b/lib/src/dom/queries/by_label_text.dart
@@ -78,8 +78,8 @@ mixin ByLabelTextQueries on IQueries {
   ///
   /// ```dart
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show isInTheDocument;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// main() {

--- a/lib/src/dom/queries/by_placeholder_text.dart
+++ b/lib/src/dom/queries/by_placeholder_text.dart
@@ -58,8 +58,8 @@ mixin ByPlaceholderTextQueries on IQueries {
   ///
   /// ```dart
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show isInTheDocument;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// main() {

--- a/lib/src/dom/queries/by_role.dart
+++ b/lib/src/dom/queries/by_role.dart
@@ -88,8 +88,8 @@ mixin ByRoleQueries on IQueries {
   ///
   /// ```dart
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show isInTheDocument;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// main() {

--- a/lib/src/dom/queries/by_testid.dart
+++ b/lib/src/dom/queries/by_testid.dart
@@ -73,8 +73,8 @@ mixin ByTestIdQueries on IQueries {
   ///
   /// ```dart
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show isInTheDocument;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// main() {

--- a/lib/src/dom/queries/by_text.dart
+++ b/lib/src/dom/queries/by_text.dart
@@ -65,8 +65,8 @@ mixin ByTextQueries on IQueries {
   ///
   /// ```dart
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show isInTheDocument;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// main() {

--- a/lib/src/dom/queries/by_title.dart
+++ b/lib/src/dom/queries/by_title.dart
@@ -62,8 +62,8 @@ mixin ByTitleQueries on IQueries {
   ///
   /// ```dart
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show isInTheDocument;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// main() {

--- a/lib/src/matchers/jest_dom/contains_element.dart
+++ b/lib/src/matchers/jest_dom/contains_element.dart
@@ -31,8 +31,8 @@ import 'package:react_testing_library/src/matchers/jest_dom/util/constants.dart'
 ///
 /// ```dart
 /// import 'package:react/react.dart' as react;
-/// import 'package:react_testing_library/matchers.dart' show containsElement;
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
+/// 
 /// import 'package:test/test.dart';
 ///
 /// main() {

--- a/lib/src/matchers/jest_dom/css_class_matchers.dart
+++ b/lib/src/matchers/jest_dom/css_class_matchers.dart
@@ -34,8 +34,8 @@ import 'package:react_testing_library/src/matchers/jest_dom/util/constants.dart'
 ///
 /// ```dart
 /// import 'package:react/react.dart' as react;
-/// import 'package:react_testing_library/matchers.dart' show hasClasses;
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
+/// 
 /// import 'package:test/test.dart';
 ///
 /// main() {
@@ -78,8 +78,8 @@ Matcher hasClasses(dynamic classes) => _ElementClassNameMatcher(_ClassNameMatche
 ///
 /// ```dart
 /// import 'package:react/react.dart' as react;
-/// import 'package:react_testing_library/matchers.dart' show hasExactClasses;
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
+/// 
 /// import 'package:test/test.dart';
 ///
 /// main() {
@@ -120,8 +120,8 @@ Matcher hasExactClasses(dynamic classes) =>
 ///
 /// ```dart
 /// import 'package:react/react.dart' as react;
-/// import 'package:react_testing_library/matchers.dart' show excludesClasses;
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
+/// 
 /// import 'package:test/test.dart';
 ///
 /// main() {

--- a/lib/src/matchers/jest_dom/has_attribute.dart
+++ b/lib/src/matchers/jest_dom/has_attribute.dart
@@ -32,8 +32,8 @@ import 'package:react_testing_library/src/matchers/jest_dom/util/constants.dart'
 ///
 /// ```dart
 /// import 'package:react/react.dart' as react;
-/// import 'package:react_testing_library/matchers.dart' show hasAttribute;
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
+/// 
 /// import 'package:test/test.dart';
 ///
 /// main() {

--- a/lib/src/matchers/jest_dom/has_description.dart
+++ b/lib/src/matchers/jest_dom/has_description.dart
@@ -51,8 +51,8 @@ import 'package:react_testing_library/src/matchers/jest_dom/util/element_text_co
 ///
 /// ```dart
 /// import 'package:react/react.dart' as react;
-/// import 'package:react_testing_library/matchers.dart' show hasDescription;
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
+/// 
 /// import 'package:test/test.dart';
 ///
 /// main() {

--- a/lib/src/matchers/jest_dom/has_form_values.dart
+++ b/lib/src/matchers/jest_dom/has_form_values.dart
@@ -44,8 +44,8 @@ import 'package:react_testing_library/src/util/js_utils.dart';
 ///
 /// ```dart
 /// import 'package:react/react.dart' as react;
-/// import 'package:react_testing_library/matchers.dart' show hasFormValues;
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
+/// 
 /// import 'package:test/test.dart';
 ///
 /// main() {

--- a/lib/src/matchers/jest_dom/has_styles.dart
+++ b/lib/src/matchers/jest_dom/has_styles.dart
@@ -37,8 +37,8 @@ import 'package:react_testing_library/src/matchers/jest_dom/util/constants.dart'
 ///
 /// ```dart
 /// import 'package:react/react.dart' as react;
-/// import 'package:react_testing_library/matchers.dart' show hasStyles;
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
+/// 
 /// import 'package:test/test.dart';
 ///
 /// main() {

--- a/lib/src/matchers/jest_dom/has_text_content.dart
+++ b/lib/src/matchers/jest_dom/has_text_content.dart
@@ -37,8 +37,8 @@ import 'package:react_testing_library/src/matchers/jest_dom/util/element_text_co
 ///
 /// ```dart
 /// import 'package:react/react.dart' as react;
-/// import 'package:react_testing_library/matchers.dart' show hasTextContent;
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
+/// 
 /// import 'package:test/test.dart';
 ///
 /// main() {

--- a/lib/src/matchers/jest_dom/has_value.dart
+++ b/lib/src/matchers/jest_dom/has_value.dart
@@ -47,8 +47,8 @@ import 'package:react_testing_library/src/matchers/jest_dom/util/get_value_of.da
 ///
 /// ```dart
 /// import 'package:react/react.dart' as react;
-/// import 'package:react_testing_library/matchers.dart' show hasValue;
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
+/// 
 /// import 'package:test/test.dart';
 ///
 /// main() {

--- a/lib/src/matchers/jest_dom/is_checked.dart
+++ b/lib/src/matchers/jest_dom/is_checked.dart
@@ -39,8 +39,8 @@ import 'package:react_testing_library/src/matchers/jest_dom/util/constants.dart'
 ///
 /// ```dart
 /// import 'package:react/react.dart' as react;
-/// import 'package:react_testing_library/matchers.dart' show isChecked;
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
+/// 
 /// import 'package:test/test.dart';
 ///
 /// main() {

--- a/lib/src/matchers/jest_dom/is_disabled.dart
+++ b/lib/src/matchers/jest_dom/is_disabled.dart
@@ -38,8 +38,8 @@ import 'package:react_testing_library/src/matchers/jest_dom/util/constants.dart'
 ///
 /// ```dart
 /// import 'package:react/react.dart' as react;
-/// import 'package:react_testing_library/matchers.dart' show isDisabled;
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
+/// 
 /// import 'package:test/test.dart';
 ///
 /// main() {

--- a/lib/src/matchers/jest_dom/is_empty_dom_element.dart
+++ b/lib/src/matchers/jest_dom/is_empty_dom_element.dart
@@ -29,8 +29,8 @@ import 'package:react_testing_library/src/matchers/jest_dom/util/constants.dart'
 ///
 /// ```dart
 /// import 'package:react/react.dart' as react;
-/// import 'package:react_testing_library/matchers.dart' show isEmptyDomElement;
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
+/// 
 /// import 'package:test/test.dart';
 ///
 /// main() {

--- a/lib/src/matchers/jest_dom/is_focused.dart
+++ b/lib/src/matchers/jest_dom/is_focused.dart
@@ -29,8 +29,8 @@ import 'package:react_testing_library/src/matchers/jest_dom/util/constants.dart'
 ///
 /// ```dart
 /// import 'package:react/react.dart' as react;
-/// import 'package:react_testing_library/matchers.dart' show isFocused;
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
+/// 
 /// import 'package:test/test.dart';
 ///
 /// main() {

--- a/lib/src/matchers/jest_dom/is_in_the_document.dart
+++ b/lib/src/matchers/jest_dom/is_in_the_document.dart
@@ -39,8 +39,8 @@ import 'contains_element.dart' show containsElement;
 ///
 /// ```dart
 /// import 'package:react/react.dart' as react;
-/// import 'package:react_testing_library/matchers.dart' show isInTheDocument;
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
+/// 
 /// import 'package:test/test.dart';
 ///
 /// main() {

--- a/lib/src/matchers/jest_dom/is_partially_checked.dart
+++ b/lib/src/matchers/jest_dom/is_partially_checked.dart
@@ -42,8 +42,8 @@ import 'package:react_testing_library/src/matchers/jest_dom/util/constants.dart'
 /// import 'dart:html';
 ///
 /// import 'package:react/react.dart' as react;
-/// import 'package:react_testing_library/matchers.dart' show isPartiallyChecked;
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
+/// 
 /// import 'package:test/test.dart';
 ///
 /// main() {

--- a/lib/src/react/render/render.dart
+++ b/lib/src/react/render/render.dart
@@ -45,8 +45,8 @@ import 'package:react_testing_library/src/react/render/types.dart' show JsRender
 /// ```dart
 /// import 'package:react/react.dart' as react;
 /// import 'package:test/test.dart';
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
-/// import 'package:react_testing_library/matchers.dart' show isInTheDocument;
+/// 
+/// 
 ///
 /// main() {
 ///   test('', () {
@@ -74,7 +74,7 @@ import 'package:react_testing_library/src/react/render/types.dart' show JsRender
 ///
 /// import 'package:react/react.dart' as react;
 /// import 'package:test/test.dart';
-/// import 'package:react_testing_library/react_testing_library.dart' as rtl;
+/// 
 ///
 /// main() {
 ///   test('', () {

--- a/lib/src/user_event/user_event.dart
+++ b/lib/src/user_event/user_event.dart
@@ -78,9 +78,9 @@ abstract class UserEvent {
   ///
   /// ```dart
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show isChecked;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
-  /// import 'package:react_testing_library/user_event.dart';
+  /// 
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// void main() {
@@ -162,9 +162,9 @@ abstract class UserEvent {
   ///
   /// ```dart
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show isChecked;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
-  /// import 'package:react_testing_library/user_event.dart';
+  /// 
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// void main() {
@@ -270,9 +270,9 @@ abstract class UserEvent {
   ///
   /// ```dart
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show hasValue;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
-  /// import 'package:react_testing_library/user_event.dart';
+  /// 
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// void main() {
@@ -386,9 +386,9 @@ abstract class UserEvent {
   ///
   /// ```dart
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show hasValue;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
-  /// import 'package:react_testing_library/user_event.dart';
+  /// 
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// void main() {
@@ -679,8 +679,8 @@ abstract class UserEvent {
   /// import 'dart:html';
   ///
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
-  /// import 'package:react_testing_library/user_event.dart';
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// void main() {
@@ -797,9 +797,9 @@ abstract class UserEvent {
   ///
   /// ```dart
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show hasValue;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
-  /// import 'package:react_testing_library/user_event.dart';
+  /// 
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// void main() {
@@ -872,9 +872,9 @@ abstract class UserEvent {
   /// import 'dart:html';
   ///
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show hasValue;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
-  /// import 'package:react_testing_library/user_event.dart';
+  /// 
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// void main() {
@@ -975,9 +975,9 @@ abstract class UserEvent {
   /// import 'dart:html';
   ///
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show hasValue;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
-  /// import 'package:react_testing_library/user_event.dart';
+  /// 
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// void main() {
@@ -1071,9 +1071,9 @@ abstract class UserEvent {
   /// import 'dart:html';
   ///
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show isFocused;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
-  /// import 'package:react_testing_library/user_event.dart';
+  /// 
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// void main() {
@@ -1172,9 +1172,9 @@ abstract class UserEvent {
   /// ```dart
   /// import 'package:react/hooks.dart';
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show isInTheDocument;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
-  /// import 'package:react_testing_library/user_event.dart';
+  /// 
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// void main() {
@@ -1267,9 +1267,9 @@ abstract class UserEvent {
   /// ```dart
   /// import 'package:react/hooks.dart';
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show isInTheDocument;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
-  /// import 'package:react_testing_library/user_event.dart';
+  /// 
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// void main() {
@@ -1367,9 +1367,9 @@ abstract class UserEvent {
   /// import 'dart:html';
   ///
   /// import 'package:react/react.dart' as react;
-  /// import 'package:react_testing_library/matchers.dart' show hasValue;
-  /// import 'package:react_testing_library/react_testing_library.dart' as rtl;
-  /// import 'package:react_testing_library/user_event.dart';
+  /// 
+  /// 
+  /// 
   /// import 'package:test/test.dart';
   ///
   /// void main() {


### PR DESCRIPTION
## Problem

An entrypoint import can be defined as an import within `lib/src` that imports a file within `lib/*.dart` (the entrypoints of a dart package). These imports are always unnecessary, and can contribute to slower dart build performance.

## Solution

This PR naively removes every entrypoint import within the repo, and updates the `gha-dart/.../checks.yaml` to the latest version. In order to merge this PR a few manual changes must be performed:

- Navigate to every file which has analysis errors caused from the missing import. Rely on intellisense to import the necessary symbol from the specific file, not the entrypoint import
- Implement the `no_entrypoint_imports` additional-checks option in `gha-dart@v2.10.13` that was added in [this PR](https://github.com/Workiva/gha-dart/pull/716). This will prevent new entrypoint imports from getting added once this PR merges

Our request to teams is to perform the above tasks, so we can default enable the `no_entrypoint_imports` check for all gha-dart consumers. Please reach out to [#support-frontend-dx](https://workiva.enterprise.slack.com/archives/C03ESR91BNU) for any questions or issues

## QA

- [ ] This pr is heavily dependant on the analysis server, and as such CI passes should be sufficient

[_Created by Sourcegraph batch change `Workiva/no_entrypoint_imports`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/no_entrypoint_imports)