### PR TITLE
Allow analyzer 10

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.0
-  build_test: ^2.0.0
+  build_test: '>=2.0.0 <4.0.0'
   build_web_compilers: '>=3.0.0 <5.0.0'
   test_html_builder: ^3.0.0
   workiva_analysis_options: ^1.0.0


### PR DESCRIPTION
# Summary
Unblock newer analyzer under Dart 3x by allowing build_test 3x versions.

# QA
- CI passes